### PR TITLE
Add concurrent workflow execution capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+**/.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,16 +582,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools 0.13.0",
+ "itertools",
  "num-traits",
  "oorandom",
  "plotters",
@@ -606,12 +606,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -1975,7 +1975,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2178,15 +2178,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2699,7 +2690,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -2736,7 +2727,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3322,6 +3313,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3585,9 +3586,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3598,9 +3599,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytemuck"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +370,7 @@ dependencies = [
  "reqwest",
  "rig-core",
  "tokio",
+ "wide",
 ]
 
 [[package]]
@@ -1975,7 +1982,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3063,6 +3070,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4072,6 +4088,16 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["Nassor Frazier-Silva"]
 
 [dependencies]
 async-trait = "0.1"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.47", features = ["full"] }
 rand = "0.9"
 cron = "0.15"
 chrono = { version = "0.4", features = ["serde"] }
@@ -21,7 +21,7 @@ futures = "0.3"
 
 [dev-dependencies]
 cargo-audit = "0.21.2"
-criterion = { version = "0.6", features = ["html_reports", "async_tokio"] }
+criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
 reqwest = { version = "0.12", features = ["json"] }
 rig-core = "0.15"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,25 @@ tokio = { version = "1.0", features = ["full"] }
 rand = "0.9"
 cron = "0.15"
 chrono = { version = "0.4", features = ["serde"] }
+futures = "0.3"
 
 [dev-dependencies]
 cargo-audit = "0.21.2"
 criterion = { version = "0.6", features = ["html_reports", "async_tokio"] }
-futures = "0.3"
 reqwest = { version = "0.12", features = ["json"] }
 rig-core = "0.15"
 
 [[example]]
 name = "ai_workflow_yes_and"
 path = "examples/ai_workflow_yes_and.rs"
+
+[[example]]
+name = "workflow_concurrent"
+path = "examples/workflow_concurrent.rs"
+
+[[example]]
+name = "scheduler_mixed_workflows"
+path = "examples/scheduler_mixed_workflows.rs"
 
 [[example]]
 name = "workflow_simple"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ cargo-audit = "0.21.2"
 criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
 reqwest = { version = "0.12", features = ["json"] }
 rig-core = "0.15"
+wide = "0.7"
 
 [[example]]
 name = "ai_workflow_yes_and"
@@ -48,6 +49,10 @@ path = "examples/workflow_book_prepositions.rs"
 [[example]]
 name = "workflow_negotiation"
 path = "examples/workflow_negotiation.rs"
+
+[[example]]
+name = "workflow_simd_matrix_pipeline"
+path = "examples/workflow_simd_matrix_pipeline.rs"
 
 [[example]]
 name = "workflow_stack_store"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-# MIT License
+MIT License
 
 Copyright (c) 2025 Nassor Frazier-Silva
 

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ async fn main() -> CanoResult<()> {
     
     // Create concurrent workflow
     let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
-    concurrent_workflow.register_cloneable_node(MyState::Start, MyTask);
+    concurrent_workflow.register_node(MyState::Start, MyTask);
     
     // Schedule concurrent workflows (multiple instances in parallel)
     scheduler.manual_concurrent("concurrent1", concurrent_workflow.clone(), 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add Cano to your `Cargo.toml`:
 [dependencies]
 cano = "0.3"
 async-trait = "0.1"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 ```
 
 ### Basic Example

--- a/examples/scheduler_book_prepositions.rs
+++ b/examples/scheduler_book_prepositions.rs
@@ -1,0 +1,924 @@
+//! # Book Preposition Analysis with Scheduler: Concurrent Downloads + Sequential Analysis
+//!
+//! This example demonstrates a sophisticated book analysis system that combines:
+//! 1. **Concurrent Workflow**: Downloads 12 popular books from Project Gutenberg in parallel
+//! 2. **Regular Workflow**: Sequential analysis and ranking pipeline
+//! 3. **Scheduler**: Orchestrates the connection between workflows
+//!
+//! The workflow architecture showcases:
+//! - Concurrent downloading for maximum throughput using queue-based work distribution
+//! - Sequential analysis pipeline for data consistency
+//! - Scheduler-based workflow orchestration and coordination
+//! - Shared store for data transfer between workflow types
+//!
+//! ## Execution
+//!
+//! ```bash
+//! cargo run --example scheduler_book_prepositions
+//! ```
+
+use async_trait::async_trait;
+use cano::error::CanoError;
+use cano::prelude::*;
+use cano::store::{KeyValueStore, MemoryStore};
+use futures::future::join_all;
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::time::{Duration, timeout};
+
+/// Workflow state management for scheduler coordination
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum WorkflowPhase {
+    // Download workflow states
+    Download,
+    DownloadComplete,
+    DownloadError,
+    
+    // Analysis workflow states
+    Analyze,
+    Rank,
+    Complete,
+    Error,
+}
+
+/// Book data structure
+#[derive(Debug, Clone)]
+struct Book {
+    id: u32,
+    title: String,
+    #[allow(dead_code)]
+    url: String,
+    content: String,
+}
+
+/// Book analysis result
+#[derive(Debug, Clone)]
+struct BookAnalysis {
+    book_id: u32,
+    title: String,
+    preposition_count: usize,
+    total_words: usize,
+    preposition_density: f64,
+    unique_prepositions: HashSet<String>,
+}
+
+/// Book ranking result
+#[derive(Debug, Clone)]
+struct BookRanking {
+    rank: usize,
+    analysis: BookAnalysis,
+}
+
+/// Common English prepositions for analysis
+const PREPOSITIONS: &[&str] = &[
+    "aboard", "about", "above", "across", "after", "against", "along", "amid", "among", 
+    "around", "as", "at", "before", "behind", "below", "beneath", "beside", "between", 
+    "beyond", "by", "concerning", "considering", "despite", "down", "during", "except", 
+    "excepting", "excluding", "following", "for", "from", "in", "inside", "into", "like", 
+    "minus", "near", "of", "off", "on", "onto", "opposite", "outside", "over", "past", 
+    "per", "plus", "regarding", "round", "save", "since", "than", "through", "to", 
+    "toward", "towards", "under", "underneath", "unlike", "until", "up", "upon", 
+    "versus", "via", "with", "within", "without",
+];
+
+/// Global shared store for inter-workflow communication
+type SharedStore = Arc<RwLock<MemoryStore>>;
+
+/// Download Node: Downloads a book from the queue in shared store
+#[derive(Clone)]
+struct BookDownloadNode {
+    shared_store: SharedStore,
+}
+
+impl BookDownloadNode {
+    fn new(shared_store: SharedStore) -> Self {
+        Self { shared_store }
+    }
+
+    /// List of popular Project Gutenberg books with their plain text URLs
+    fn get_book_list() -> Vec<(u32, String, String)> {
+        vec![
+            (
+                1342,
+                "Pride and Prejudice by Jane Austen".to_string(),
+                "https://www.gutenberg.org/files/1342/1342-0.txt".to_string(),
+            ),
+            (
+                11,
+                "Alice's Adventures in Wonderland by Lewis Carroll".to_string(),
+                "https://www.gutenberg.org/files/11/11-0.txt".to_string(),
+            ),
+            (
+                84,
+                "Frankenstein by Mary Wollstonecraft Shelley".to_string(),
+                "https://www.gutenberg.org/files/84/84-0.txt".to_string(),
+            ),
+            (
+                1661,
+                "The Adventures of Sherlock Holmes by Arthur Conan Doyle".to_string(),
+                "https://www.gutenberg.org/files/1661/1661-0.txt".to_string(),
+            ),
+            (
+                2701,
+                "Moby Dick by Herman Melville".to_string(),
+                "https://www.gutenberg.org/files/2701/2701-0.txt".to_string(),
+            ),
+            (
+                1080,
+                "A Modest Proposal by Jonathan Swift".to_string(),
+                "https://www.gutenberg.org/files/1080/1080-0.txt".to_string(),
+            ),
+            (
+                46,
+                "A Christmas Carol by Charles Dickens".to_string(),
+                "https://www.gutenberg.org/files/46/46-0.txt".to_string(),
+            ),
+            (
+                1513,
+                "Romeo and Juliet by William Shakespeare".to_string(),
+                "https://www.gutenberg.org/files/1513/1513-0.txt".to_string(),
+            ),
+            (
+                174,
+                "The Picture of Dorian Gray by Oscar Wilde".to_string(),
+                "https://www.gutenberg.org/files/174/174-0.txt".to_string(),
+            ),
+            (
+                345,
+                "Dracula by Bram Stoker".to_string(),
+                "https://www.gutenberg.org/files/345/345-0.txt".to_string(),
+            ),
+            (
+                76,
+                "Adventures of Huckleberry Finn by Mark Twain".to_string(),
+                "https://www.gutenberg.org/files/76/76-0.txt".to_string(),
+            ),
+            (
+                1260,
+                "Jane Eyre by Charlotte Brontë".to_string(),
+                "https://www.gutenberg.org/files/1260/1260-0.txt".to_string(),
+            ),
+        ]
+    }
+
+    /// Download a single book with error handling and timeout
+    async fn download_book(book_id: u32, title: &str, url: &str) -> Result<Book, String> {
+        println!("📚 Downloading: {title}");
+
+        let client = reqwest::Client::new();
+
+        // Set a 30-second timeout for each download
+        let download_future = async {
+            let response = client
+                .get(url)
+                .send()
+                .await
+                .map_err(|e| format!("Failed to fetch {url}: {e}"))?;
+
+            if !response.status().is_success() {
+                return Err(format!("HTTP error for {title}: {}", response.status()));
+            }
+
+            let content = response
+                .text()
+                .await
+                .map_err(|e| format!("Failed to read content for {title}: {e}"))?;
+
+            if content.len() < 1000 {
+                return Err(format!(
+                    "Content too short for {title}, might be an error page",
+                ));
+            }
+
+            println!("✅ Downloaded: {title} ({} chars)", content.len());
+
+            Ok(Book {
+                id: book_id,
+                title: title.to_string(),
+                url: url.to_string(),
+                content,
+            })
+        };
+
+        match timeout(Duration::from_secs(30), download_future).await {
+            Ok(result) => result,
+            Err(_) => Err(format!("Timeout downloading {title}")),
+        }
+    }
+}
+
+#[async_trait]
+impl Node<WorkflowPhase> for BookDownloadNode {
+    type PrepResult = Option<(u32, String, String)>;
+    type ExecResult = Option<Book>;
+
+    fn config(&self) -> NodeConfig {
+        NodeConfig::new().with_fixed_retry(2, Duration::from_secs(1))
+    }
+
+    /// Preparation: Get next book from the download queue
+    async fn prep(&self, _store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+        let shared_store = self.shared_store.write().await;
+        
+        // Get the download queue
+        let mut queue: Vec<(u32, String, String)> = shared_store
+            .get("download_queue")
+            .unwrap_or_else(|_| Vec::new());
+
+        if queue.is_empty() {
+            // No more books to download
+            return Ok(None);
+        }
+
+        // Take the first book from the queue
+        let book_info = queue.remove(0);
+        shared_store.put("download_queue", queue)?;
+
+        println!("📋 Picked up for download: {}", book_info.1);
+        Ok(Some(book_info))
+    }
+
+    /// Execution: Download the book if one was assigned
+    async fn exec(&self, prep_res: Self::PrepResult) -> Self::ExecResult {
+        if let Some((book_id, title, url)) = prep_res {
+            match Self::download_book(book_id, &title, &url).await {
+                Ok(book) => Some(book),
+                Err(error) => {
+                    eprintln!("❌ Download failed for {title}: {error}");
+                    None
+                }
+            }
+        } else {
+            println!("📭 No more books to download");
+            None
+        }
+    }
+
+    /// Post-processing: Store the book in the shared store
+    async fn post(
+        &self,
+        _store: &MemoryStore,
+        exec_res: Self::ExecResult,
+    ) -> Result<WorkflowPhase, CanoError> {
+        if let Some(book) = exec_res {
+            // Store the book in the shared store
+            let shared_store = self.shared_store.write().await;
+            
+            // Get existing books or create new vector
+            let mut books: Vec<Book> = shared_store
+                .get("downloaded_books")
+                .unwrap_or_else(|_| Vec::new());
+            
+            books.push(book.clone());
+            shared_store.put("downloaded_books", books)?;
+            
+            println!("✅ Stored book: {} in shared store", book.title);
+            Ok(WorkflowPhase::DownloadComplete)
+        } else {
+            Ok(WorkflowPhase::DownloadError)
+        }
+    }
+}
+
+/// Analysis Node: Analyzes prepositions in downloaded books
+#[derive(Clone)]
+struct PrepositionAnalysisNode {
+    shared_store: SharedStore,
+}
+
+impl PrepositionAnalysisNode {
+    fn new(shared_store: SharedStore) -> Self {
+        Self { shared_store }
+    }
+
+    /// Analyze prepositions in a single book
+    fn analyze_book_prepositions(book: &Book) -> BookAnalysis {
+        let preposition_set: HashSet<&str> = PREPOSITIONS.iter().copied().collect();
+        let mut found_prepositions = HashSet::new();
+        let mut total_preposition_count = 0;
+
+        // Clean and tokenize the text
+        let content_lower = book.content.to_lowercase();
+        let words: Vec<&str> = content_lower
+            .split_whitespace()
+            .map(|word| {
+                // Remove punctuation
+                word.trim_matches(|c: char| !c.is_alphabetic())
+            })
+            .filter(|word| !word.is_empty())
+            .collect();
+
+        let total_words = words.len();
+
+        // Count prepositions
+        for word in words {
+            if preposition_set.contains(word) {
+                found_prepositions.insert(word.to_string());
+                total_preposition_count += 1;
+            }
+        }
+
+        let preposition_density = if total_words > 0 {
+            (total_preposition_count as f64 / total_words as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        println!(
+            "📖 Analyzed '{}': {} unique prepositions, {:.2}% density",
+            book.title,
+            found_prepositions.len(),
+            preposition_density
+        );
+
+        BookAnalysis {
+            book_id: book.id,
+            title: book.title.clone(),
+            preposition_count: found_prepositions.len(),
+            total_words,
+            preposition_density,
+            unique_prepositions: found_prepositions,
+        }
+    }
+}
+
+#[async_trait]
+impl Node<WorkflowPhase> for PrepositionAnalysisNode {
+    type PrepResult = Vec<Book>;
+    type ExecResult = Vec<BookAnalysis>;
+
+    fn config(&self) -> NodeConfig {
+        NodeConfig::minimal()
+    }
+
+    /// Preparation: Load downloaded books from shared store
+    async fn prep(&self, _store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+        let shared_store = self.shared_store.read().await;
+        let books: Vec<Book> = shared_store
+            .get("downloaded_books")
+            .map_err(|e| CanoError::preparation(format!("Failed to load books: {e}")))?;
+
+        println!("📚 Loaded {} books for preposition analysis", books.len());
+        Ok(books)
+    }
+
+    /// Execution: Analyze prepositions in all books
+    async fn exec(&self, prep_res: Self::PrepResult) -> Self::ExecResult {
+        println!("🔍 Analyzing prepositions in {} books...", prep_res.len());
+
+        // Process books in parallel using async tasks
+        let analysis_futures: Vec<_> = prep_res
+            .iter()
+            .map(|book| {
+                let book_clone = book.clone();
+                tokio::spawn(async move { Self::analyze_book_prepositions(&book_clone) })
+            })
+            .collect();
+
+        let results = join_all(analysis_futures).await;
+
+        let mut analyses = Vec::new();
+        for result in results {
+            match result {
+                Ok(analysis) => analyses.push(analysis),
+                Err(e) => eprintln!("❌ Analysis task failed: {e}"),
+            }
+        }
+
+        println!("📊 Completed analysis of {} books", analyses.len());
+        analyses
+    }
+
+    /// Post-processing: Store analysis results in shared store
+    async fn post(
+        &self,
+        _store: &MemoryStore,
+        exec_res: Self::ExecResult,
+    ) -> Result<WorkflowPhase, CanoError> {
+        if exec_res.is_empty() {
+            return Err(CanoError::node_execution("No book analyses were completed"));
+        }
+
+        let shared_store = self.shared_store.read().await;
+        shared_store.put("book_analyses", exec_res.clone())?;
+
+        // Clean up the raw book content to save memory
+        shared_store.remove("downloaded_books")?;
+
+        println!(
+            "✅ Stored {} book analyses and cleaned up raw content",
+            exec_res.len()
+        );
+        Ok(WorkflowPhase::Rank) // Move to ranking phase
+    }
+}
+
+/// Ranking Node: Ranks books by their preposition diversity
+#[derive(Clone)]
+struct BookRankingNode {
+    shared_store: SharedStore,
+}
+
+impl BookRankingNode {
+    fn new(shared_store: SharedStore) -> Self {
+        Self { shared_store }
+    }
+}
+
+#[async_trait]
+impl Node<WorkflowPhase> for BookRankingNode {
+    type PrepResult = Vec<BookAnalysis>;
+    type ExecResult = Vec<BookRanking>;
+
+    fn config(&self) -> NodeConfig {
+        NodeConfig::minimal()
+    }
+
+    /// Preparation: Load book analyses from shared store
+    async fn prep(&self, _store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+        let shared_store = self.shared_store.read().await;
+        let analyses: Vec<BookAnalysis> = shared_store
+            .get("book_analyses")
+            .map_err(|e| CanoError::preparation(format!("Failed to load analyses: {e}")))?;
+
+        println!("📊 Loaded {} book analyses for ranking", analyses.len());
+        Ok(analyses)
+    }
+
+    /// Execution: Rank books by preposition count and density
+    async fn exec(&self, prep_res: Self::PrepResult) -> Self::ExecResult {
+        println!("🏆 Ranking books by preposition diversity...");
+
+        let mut analyses = prep_res;
+
+        // Sort by preposition count (descending), then by density as tiebreaker
+        analyses.sort_by(|a, b| match b.preposition_count.cmp(&a.preposition_count) {
+            std::cmp::Ordering::Equal => b
+                .preposition_density
+                .partial_cmp(&a.preposition_density)
+                .unwrap_or(std::cmp::Ordering::Equal),
+            other => other,
+        });
+
+        // Create rankings
+        let rankings: Vec<BookRanking> = analyses
+            .into_iter()
+            .enumerate()
+            .map(|(index, analysis)| BookRanking {
+                rank: index + 1,
+                analysis,
+            })
+            .collect();
+
+        println!(
+            "📈 Ranked {} books by preposition diversity",
+            rankings.len()
+        );
+        rankings
+    }
+
+    /// Post-processing: Store final rankings and display results
+    async fn post(
+        &self,
+        _store: &MemoryStore,
+        exec_res: Self::ExecResult,
+    ) -> Result<WorkflowPhase, CanoError> {
+        let shared_store = self.shared_store.read().await;
+        shared_store.put("book_rankings", exec_res.clone())?;
+
+        // Display results
+        println!("\n🏆 FINAL BOOK RANKINGS BY PREPOSITION DIVERSITY");
+        println!("================================================");
+
+        for ranking in &exec_res {
+            println!(
+                "#{}: {} (ID: {})",
+                ranking.rank, ranking.analysis.title, ranking.analysis.book_id
+            );
+            println!(
+                "    📊 {} unique prepositions | {:.2}% density | {} total words",
+                ranking.analysis.preposition_count,
+                ranking.analysis.preposition_density,
+                ranking.analysis.total_words
+            );
+
+            // Show some example prepositions
+            let sample_prepositions: Vec<&String> = ranking
+                .analysis
+                .unique_prepositions
+                .iter()
+                .take(10)
+                .collect();
+            println!("    🔤 Sample prepositions: {sample_prepositions:?}");
+            println!();
+        }
+
+        // Summary statistics
+        let total_books = exec_res.len();
+        let avg_prepositions: f64 = exec_res
+            .iter()
+            .map(|r| r.analysis.preposition_count as f64)
+            .sum::<f64>()
+            / total_books as f64;
+        let avg_density: f64 = exec_res
+            .iter()
+            .map(|r| r.analysis.preposition_density)
+            .sum::<f64>()
+            / total_books as f64;
+
+        println!("📈 SUMMARY STATISTICS");
+        println!("=====================");
+        println!("Total books analyzed: {}", total_books);
+        println!(
+            "Average unique prepositions per book: {:.1}",
+            avg_prepositions
+        );
+        println!("Average preposition density: {:.2}%", avg_density);
+
+        if let (Some(highest), Some(lowest)) = (exec_res.first(), exec_res.last()) {
+            println!(
+                "\n🥇 Highest diversity: {} ({} prepositions)",
+                highest.analysis.title, highest.analysis.preposition_count
+            );
+            println!(
+                "🥉 Lowest diversity: {} ({} prepositions)",
+                lowest.analysis.title, lowest.analysis.preposition_count
+            );
+        }
+
+        println!("✅ Book preposition analysis complete!");
+        Ok(WorkflowPhase::Complete)
+    }
+}
+
+/// Create the concurrent download workflow 
+fn create_download_workflow(shared_store: SharedStore) -> ConcurrentWorkflow<WorkflowPhase> {
+    let mut concurrent_workflow = ConcurrentWorkflow::new(WorkflowPhase::Download);
+    
+    // Register the download node (will be cloned for each instance)
+    concurrent_workflow
+        .register_node(WorkflowPhase::Download, BookDownloadNode::new(shared_store))
+        .add_exit_states(vec![
+            WorkflowPhase::DownloadComplete,
+            WorkflowPhase::DownloadError,
+        ]);
+    
+    concurrent_workflow
+}
+
+/// Create the sequential analysis workflow
+fn create_analysis_workflow(shared_store: SharedStore) -> Workflow<WorkflowPhase> {
+    let mut workflow = Workflow::new(WorkflowPhase::Analyze);
+    
+    workflow
+        .register_node(
+            WorkflowPhase::Analyze,
+            PrepositionAnalysisNode::new(shared_store.clone()),
+        )
+        .register_node(
+            WorkflowPhase::Rank,
+            BookRankingNode::new(shared_store),
+        )
+        .add_exit_states(vec![
+            WorkflowPhase::Complete,
+            WorkflowPhase::Error,
+        ]);
+    
+    workflow
+}
+
+/// Main scheduler-based book preposition analysis
+async fn run_scheduler_based_analysis() -> Result<(), CanoError> {
+    println!("🚀 Starting Scheduler-Based Book Preposition Analysis");
+    println!("====================================================");
+    println!("📋 Architecture:");
+    println!("  • Concurrent Workflow: Downloads 12 books in parallel via work queue");
+    println!("  • Regular Workflow: Sequential analysis and ranking");
+    println!("  • Scheduler: Orchestrates workflow coordination");
+    println!();
+
+    // Create shared store for inter-workflow communication
+    let shared_store = Arc::new(RwLock::new(MemoryStore::new()));
+
+    // Create scheduler
+    let mut scheduler = Scheduler::new();
+
+    // Initialize the download queue in shared store
+    {
+        let shared_store_guard = shared_store.write().await;
+        let book_list = BookDownloadNode::get_book_list();
+        shared_store_guard.put("download_queue", book_list)?;
+        println!("📋 Initialized download queue with {} books", 12);
+    }
+
+    // Create and register concurrent download workflow
+    let download_workflow = create_download_workflow(shared_store.clone());
+    
+    println!("📥 Registering concurrent download workflow with 12 instances...");
+    scheduler.manual_concurrent(
+        "book_downloads",
+        download_workflow,
+        12, // One instance per book
+        WaitStrategy::WaitForever, // Wait for all downloads to complete
+    )?;
+
+    // Create and register sequential analysis workflow
+    let analysis_workflow = create_analysis_workflow(shared_store.clone());
+    
+    println!("📊 Registering sequential analysis workflow...");
+    scheduler.manual("book_analysis", analysis_workflow)?;
+
+    // Start the scheduler
+    println!("🎬 Starting scheduler...");
+    scheduler.start().await?;
+
+    // Trigger the concurrent download workflow
+    println!("\n🔄 Triggering concurrent book download workflow...");
+    scheduler.trigger("book_downloads").await?;
+
+    // Wait for downloads to complete
+    println!("⏳ Waiting for downloads to complete...");
+    
+    // Poll for download completion
+    let mut download_completed = false;
+    let mut check_count = 0;
+    const MAX_CHECKS: usize = 60; // 5 minutes max wait
+    
+    while !download_completed && check_count < MAX_CHECKS {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        check_count += 1;
+        
+        // Check download status
+        if let Some(info) = scheduler.status("book_downloads").await {
+            match &info.status {
+                cano::scheduler::Status::ConcurrentCompleted(status) => {
+                    println!(
+                        "📊 Download status: {}/{} completed, {}/{} failed",
+                        status.completed, status.total_workflows,
+                        status.failed, status.total_workflows
+                    );
+                    if status.completed + status.failed >= status.total_workflows {
+                        download_completed = true;
+                    }
+                }
+                cano::scheduler::Status::ConcurrentRunning(status) => {
+                    println!(
+                        "📥 Downloads in progress: {}/{} completed, {} running",
+                        status.completed, status.total_workflows, status.running()
+                    );
+                }
+                _ => {
+                    println!("📋 Download status: {:?}", info.status);
+                }
+            }
+        }
+    }
+
+    if !download_completed {
+        eprintln!("❌ Downloads did not complete within the timeout period");
+        return Err(CanoError::workflow("Download timeout"));
+    }
+
+    // Check how many books were successfully downloaded
+    {
+        let shared_store_guard = shared_store.read().await;
+        let books: Vec<Book> = shared_store_guard
+            .get("downloaded_books")
+            .unwrap_or_else(|_| Vec::new());
+        
+        println!("✅ Downloads completed! {} books successfully downloaded", books.len());
+        
+        if books.is_empty() {
+            eprintln!("❌ No books were successfully downloaded");
+            return Err(CanoError::workflow("No books downloaded"));
+        }
+    }
+
+    // Now trigger the analysis workflow
+    println!("\n🔄 Triggering sequential analysis workflow...");
+    scheduler.trigger("book_analysis").await?;
+
+    // Wait for analysis to complete
+    println!("⏳ Waiting for analysis to complete...");
+    
+    let mut analysis_completed = false;
+    check_count = 0;
+    
+    while !analysis_completed && check_count < MAX_CHECKS {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        check_count += 1;
+        
+        // Check analysis status
+        if let Some(info) = scheduler.status("book_analysis").await {
+            match &info.status {
+                cano::scheduler::Status::Idle => {
+                    if info.run_count > 0 {
+                        analysis_completed = true;
+                        println!("✅ Analysis workflow completed successfully!");
+                    }
+                }
+                cano::scheduler::Status::Running => {
+                    println!("📊 Analysis workflow is running...");
+                }
+                cano::scheduler::Status::Failed(error) => {
+                    eprintln!("❌ Analysis workflow failed: {error}");
+                    return Err(CanoError::workflow(format!("Analysis failed: {error}")));
+                }
+                _ => {
+                    println!("📋 Analysis status: {:?}", info.status);
+                }
+            }
+        }
+    }
+
+    if !analysis_completed {
+        eprintln!("❌ Analysis did not complete within the timeout period");
+        return Err(CanoError::workflow("Analysis timeout"));
+    }
+
+    // Display final summary
+    {
+        let shared_store_guard = shared_store.read().await;
+        if let Ok(rankings) = shared_store_guard.get::<Vec<BookRanking>>("book_rankings") {
+            println!("\n🏆 SCHEDULER-BASED WORKFLOW SUMMARY");
+            println!("===================================");
+            println!("📊 Total books processed: {}", rankings.len());
+
+            if let (Some(top), Some(bottom)) = (rankings.first(), rankings.last()) {
+                println!(
+                    "🥇 Most diverse: {} ({} prepositions)",
+                    top.analysis.title, top.analysis.preposition_count
+                );
+                println!(
+                    "🥉 Least diverse: {} ({} prepositions)",
+                    bottom.analysis.title, bottom.analysis.preposition_count
+                );
+            }
+            
+            println!("\n✨ Architecture Benefits Demonstrated:");
+            println!("  • Concurrent workflow with work queue maximized download throughput");
+            println!("  • Sequential analysis ensured data consistency");
+            println!("  • Scheduler provided workflow orchestration and coordination");
+            println!("  • Shared store enabled seamless data transfer between workflow types");
+        }
+    }
+
+    // Stop the scheduler
+    println!("\n🛑 Stopping scheduler...");
+    scheduler.stop().await?;
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    println!("📚 Scheduler-Based Book Preposition Analysis");
+    println!("===========================================");
+    println!("🏗️ Hybrid Architecture: Concurrent Downloads + Sequential Analysis");
+    println!();
+
+    match run_scheduler_based_analysis().await {
+        Ok(()) => {
+            println!("\n🎉 Scheduler-based book analysis completed successfully!");
+        }
+        Err(e) => {
+            eprintln!("\n❌ Scheduler-based analysis failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cano::store::{MemoryStore, Store};
+
+    #[tokio::test]
+    async fn test_book_list() {
+        let book_list = BookDownloadNode::get_book_list();
+
+        assert_eq!(book_list.len(), 12);
+
+        // Verify each book has valid data
+        for (id, title, url) in &book_list {
+            assert!(*id > 0);
+            assert!(!title.is_empty());
+            assert!(url.starts_with("https://www.gutenberg.org/"));
+            assert!(url.ends_with(".txt"));
+        }
+
+        // Verify we have some expected classics
+        let titles: Vec<String> = book_list
+            .iter()
+            .map(|(_, title, _)| title.clone())
+            .collect();
+        let titles_str = titles.join(" ");
+
+        assert!(titles_str.contains("Pride and Prejudice"));
+        assert!(titles_str.contains("Alice's Adventures"));
+        assert!(titles_str.contains("Sherlock Holmes"));
+        assert!(titles_str.contains("Moby Dick"));
+    }
+
+    #[tokio::test]
+    async fn test_preposition_analysis() {
+        let book = Book {
+            id: 1,
+            title: "Test Book".to_string(),
+            url: "http://example.com".to_string(),
+            content:
+                "The cat sat on the mat with great care. It was under the table, near the door."
+                    .to_string(),
+        };
+
+        let analysis = PrepositionAnalysisNode::analyze_book_prepositions(&book);
+
+        assert_eq!(analysis.book_id, 1);
+        assert_eq!(analysis.title, "Test Book");
+        assert!(analysis.preposition_count > 0);
+        assert!(analysis.total_words > 0);
+        assert!(analysis.preposition_density > 0.0);
+
+        // Should find prepositions like "on", "with", "under", "near"
+        assert!(analysis.unique_prepositions.contains("on"));
+        assert!(analysis.unique_prepositions.contains("with"));
+        assert!(analysis.unique_prepositions.contains("under"));
+        assert!(analysis.unique_prepositions.contains("near"));
+    }
+
+    #[tokio::test]
+    async fn test_shared_store_communication() {
+        let shared_store = Arc::new(RwLock::new(MemoryStore::new()));
+
+        // Simulate download phase
+        let download_node = BookDownloadNode::new(shared_store.clone());
+
+        // Test that we can store books in shared store
+        let store = MemoryStore::new();
+        let book = Book {
+            id: 1,
+            title: "Test Book".to_string(),
+            url: "http://example.com".to_string(),
+            content: "Test content with prepositions on and under the table.".to_string(),
+        };
+
+        download_node.post(&store, Some(book)).await.unwrap();
+
+        // Test that analysis can read from shared store
+        let analysis_node = PrepositionAnalysisNode::new(shared_store.clone());
+        let books = analysis_node.prep(&store).await.unwrap();
+
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].title, "Test Book");
+    }
+
+    #[test]
+    fn test_preposition_constants() {
+        // Verify our preposition list contains common ones
+        assert!(PREPOSITIONS.contains(&"in"));
+        assert!(PREPOSITIONS.contains(&"on"));
+        assert!(PREPOSITIONS.contains(&"at"));
+        assert!(PREPOSITIONS.contains(&"by"));
+        assert!(PREPOSITIONS.contains(&"for"));
+        assert!(PREPOSITIONS.contains(&"with"));
+        assert!(PREPOSITIONS.contains(&"to"));
+        assert!(PREPOSITIONS.contains(&"from"));
+
+        // Should have a reasonable number of prepositions
+        assert!(PREPOSITIONS.len() > 50);
+        assert!(PREPOSITIONS.len() < 100);
+    }
+
+    #[tokio::test]
+    async fn test_download_queue_mechanism() {
+        let shared_store = Arc::new(RwLock::new(MemoryStore::new()));
+
+        // Initialize queue
+        {
+            let shared_guard = shared_store.write().await;
+            let test_books = vec![
+                (1, "Book 1".to_string(), "http://example.com/1".to_string()),
+                (2, "Book 2".to_string(), "http://example.com/2".to_string()),
+            ];
+            shared_guard.put("download_queue", test_books).unwrap();
+        }
+
+        let download_node = BookDownloadNode::new(shared_store.clone());
+        let store = MemoryStore::new();
+
+        // First call should get Book 1
+        let book1 = download_node.prep(&store).await.unwrap();
+        assert!(book1.is_some());
+        assert_eq!(book1.unwrap().0, 1);
+
+        // Second call should get Book 2
+        let book2 = download_node.prep(&store).await.unwrap();
+        assert!(book2.is_some());
+        assert_eq!(book2.unwrap().0, 2);
+
+        // Third call should get None (empty queue)
+        let no_book = download_node.prep(&store).await.unwrap();
+        assert!(no_book.is_none());
+    }
+}

--- a/examples/scheduler_concurrent_workflows.rs
+++ b/examples/scheduler_concurrent_workflows.rs
@@ -142,26 +142,26 @@ async fn main() -> CanoResult<()> {
     println!("This demo shows multiple instances of the same workflow running concurrently.");
     println!("Watch for overlapping execution messages and active instance counts!\n");
 
-    // Create a long-running workflow (5 seconds execution time)
-    let mut long_task_flow: Workflow<TaskState> = Workflow::new(TaskState::Execute);
+        // Create a long-running workflow (5 seconds execution time)
+    let mut long_task_flow = Workflow::new(TaskState::Execute);
     long_task_flow
         .register_node(TaskState::Execute, LongRunningTask::new("LongTask", 7000))
         .add_exit_states(vec![TaskState::Complete]);
 
     // Create a medium-running workflow (3 seconds execution time)
-    let mut medium_task_flow: Workflow<TaskState> = Workflow::new(TaskState::Execute);
+    let mut medium_task_flow = Workflow::new(TaskState::Execute);
     medium_task_flow
         .register_node(TaskState::Execute, LongRunningTask::new("MediumTask", 3000))
         .add_exit_states(vec![TaskState::Complete]);
 
     // Create a fast-running workflow (500ms execution time)
-    let mut fast_task_flow: Workflow<TaskState> = Workflow::new(TaskState::Execute);
+    let mut fast_task_flow = Workflow::new(TaskState::Execute);
     fast_task_flow
         .register_node(TaskState::Execute, LongRunningTask::new("FastTask", 500))
         .add_exit_states(vec![TaskState::Complete]);
 
     // Setup scheduler with aggressive scheduling to force overlaps
-    let mut scheduler: Scheduler<TaskState> = Scheduler::new();
+    let mut scheduler = Scheduler::new();
 
     // Long task every 2 seconds (7s execution, 2s interval = lots of overlap)
     scheduler.every_seconds("long_task", long_task_flow, 2)?;

--- a/examples/scheduler_concurrent_workflows.rs
+++ b/examples/scheduler_concurrent_workflows.rs
@@ -142,7 +142,7 @@ async fn main() -> CanoResult<()> {
     println!("This demo shows multiple instances of the same workflow running concurrently.");
     println!("Watch for overlapping execution messages and active instance counts!\n");
 
-        // Create a long-running workflow (5 seconds execution time)
+    // Create a long-running workflow (5 seconds execution time)
     let mut long_task_flow = Workflow::new(TaskState::Execute);
     long_task_flow
         .register_node(TaskState::Execute, LongRunningTask::new("LongTask", 7000))

--- a/examples/scheduler_duration_scheduling.rs
+++ b/examples/scheduler_duration_scheduling.rs
@@ -25,16 +25,15 @@ use tokio::time::Duration;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum TaskState {
     Start,
-    #[allow(dead_code)]
-    End,
+    Complete,
 }
 
-// Simple demo node
+// Demo nodes for different schedules
 #[derive(Clone)]
-struct DemoNode(String);
+struct DailyTask;
 
 #[async_trait]
-impl Node<TaskState> for DemoNode {
+impl Node<TaskState> for DailyTask {
     type PrepResult = ();
     type ExecResult = ();
 
@@ -43,7 +42,7 @@ impl Node<TaskState> for DemoNode {
     }
 
     async fn exec(&self, _data: Self::PrepResult) -> Self::ExecResult {
-        println!("Executing {}", self.0);
+        println!("📅 Daily task executed at {}", chrono::Utc::now().format("%H:%M:%S"));
     }
 
     async fn post(
@@ -51,67 +50,101 @@ impl Node<TaskState> for DemoNode {
         _store: &MemoryStore,
         _result: Self::ExecResult,
     ) -> Result<TaskState, CanoError> {
-        Ok(TaskState::End)
+        Ok(TaskState::Complete)
+    }
+}
+
+#[derive(Clone)]
+struct HourlyTask;
+
+#[async_trait]
+impl Node<TaskState> for HourlyTask {
+    type PrepResult = ();
+    type ExecResult = ();
+
+    async fn prep(&self, _store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+        Ok(())
+    }
+
+    async fn exec(&self, _data: Self::PrepResult) -> Self::ExecResult {
+        println!("⏰ Hourly task executed at {}", chrono::Utc::now().format("%H:%M:%S"));
+    }
+
+    async fn post(
+        &self,
+        _store: &MemoryStore,
+        _result: Self::ExecResult,
+    ) -> Result<TaskState, CanoError> {
+        Ok(TaskState::Complete)
+    }
+}
+
+#[derive(Clone)]
+struct FrequentTask;
+
+#[async_trait]
+impl Node<TaskState> for FrequentTask {
+    type PrepResult = ();
+    type ExecResult = ();
+
+    async fn prep(&self, _store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+        Ok(())
+    }
+
+    async fn exec(&self, _data: Self::PrepResult) -> Self::ExecResult {
+        println!("🔄 Frequent task executed at {}", chrono::Utc::now().format("%H:%M:%S"));
+    }
+
+    async fn post(
+        &self,
+        _store: &MemoryStore,
+        _result: Self::ExecResult,
+    ) -> Result<TaskState, CanoError> {
+        Ok(TaskState::Complete)
     }
 }
 
 #[tokio::main]
 async fn main() -> CanoResult<()> {
-    let mut scheduler: Scheduler<TaskState> = Scheduler::new();
+    println!("⏰ Duration-Based Scheduling Example");
+    println!("====================================");
 
-    // Create different flows
-    let mut daily_flow: Workflow<TaskState> = Workflow::new(TaskState::Start);
-    daily_flow.register_node(TaskState::Start, DemoNode("Daily Report".to_string()));
-    daily_flow.add_exit_state(TaskState::End);
+    let mut scheduler = Scheduler::new();
 
-    let mut hourly_flow: Workflow<TaskState> = Workflow::new(TaskState::Start);
-    hourly_flow.register_node(TaskState::Start, DemoNode("Hourly Check".to_string()));
-    hourly_flow.add_exit_state(TaskState::End);
+    // Create workflows with different durations
+    let mut daily_flow = Workflow::new(TaskState::Start);
+    daily_flow
+        .register_node(TaskState::Start, DailyTask)
+        .add_exit_state(TaskState::Complete);
 
-    let mut frequent_flow: Workflow<TaskState> = Workflow::new(TaskState::Start);
-    frequent_flow.register_node(TaskState::Start, DemoNode("Frequent Task".to_string()));
-    frequent_flow.add_exit_state(TaskState::End);
+    let mut hourly_flow = Workflow::new(TaskState::Start);
+    hourly_flow
+        .register_node(TaskState::Start, HourlyTask)
+        .add_exit_state(TaskState::Complete);
 
-    let mut manual_flow: Workflow<TaskState> = Workflow::new(TaskState::Start);
-    manual_flow.register_node(TaskState::Start, DemoNode("Manual Task".to_string()));
-    manual_flow.add_exit_state(TaskState::End);
+    let mut frequent_flow = Workflow::new(TaskState::Start);
+    frequent_flow
+        .register_node(TaskState::Start, FrequentTask)
+        .add_exit_state(TaskState::Complete);
 
-    // ===============================
-    // DURATION-BASED SCHEDULING
-    // ===============================
+    // Schedule workflows with different durations
+    scheduler.every("daily_task", daily_flow, Duration::from_secs(86400))?; // 24 hours
+    scheduler.every("hourly_task", hourly_flow, Duration::from_secs(3600))?; // 1 hour
+    scheduler.every("frequent_task", frequent_flow, Duration::from_secs(2))?; // 2 seconds for demo
 
-    // Convenience methods for common intervals
-    scheduler.every_hours("daily_report", daily_flow, 24)?; // Every 24 hours
-    scheduler.every_minutes("hourly_check", hourly_flow, 60)?; // Every hour (60 minutes)
-    scheduler.every_seconds("frequent_task", frequent_flow, 30)?; // Every 30 seconds
+    println!("📅 Scheduled workflows:");
+    println!("  • Daily task: Every 24 hours");
+    println!("  • Hourly task: Every 1 hour");
+    println!("  • Frequent task: Every 2 seconds (for demo)");
+    println!();
 
-    // Precise Duration control for sub-second timing
-    scheduler.every("high_freq", manual_flow, Duration::from_millis(500))?; // Every 500ms
-
-    // Cron for complex schedules
-    // scheduler.cron("business_hours", workflow, "0 9-17 * * 1-5")?;  // Weekdays 9-5
-
-    // Manual triggers
-    // scheduler.manual("on_demand", workflow)?;
-
-    println!("🚀 Starting scheduler with multiple interval types...");
     scheduler.start().await?;
 
-    // Let it run for demonstration
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    println!("🚀 Scheduler started! Running for 10 seconds...");
+    tokio::time::sleep(Duration::from_secs(10)).await;
 
-    println!("📊 Current status:");
-    for flow_info in scheduler.list().await {
-        println!(
-            "  {} - {:?} (runs: {})",
-            flow_info.id, flow_info.status, flow_info.run_count
-        );
-    }
-
-    // Graceful shutdown
-    println!("🛑 Stopping scheduler...");
     scheduler.stop().await?;
-    println!("✅ Done!");
+    println!("✅ Scheduler stopped gracefully");
 
     Ok(())
 }

--- a/examples/scheduler_duration_scheduling.rs
+++ b/examples/scheduler_duration_scheduling.rs
@@ -42,7 +42,10 @@ impl Node<TaskState> for DailyTask {
     }
 
     async fn exec(&self, _data: Self::PrepResult) -> Self::ExecResult {
-        println!("📅 Daily task executed at {}", chrono::Utc::now().format("%H:%M:%S"));
+        println!(
+            "📅 Daily task executed at {}",
+            chrono::Utc::now().format("%H:%M:%S")
+        );
     }
 
     async fn post(
@@ -67,7 +70,10 @@ impl Node<TaskState> for HourlyTask {
     }
 
     async fn exec(&self, _data: Self::PrepResult) -> Self::ExecResult {
-        println!("⏰ Hourly task executed at {}", chrono::Utc::now().format("%H:%M:%S"));
+        println!(
+            "⏰ Hourly task executed at {}",
+            chrono::Utc::now().format("%H:%M:%S")
+        );
     }
 
     async fn post(
@@ -92,7 +98,10 @@ impl Node<TaskState> for FrequentTask {
     }
 
     async fn exec(&self, _data: Self::PrepResult) -> Self::ExecResult {
-        println!("🔄 Frequent task executed at {}", chrono::Utc::now().format("%H:%M:%S"));
+        println!(
+            "🔄 Frequent task executed at {}",
+            chrono::Utc::now().format("%H:%M:%S")
+        );
     }
 
     async fn post(

--- a/examples/scheduler_graceful_shutdown.rs
+++ b/examples/scheduler_graceful_shutdown.rs
@@ -91,16 +91,14 @@ impl Node<MyState> for QuickNode {
 
 #[tokio::main]
 async fn main() -> CanoResult<()> {
-    let mut scheduler: Scheduler<MyState> = Scheduler::new();
+    let mut scheduler = Scheduler::new();
 
-    // Create flows with proper nodes
-    let mut long_flow_builder: Workflow<MyState> = Workflow::new(MyState::Start);
+    // Create a long-running flow
+    let mut long_flow_builder = Workflow::new(MyState::Start);
     long_flow_builder.register_node(MyState::Start, LongProcessingNode);
-    long_flow_builder.add_exit_state(MyState::End);
 
-    let mut quick_flow_builder: Workflow<MyState> = Workflow::new(MyState::Start);
+    let mut quick_flow_builder = Workflow::new(MyState::Start);
     quick_flow_builder.register_node(MyState::Start, QuickNode);
-    quick_flow_builder.add_exit_state(MyState::End);
 
     // Add flows to scheduler
     scheduler.every_seconds("long_task", long_flow_builder, 10)?; // Every 10 seconds

--- a/examples/scheduler_mixed_workflows.rs
+++ b/examples/scheduler_mixed_workflows.rs
@@ -102,7 +102,7 @@ async fn main() -> CanoResult<()> {
     // Create concurrent workflow
     let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
     concurrent_workflow
-        .register_cloneable_node(TaskState::Start, SimpleTask::new("ConcurrentTask"));
+        .register_node(TaskState::Start, SimpleTask::new("ConcurrentTask"));
 
     // Schedule concurrent workflows with different strategies
     scheduler.manual_concurrent(

--- a/examples/scheduler_mixed_workflows.rs
+++ b/examples/scheduler_mixed_workflows.rs
@@ -1,0 +1,229 @@
+//! # Enhanced Scheduler with Concurrent Workflows Example
+//!
+//! This example demonstrates the enhanced scheduler that supports both regular
+//! and concurrent workflows with various scheduling strategies.
+
+use cano::prelude::*;
+use cano::scheduler::Status;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum TaskState {
+    Start,
+    Complete,
+    #[allow(dead_code)]
+    Error,
+}
+
+#[derive(Clone)]
+struct SimpleTask {
+    task_id: String,
+    execution_count: Arc<AtomicU32>,
+}
+
+impl SimpleTask {
+    fn new(id: &str) -> Self {
+        Self {
+            task_id: id.to_string(),
+            execution_count: Arc::new(AtomicU32::new(0)),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn get_execution_count(&self) -> u32 {
+        self.execution_count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl Node<TaskState> for SimpleTask {
+    type PrepResult = String;
+    type ExecResult = String;
+
+    async fn prep(&self, _store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+        Ok(format!("Task {} prepared", self.task_id))
+    }
+
+    async fn exec(&self, prep_result: Self::PrepResult) -> Self::ExecResult {
+        let count = self.execution_count.fetch_add(1, Ordering::SeqCst) + 1;
+
+        // Simulate some work
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        format!("{} - Execution #{}", prep_result, count)
+    }
+
+    async fn post(
+        &self,
+        store: &MemoryStore,
+        exec_result: Self::ExecResult,
+    ) -> Result<TaskState, CanoError> {
+        store.put("last_execution", exec_result)?;
+        Ok(TaskState::Complete)
+    }
+}
+
+#[tokio::main]
+async fn main() -> CanoResult<()> {
+    println!("🚀 Enhanced Scheduler with Concurrent Workflows");
+    println!("===============================================\n");
+
+    let mut scheduler: Scheduler<TaskState> = Scheduler::new();
+
+    // Example 1: Regular workflows
+    println!("📊 Setting up Regular Workflows");
+    println!("-------------------------------");
+
+    // Create regular workflows
+    let mut regular_workflow1: Workflow<TaskState> = Workflow::new(TaskState::Start);
+    regular_workflow1.add_exit_state(TaskState::Complete);
+    regular_workflow1.register_node(TaskState::Start, SimpleTask::new("RegularTask1"));
+
+    let mut regular_workflow2: Workflow<TaskState> = Workflow::new(TaskState::Start);
+    regular_workflow2.add_exit_state(TaskState::Complete);
+    regular_workflow2.register_node(TaskState::Start, SimpleTask::new("RegularTask2"));
+
+    // Schedule regular workflows
+    scheduler.manual("regular_task_1", regular_workflow1)?;
+    scheduler.every_seconds("regular_task_2", regular_workflow2, 2)?;
+
+    println!("✅ Added 2 regular workflows");
+
+    // Example 2: Concurrent workflows
+    println!("\n📊 Setting up Concurrent Workflows");
+    println!("----------------------------------");
+
+    // Create template workflow for concurrent execution
+    let mut template_workflow: Workflow<TaskState> = Workflow::new(TaskState::Start);
+    template_workflow.add_exit_state(TaskState::Complete);
+
+    // Create concurrent workflow
+    let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+    concurrent_workflow
+        .register_cloneable_node(TaskState::Start, SimpleTask::new("ConcurrentTask"));
+
+    // Schedule concurrent workflows with different strategies
+    scheduler.manual_concurrent(
+        "concurrent_batch_1",
+        concurrent_workflow.clone(),
+        3, // 3 instances
+        WaitStrategy::WaitForever,
+    )?;
+
+    scheduler.every_seconds_concurrent(
+        "concurrent_batch_2",
+        concurrent_workflow.clone(),
+        5,                             // every 5 seconds
+        5,                             // 5 instances
+        WaitStrategy::WaitForQuota(3), // wait for 3 to complete
+    )?;
+
+    scheduler.manual_concurrent(
+        "concurrent_batch_3",
+        concurrent_workflow,
+        4,                                                      // 4 instances
+        WaitStrategy::WaitDuration(Duration::from_millis(200)), // 200ms timeout
+    )?;
+
+    println!("✅ Added 3 concurrent workflows");
+
+    // Example 3: List all workflows
+    println!("\n📊 Workflow Summary");
+    println!("------------------");
+
+    let workflows = scheduler.list().await;
+    for workflow in &workflows {
+        println!("ID: {}", workflow.id);
+        println!("  Status: {:?}", workflow.status);
+        println!("  Run count: {}", workflow.run_count);
+        if let Some(instances) = workflow.concurrent_instances {
+            println!("  Concurrent instances: {instances}");
+        }
+        println!("  Last run: {:?}", workflow.last_run);
+        println!();
+    }
+
+    // Example 4: Start scheduler and trigger manual workflows
+    println!("📊 Starting Scheduler and Triggering Manual Workflows");
+    println!("-----------------------------------------------------");
+
+    scheduler.start().await?;
+
+    // Trigger manual workflows
+    println!("🔄 Triggering regular manual workflow...");
+    scheduler.trigger("regular_task_1").await?;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    println!("🔄 Triggering concurrent manual workflow (WaitForever)...");
+    scheduler.trigger("concurrent_batch_1").await?;
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    println!("🔄 Triggering concurrent manual workflow (WaitDuration)...");
+    scheduler.trigger("concurrent_batch_3").await?;
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Example 5: Check status of workflows
+    println!("\n📊 Workflow Status After Execution");
+    println!("----------------------------------");
+
+    for workflow_id in ["regular_task_1", "concurrent_batch_1", "concurrent_batch_3"] {
+        if let Some(info) = scheduler.status(workflow_id).await {
+            println!("Workflow: {}", info.id);
+            println!("  Status: {:?}", info.status);
+            println!("  Run count: {}", info.run_count);
+            if let Status::ConcurrentCompleted(status) = &info.status {
+                println!("  Total workflows: {}", status.total_workflows);
+                println!("  Completed: {}", status.completed);
+                println!("  Failed: {}", status.failed);
+                println!("  Cancelled: {}", status.cancelled);
+                println!("  Duration: {:?}", status.duration);
+            }
+            println!();
+        }
+    }
+
+    // Example 6: Running workflows tracking
+    println!("📊 Scheduler Monitoring");
+    println!("----------------------");
+
+    println!(
+        "Has running workflows: {}",
+        scheduler.has_running_flows().await
+    );
+    println!(
+        "Running workflow count: {}",
+        scheduler.running_count().await
+    );
+
+    // Wait a bit for any scheduled workflows
+    println!("\n⏳ Waiting for scheduled workflows to run...");
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Example 7: Stop scheduler gracefully
+    println!("\n📊 Stopping Scheduler");
+    println!("--------------------");
+
+    scheduler.stop().await?;
+    println!("✅ Scheduler stopped gracefully");
+
+    // Final status
+    let final_workflows = scheduler.list().await;
+    println!("\n📊 Final Workflow Summary");
+    println!("-------------------------");
+
+    for workflow in &final_workflows {
+        println!(
+            "ID: {} - Runs: {} - Status: {:?}",
+            workflow.id, workflow.run_count, workflow.status
+        );
+    }
+
+    println!("\n✅ Enhanced Scheduler example completed successfully!");
+
+    Ok(())
+}

--- a/examples/scheduler_mixed_workflows.rs
+++ b/examples/scheduler_mixed_workflows.rs
@@ -70,18 +70,18 @@ async fn main() -> CanoResult<()> {
     println!("🚀 Enhanced Scheduler with Concurrent Workflows");
     println!("===============================================\n");
 
-    let mut scheduler: Scheduler<TaskState> = Scheduler::new();
+    let mut scheduler = Scheduler::new();
 
     // Example 1: Regular workflows
     println!("📊 Setting up Regular Workflows");
     println!("-------------------------------");
 
     // Create regular workflows
-    let mut regular_workflow1: Workflow<TaskState> = Workflow::new(TaskState::Start);
+    let mut regular_workflow1 = Workflow::new(TaskState::Start);
     regular_workflow1.add_exit_state(TaskState::Complete);
     regular_workflow1.register_node(TaskState::Start, SimpleTask::new("RegularTask1"));
 
-    let mut regular_workflow2: Workflow<TaskState> = Workflow::new(TaskState::Start);
+    let mut regular_workflow2 = Workflow::new(TaskState::Start);
     regular_workflow2.add_exit_state(TaskState::Complete);
     regular_workflow2.register_node(TaskState::Start, SimpleTask::new("RegularTask2"));
 
@@ -95,14 +95,11 @@ async fn main() -> CanoResult<()> {
     println!("\n📊 Setting up Concurrent Workflows");
     println!("----------------------------------");
 
-    // Create template workflow for concurrent execution
-    let mut template_workflow: Workflow<TaskState> = Workflow::new(TaskState::Start);
-    template_workflow.add_exit_state(TaskState::Complete);
+    // Create concurrent workflow directly
+    let mut concurrent_workflow = ConcurrentWorkflow::new(TaskState::Start);
+    concurrent_workflow.add_exit_state(TaskState::Complete);
 
-    // Create concurrent workflow
-    let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
-    concurrent_workflow
-        .register_node(TaskState::Start, SimpleTask::new("ConcurrentTask"));
+    concurrent_workflow.register_node(TaskState::Start, SimpleTask::new("ConcurrentTask"));
 
     // Schedule concurrent workflows with different strategies
     scheduler.manual_concurrent(

--- a/examples/scheduler_scheduling.rs
+++ b/examples/scheduler_scheduling.rs
@@ -233,28 +233,28 @@ async fn main() -> CanoResult<()> {
     println!("=====================================");
 
     // Create flows
-    let mut hourly_report_flow: Workflow<WorkflowAction> = Workflow::new(WorkflowAction::Start);
+    let mut hourly_report_flow = Workflow::new(WorkflowAction::Start);
     hourly_report_flow
         .register_node(WorkflowAction::Start, ReportNode::new("Hourly"))
         .add_exit_states(vec![WorkflowAction::Complete, WorkflowAction::Error]);
 
-    let mut cleanup_flow: Workflow<WorkflowAction> = Workflow::new(WorkflowAction::Start);
+    let mut cleanup_flow = Workflow::new(WorkflowAction::Start);
     cleanup_flow
         .register_node(WorkflowAction::Start, CleanupNode::new("Temporary"))
         .add_exit_states(vec![WorkflowAction::Complete, WorkflowAction::Error]);
 
-    let mut manual_flow: Workflow<WorkflowAction> = Workflow::new(WorkflowAction::Start);
+    let mut manual_flow = Workflow::new(WorkflowAction::Start);
     manual_flow
         .register_node(WorkflowAction::Start, ManualTaskNode::new("Data Migration"))
         .add_exit_states(vec![WorkflowAction::Complete, WorkflowAction::Error]);
 
-    let mut setup_flow: Workflow<WorkflowAction> = Workflow::new(WorkflowAction::Start);
+    let mut setup_flow = Workflow::new(WorkflowAction::Start);
     setup_flow
         .register_node(WorkflowAction::Start, SetupNode::new("System"))
         .add_exit_states(vec![WorkflowAction::Complete, WorkflowAction::Error]);
 
     // Create scheduler with multiple flows
-    let mut scheduler: Scheduler<WorkflowAction> = Scheduler::new();
+    let mut scheduler = Scheduler::new();
 
     // Run hourly report every 5 seconds for demo to see concurrent executions
     scheduler.every_seconds("hourly_report", hourly_report_flow, 5)?;

--- a/examples/workflow_concurrent.rs
+++ b/examples/workflow_concurrent.rs
@@ -1,20 +1,18 @@
 //! # Concurrent Workflow Example
 //!
-//! This example demonstrates the new simplified concurrent workflow API in Cano.
+//! This example demonstrates the concurrent workflow API in Cano.
 //! It shows how to execute multiple workflow instances in parallel with different
 //! wait strategies for flexible execution control.
 //!
-//! ## New Simplified API
+//! ## Concurrent Workflow API
 //!
-//! The new API eliminates the need for `register_cloneable_node()` and makes it easier
-//! to build concurrent workflows:
+//! The concurrent workflow API provides a simple way to execute multiple workflow
+//! instances in parallel:
 //!
 //! ```rust,ignore
-//! // Old API (deprecated)
-//! concurrent_workflow.register_cloneable_node(state, node);
-//!
-//! // New API (recommended)
+//! let mut concurrent_workflow = ConcurrentWorkflow::new(start_state);
 //! concurrent_workflow.register_node(state, node);
+//! concurrent_workflow.add_exit_state(exit_state);
 //! ```
 
 use cano::prelude::*;
@@ -92,12 +90,9 @@ async fn main() -> CanoResult<()> {
     println!("🚀 Concurrent Workflow Example");
     println!("================================\n");
 
-    // Create a template workflow
-    let mut template_workflow: Workflow<ProcessingState> = Workflow::new(ProcessingState::Start);
-    template_workflow.add_exit_state(ProcessingState::Complete);
-
-    // Create a concurrent workflow
-    let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+    // Create a concurrent workflow directly
+    let mut concurrent_workflow = ConcurrentWorkflow::new(ProcessingState::Start);
+    concurrent_workflow.add_exit_state(ProcessingState::Complete);
 
     // Register a processing node directly - much simpler!
     let processing_node = ProcessingNode::new("DataProcessor");
@@ -229,13 +224,14 @@ async fn main() -> CanoResult<()> {
     println!("📊 Example 5: Concurrent Workflow Builder Pattern");
     println!("-------------------------------------------------");
 
-    // Demonstrate the builder pattern
-    let _built_concurrent_workflow: ConcurrentWorkflow<ProcessingState> =
-        ConcurrentWorkflowBuilder::new(Workflow::new(ProcessingState::Start)).build();
+    // Demonstrate the builder pattern for concurrent workflows
+    let mut concurrent_workflow = ConcurrentWorkflowBuilder::new(ProcessingState::Start).build();
+
+    // Register nodes on the built workflow
+    concurrent_workflow.register_node(ProcessingState::Start, ProcessingNode::new("Builder"));
+    concurrent_workflow.add_exit_state(ProcessingState::Complete);
 
     let stores = vec![MemoryStore::new(), MemoryStore::new()];
-    // Note: This example needs to be updated to register nodes properly
-    // For now, let's reuse the existing concurrent_workflow
     let (results, status) = concurrent_workflow
         .execute_concurrent(stores, WaitStrategy::WaitForever)
         .await?;

--- a/examples/workflow_concurrent.rs
+++ b/examples/workflow_concurrent.rs
@@ -1,0 +1,243 @@
+//! # Concurrent Workflow Example
+//!
+//! This example demonstrates the new concurrent workflow functionality in Cano.
+//! It shows how to execute multiple workflow instances in parallel with different
+//! wait strategies for flexible execution control.
+
+use cano::prelude::*;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ProcessingState {
+    Start,
+    Complete,
+}
+
+#[derive(Clone)]
+struct ProcessingNode {
+    execution_count: Arc<AtomicU32>,
+    node_id: String,
+}
+
+impl ProcessingNode {
+    fn new(id: &str) -> Self {
+        Self {
+            execution_count: Arc::new(AtomicU32::new(0)),
+            node_id: id.to_string(),
+        }
+    }
+
+    fn get_execution_count(&self) -> u32 {
+        self.execution_count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl Node<ProcessingState> for ProcessingNode {
+    type PrepResult = String;
+    type ExecResult = String;
+
+    async fn prep(&self, store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+        // Load some data from store or create default
+        let input_data = store
+            .get::<String>("input_data")
+            .unwrap_or_else(|_| "default_input".to_string());
+
+        Ok(format!(
+            "Node {} prepared with: {}",
+            self.node_id, input_data
+        ))
+    }
+
+    async fn exec(&self, prep_result: Self::PrepResult) -> Self::ExecResult {
+        // Increment execution counter
+        let count = self.execution_count.fetch_add(1, Ordering::SeqCst) + 1;
+
+        // Simulate some processing time
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        format!("{} - Execution #{}", prep_result, count)
+    }
+
+    async fn post(
+        &self,
+        store: &MemoryStore,
+        exec_result: Self::ExecResult,
+    ) -> Result<ProcessingState, CanoError> {
+        // Store the result
+        store.put("processed_result", exec_result)?;
+
+        // Move to next state
+        Ok(ProcessingState::Complete)
+    }
+}
+
+#[tokio::main]
+async fn main() -> CanoResult<()> {
+    println!("🚀 Concurrent Workflow Example");
+    println!("================================\n");
+
+    // Create a template workflow
+    let mut template_workflow: Workflow<ProcessingState> = Workflow::new(ProcessingState::Start);
+    template_workflow.add_exit_state(ProcessingState::Complete);
+
+    // Create a concurrent workflow
+    let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+
+    // Register a cloneable processing node
+    let processing_node = ProcessingNode::new("DataProcessor");
+    concurrent_workflow.register_cloneable_node(ProcessingState::Start, processing_node.clone());
+
+    println!("📊 Example 1: WaitForever Strategy");
+    println!("----------------------------------");
+
+    // Create stores for concurrent execution (each workflow gets its own store)
+    let stores = vec![
+        {
+            let store = MemoryStore::new();
+            store.put("input_data", "Dataset_A".to_string()).unwrap();
+            store
+        },
+        {
+            let store = MemoryStore::new();
+            store.put("input_data", "Dataset_B".to_string()).unwrap();
+            store
+        },
+        {
+            let store = MemoryStore::new();
+            store.put("input_data", "Dataset_C".to_string()).unwrap();
+            store
+        },
+    ];
+
+    // Execute with WaitForever strategy (wait for all to complete)
+    let (results, status) = concurrent_workflow
+        .execute_concurrent(stores, WaitStrategy::WaitForever)
+        .await?;
+
+    println!("Results: {} workflows executed", results.len());
+    println!(
+        "Status: completed={}, failed={}, cancelled={}",
+        status.completed, status.failed, status.cancelled
+    );
+    println!("Duration: {:?}\n", status.duration);
+
+    // Check individual results
+    for (i, result) in results.iter().enumerate() {
+        match result {
+            WorkflowResult::Success(final_state) => {
+                println!("  Workflow {}: Success -> {:?}", i + 1, final_state);
+            }
+            WorkflowResult::Failed(error) => {
+                println!("  Workflow {}: Failed -> {}", i + 1, error);
+            }
+            WorkflowResult::Cancelled => {
+                println!("  Workflow {}: Cancelled", i + 1);
+            }
+        }
+    }
+
+    println!("\n📊 Example 2: WaitForQuota Strategy");
+    println!("-----------------------------------");
+
+    // Create more stores for quota example
+    let stores = vec![
+        MemoryStore::new(),
+        MemoryStore::new(),
+        MemoryStore::new(),
+        MemoryStore::new(),
+        MemoryStore::new(),
+    ];
+
+    // Execute with quota strategy (complete 3 out of 5, cancel the rest)
+    let (results, status) = concurrent_workflow
+        .execute_concurrent(stores, WaitStrategy::WaitForQuota(3))
+        .await?;
+
+    println!("Results: {} workflows executed", results.len());
+    println!(
+        "Status: completed={}, failed={}, cancelled={}",
+        status.completed, status.failed, status.cancelled
+    );
+    println!("Duration: {:?}\n", status.duration);
+
+    println!("📊 Example 3: WaitDuration Strategy");
+    println!("-----------------------------------");
+
+    // Create stores for duration example
+    let stores = vec![MemoryStore::new(), MemoryStore::new(), MemoryStore::new()];
+
+    // Execute with duration strategy (100ms timeout)
+    let (results, status) = concurrent_workflow
+        .execute_concurrent(
+            stores,
+            WaitStrategy::WaitDuration(Duration::from_millis(100)),
+        )
+        .await?;
+
+    println!("Results: {} workflows executed", results.len());
+    println!(
+        "Status: completed={}, failed={}, cancelled={}",
+        status.completed, status.failed, status.cancelled
+    );
+    println!("Duration: {:?}\n", status.duration);
+
+    println!("📊 Example 4: WaitQuotaOrDuration Strategy");
+    println!("------------------------------------------");
+
+    // Create stores for combined strategy example
+    let stores = vec![
+        MemoryStore::new(),
+        MemoryStore::new(),
+        MemoryStore::new(),
+        MemoryStore::new(),
+    ];
+
+    // Execute with combined strategy (2 completions OR 200ms, whichever comes first)
+    let (results, status) = concurrent_workflow
+        .execute_concurrent(
+            stores,
+            WaitStrategy::WaitQuotaOrDuration {
+                quota: 2,
+                duration: Duration::from_millis(200),
+            },
+        )
+        .await?;
+
+    println!("Results: {} workflows executed", results.len());
+    println!(
+        "Status: completed={}, failed={}, cancelled={}",
+        status.completed, status.failed, status.cancelled
+    );
+    println!("Duration: {:?}\n", status.duration);
+
+    println!("📊 Example 5: Concurrent Workflow Builder Pattern");
+    println!("-------------------------------------------------");
+
+    // Demonstrate the builder pattern
+    let built_concurrent_workflow =
+        ConcurrentWorkflowBuilder::new(Workflow::new(ProcessingState::Start))
+            .register_cloneable_node(ProcessingState::Start, ProcessingNode::new("BuilderNode"))
+            .build();
+
+    let stores = vec![MemoryStore::new(), MemoryStore::new()];
+    let (results, status) = built_concurrent_workflow
+        .execute_concurrent(stores, WaitStrategy::WaitForever)
+        .await?;
+
+    println!("Builder pattern results: {} workflows", results.len());
+    println!(
+        "Status: completed={}, failed={}, cancelled={}",
+        status.completed, status.failed, status.cancelled
+    );
+
+    println!("\n✅ All concurrent workflow examples completed successfully!");
+    println!(
+        "Total node executions: {}",
+        processing_node.get_execution_count()
+    );
+
+    Ok(())
+}

--- a/examples/workflow_concurrent.rs
+++ b/examples/workflow_concurrent.rs
@@ -1,8 +1,21 @@
 //! # Concurrent Workflow Example
 //!
-//! This example demonstrates the new concurrent workflow functionality in Cano.
+//! This example demonstrates the new simplified concurrent workflow API in Cano.
 //! It shows how to execute multiple workflow instances in parallel with different
 //! wait strategies for flexible execution control.
+//!
+//! ## New Simplified API
+//!
+//! The new API eliminates the need for `register_cloneable_node()` and makes it easier
+//! to build concurrent workflows:
+//!
+//! ```rust,ignore
+//! // Old API (deprecated)
+//! concurrent_workflow.register_cloneable_node(state, node);
+//!
+//! // New API (recommended)
+//! concurrent_workflow.register_node(state, node);
+//! ```
 
 use cano::prelude::*;
 use std::sync::Arc;
@@ -86,9 +99,9 @@ async fn main() -> CanoResult<()> {
     // Create a concurrent workflow
     let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
 
-    // Register a cloneable processing node
+    // Register a processing node directly - much simpler!
     let processing_node = ProcessingNode::new("DataProcessor");
-    concurrent_workflow.register_cloneable_node(ProcessingState::Start, processing_node.clone());
+    concurrent_workflow.register_node(ProcessingState::Start, processing_node.clone());
 
     println!("📊 Example 1: WaitForever Strategy");
     println!("----------------------------------");
@@ -217,13 +230,13 @@ async fn main() -> CanoResult<()> {
     println!("-------------------------------------------------");
 
     // Demonstrate the builder pattern
-    let built_concurrent_workflow =
-        ConcurrentWorkflowBuilder::new(Workflow::new(ProcessingState::Start))
-            .register_cloneable_node(ProcessingState::Start, ProcessingNode::new("BuilderNode"))
-            .build();
+    let _built_concurrent_workflow: ConcurrentWorkflow<ProcessingState> =
+        ConcurrentWorkflowBuilder::new(Workflow::new(ProcessingState::Start)).build();
 
     let stores = vec![MemoryStore::new(), MemoryStore::new()];
-    let (results, status) = built_concurrent_workflow
+    // Note: This example needs to be updated to register nodes properly
+    // For now, let's reuse the existing concurrent_workflow
+    let (results, status) = concurrent_workflow
         .execute_concurrent(stores, WaitStrategy::WaitForever)
         .await?;
 

--- a/examples/workflow_simd_matrix_pipeline.rs
+++ b/examples/workflow_simd_matrix_pipeline.rs
@@ -1,0 +1,539 @@
+//! # SIMD Matrix Processing Pipeline Example
+//!
+//! This example demonstrates a sophisticated data processing pipeline using the `wide` crate
+//! for SIMD (Single Instruction, Multiple Data) acceleration in a Cano workflow.
+//!
+//! ## Pipeline Architecture
+//!
+//! The pipeline consists of four stages, each implementing different SIMD-accelerated operations:
+//!
+//! 1. **Data Generation** (`MatrixGenerator`): Creates random 64x64 matrices filled with float32 values
+//! 2. **Matrix Multiplication** (`SimdMatrixMultiplier`): Performs matrix multiplication using SIMD f32x8 vectors
+//! 3. **Matrix Transformation** (`SimdMatrixTransformer`): Applies scaling and element-wise addition using SIMD
+//! 4. **Statistical Analysis** (`SimdStatisticsCalculator`): Computes sum, mean, and variance using SIMD operations
+//!
+//! ## SIMD Optimizations Demonstrated
+//!
+//! - **f32x8 Vector Operations**: Processes 8 float32 values simultaneously
+//! - **Matrix Multiplication**: Optimized inner loops using SIMD for better cache efficiency
+//! - **Element-wise Operations**: Vectorized addition, scaling, and statistical calculations
+//! - **Memory Access Patterns**: Aligned memory access for optimal SIMD performance
+//!
+//! ## Key Features
+//!
+//! - Uses Cano's three-phase node execution (prep, exec, post)
+//! - Inter-node communication through shared MemoryStore
+//! - State-driven workflow orchestration with typed transitions
+//! - Performance monitoring with execution timing
+//! - Graceful handling of partial SIMD vectors (when data size isn't divisible by 8)
+//!
+//! ## Performance Benefits
+//!
+//! The SIMD operations provide significant performance improvements over scalar operations:
+//! - Matrix multiplication: ~8x theoretical speedup for float32 operations
+//! - Element-wise operations: Nearly linear scaling with vector width
+//! - Statistical calculations: Reduced loop iterations and improved cache utilization
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run --example simd_matrix_pipeline
+//! ```
+//!
+//! The example generates 20 matrices of size 64x64, processes them through the pipeline,
+//! and reports timing information for each stage.
+
+use cano::prelude::*;
+use std::time::Instant;
+use wide::f32x8;
+
+/// Matrix structure optimized for SIMD operations
+#[derive(Debug, Clone)]
+struct SimdMatrix {
+    data: Vec<f32>,
+    rows: usize,
+    cols: usize,
+}
+
+impl SimdMatrix {
+    fn new(rows: usize, cols: usize) -> Self {
+        Self {
+            data: vec![0.0; rows * cols],
+            rows,
+            cols,
+        }
+    }
+
+    fn from_data(data: Vec<f32>, rows: usize, cols: usize) -> Self {
+        assert_eq!(data.len(), rows * cols);
+        Self { data, rows, cols }
+    }
+
+    fn get(&self, row: usize, col: usize) -> f32 {
+        self.data[row * self.cols + col]
+    }
+
+    fn set(&mut self, row: usize, col: usize, value: f32) {
+        self.data[row * self.cols + col] = value;
+    }
+
+    /// Standard scalar matrix multiplication for comparison
+    fn multiply_scalar(&self, other: &SimdMatrix) -> SimdMatrix {
+        assert_eq!(self.cols, other.rows);
+        
+        let mut result = SimdMatrix::new(self.rows, other.cols);
+        
+        for i in 0..self.rows {
+            for j in 0..other.cols {
+                let mut sum = 0.0;
+                for k in 0..self.cols {
+                    sum += self.get(i, k) * other.get(k, j);
+                }
+                result.set(i, j, sum);
+            }
+        }
+        
+        result
+    }
+
+    /// SIMD-accelerated matrix multiplication
+    fn multiply_simd(&self, other: &SimdMatrix) -> SimdMatrix {
+        assert_eq!(self.cols, other.rows);
+        
+        let mut result = SimdMatrix::new(self.rows, other.cols);
+        
+        // Process 8 elements at a time using SIMD
+        for i in 0..self.rows {
+            for j in (0..other.cols).step_by(8) {
+                let mut sum = f32x8::ZERO;
+                
+                for k in 0..self.cols {
+                    let a_val = f32x8::splat(self.get(i, k));
+                    
+                    // Load 8 consecutive elements from matrix B
+                    let remaining = (other.cols - j).min(8);
+                    let mut b_vals = [0.0f32; 8];
+                    for l in 0..remaining {
+                        if j + l < other.cols {
+                            b_vals[l] = other.get(k, j + l);
+                        }
+                    }
+                    let b_vec = f32x8::from(b_vals);
+                    
+                    sum += a_val * b_vec;
+                }
+                
+                // Store the results back
+                let sum_array: [f32; 8] = sum.into();
+                for l in 0..8 {
+                    if j + l < other.cols {
+                        result.set(i, j + l, sum_array[l]);
+                    }
+                }
+            }
+        }
+        
+        result
+    }
+
+    /// SIMD-accelerated element-wise operations
+    fn add_simd(&self, other: &SimdMatrix) -> SimdMatrix {
+        assert_eq!(self.rows, other.rows);
+        assert_eq!(self.cols, other.cols);
+        
+        let mut result = SimdMatrix::new(self.rows, self.cols);
+        
+        // Process 8 elements at a time
+        for i in (0..self.data.len()).step_by(8) {
+            let remaining = (self.data.len() - i).min(8);
+            let mut a_vals = [0.0f32; 8];
+            let mut b_vals = [0.0f32; 8];
+            
+            for j in 0..remaining {
+                a_vals[j] = self.data[i + j];
+                b_vals[j] = other.data[i + j];
+            }
+            
+            let a_vec = f32x8::from(a_vals);
+            let b_vec = f32x8::from(b_vals);
+            let sum_vec = a_vec + b_vec;
+            let sum_array: [f32; 8] = sum_vec.into();
+            
+            for j in 0..remaining {
+                result.data[i + j] = sum_array[j];
+            }
+        }
+        
+        result
+    }
+
+    /// SIMD-accelerated scalar multiplication
+    fn scale_simd(&self, scalar: f32) -> SimdMatrix {
+        let mut result = SimdMatrix::new(self.rows, self.cols);
+        let scalar_vec = f32x8::splat(scalar);
+        
+        for i in (0..self.data.len()).step_by(8) {
+            let remaining = (self.data.len() - i).min(8);
+            let mut vals = [0.0f32; 8];
+            
+            for j in 0..remaining {
+                vals[j] = self.data[i + j];
+            }
+            
+            let vec = f32x8::from(vals);
+            let scaled = vec * scalar_vec;
+            let scaled_array: [f32; 8] = scaled.into();
+            
+            for j in 0..remaining {
+                result.data[i + j] = scaled_array[j];
+            }
+        }
+        
+        result
+    }
+}
+
+/// Pipeline states for the SIMD matrix processing workflow
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum PipelineState {
+    Generate,
+    Multiply,
+    Transform,
+    Statistics,
+    Complete,
+    Error,
+}
+
+/// Data generation node - creates random matrices
+#[derive(Clone)]
+struct MatrixGenerator {
+    size: usize,
+    count: usize,
+}
+
+impl MatrixGenerator {
+    fn new(size: usize, count: usize) -> Self {
+        Self { size, count }
+    }
+}
+
+#[async_trait::async_trait]
+impl Node<PipelineState> for MatrixGenerator {
+    type PrepResult = ();
+    type ExecResult = Vec<SimdMatrix>;
+
+    fn config(&self) -> NodeConfig {
+        NodeConfig::minimal()
+    }
+
+    async fn prep(&self, _store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+        println!("🔢 Preparing to generate {} {}x{} matrices...", self.count, self.size, self.size);
+        Ok(())
+    }
+
+    async fn exec(&self, _prep_res: Self::PrepResult) -> Self::ExecResult {
+        println!("🔢 Generating matrices...");
+        
+        let mut matrices = Vec::new();
+        
+        for i in 0..self.count {
+            let mut data = Vec::with_capacity(self.size * self.size);
+            
+            // Generate random matrix data
+            for _ in 0..(self.size * self.size) {
+                data.push(rand::random::<f32>() * 10.0);
+            }
+            
+            let matrix = SimdMatrix::from_data(data, self.size, self.size);
+            matrices.push(matrix);
+            
+            if i % 10 == 0 {
+                println!("  Generated matrix {}/{}", i + 1, self.count);
+            }
+        }
+        
+        matrices
+    }
+
+    async fn post(&self, store: &MemoryStore, exec_res: Self::ExecResult) -> Result<PipelineState, CanoError> {
+        store.put("matrices", exec_res)?;
+        println!("✅ Matrix generation complete!");
+        Ok(PipelineState::Multiply)
+    }
+}
+
+/// Matrix multiplication node using SIMD
+#[derive(Clone)]
+struct SimdMatrixMultiplier;
+
+#[async_trait::async_trait]
+impl Node<PipelineState> for SimdMatrixMultiplier {
+    type PrepResult = Vec<SimdMatrix>;
+    type ExecResult = Vec<SimdMatrix>;
+
+    fn config(&self) -> NodeConfig {
+        NodeConfig::minimal()
+    }
+
+    async fn prep(&self, store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+        println!("🧮 Loading matrices for SIMD multiplication...");
+        let matrices: Vec<SimdMatrix> = store.get("matrices")?;
+        Ok(matrices)
+    }
+
+    async fn exec(&self, prep_res: Self::PrepResult) -> Self::ExecResult {
+        println!("🧮 Performing SIMD matrix multiplications...");
+        let start = Instant::now();
+        
+        let mut results = Vec::new();
+        
+        // Multiply consecutive pairs of matrices
+        for chunk in prep_res.chunks(2) {
+            if chunk.len() == 2 {
+                let result = chunk[0].multiply_simd(&chunk[1]);
+                results.push(result);
+            }
+        }
+        
+        let duration = start.elapsed();
+        println!("✅ Matrix multiplications complete in {:?} (SIMD accelerated)", duration);
+        println!("  Processed {} matrix pairs", results.len());
+        
+        results
+    }
+
+    async fn post(&self, store: &MemoryStore, exec_res: Self::ExecResult) -> Result<PipelineState, CanoError> {
+        store.put("multiplied_matrices", exec_res)?;
+        Ok(PipelineState::Transform)
+    }
+}
+
+/// Matrix transformation node - applies scaling and addition using SIMD
+#[derive(Clone)]
+struct SimdMatrixTransformer {
+    scale_factor: f32,
+}
+
+impl SimdMatrixTransformer {
+    fn new(scale_factor: f32) -> Self {
+        Self { scale_factor }
+    }
+}
+
+#[async_trait::async_trait]
+impl Node<PipelineState> for SimdMatrixTransformer {
+    type PrepResult = Vec<SimdMatrix>;
+    type ExecResult = Vec<SimdMatrix>;
+
+    fn config(&self) -> NodeConfig {
+        NodeConfig::minimal()
+    }
+
+    async fn prep(&self, store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+        println!("🔄 Loading matrices for SIMD transformations...");
+        let matrices: Vec<SimdMatrix> = store.get("multiplied_matrices")?;
+        Ok(matrices)
+    }
+
+    async fn exec(&self, prep_res: Self::PrepResult) -> Self::ExecResult {
+        println!("🔄 Applying SIMD transformations (scale factor: {})...", self.scale_factor);
+        let start = Instant::now();
+        
+        let mut results: Vec<SimdMatrix> = Vec::new();
+        
+        for (i, matrix) in prep_res.iter().enumerate() {
+            // Scale the matrix using SIMD
+            let scaled = matrix.scale_simd(self.scale_factor);
+            
+            // If we have multiple matrices, add them together using SIMD
+            if i > 0 && !results.is_empty() {
+                let last_idx = results.len() - 1;
+                let combined = results[last_idx].add_simd(&scaled);
+                results[last_idx] = combined;
+            } else {
+                results.push(scaled);
+            }
+        }
+        
+        let duration = start.elapsed();
+        println!("✅ Matrix transformations complete in {:?} (SIMD accelerated)", duration);
+        println!("  Processed {} matrices", prep_res.len());
+        
+        results
+    }
+
+    async fn post(&self, store: &MemoryStore, exec_res: Self::ExecResult) -> Result<PipelineState, CanoError> {
+        store.put("transformed_matrices", exec_res)?;
+        Ok(PipelineState::Statistics)
+    }
+}
+
+/// Statistical analysis node using SIMD for vector operations
+#[derive(Clone)]
+struct SimdStatisticsCalculator;
+
+#[async_trait::async_trait]
+impl Node<PipelineState> for SimdStatisticsCalculator {
+    type PrepResult = Vec<SimdMatrix>;
+    type ExecResult = Vec<(f32, f32, f32)>; // (sum, mean, variance)
+
+    fn config(&self) -> NodeConfig {
+        NodeConfig::minimal()
+    }
+
+    async fn prep(&self, store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+        println!("📊 Loading matrices for statistics calculation...");
+        let matrices: Vec<SimdMatrix> = store.get("transformed_matrices")?;
+        Ok(matrices)
+    }
+
+    async fn exec(&self, prep_res: Self::PrepResult) -> Self::ExecResult {
+        println!("📊 Calculating matrix statistics using SIMD...");
+        let start = Instant::now();
+        
+        let mut results = Vec::new();
+        
+        for matrix in prep_res {
+            // Calculate sum using SIMD
+            let mut sum = f32x8::ZERO;
+            let data_len = matrix.data.len();
+            
+            for i in (0..data_len).step_by(8) {
+                let remaining = (data_len - i).min(8);
+                let mut vals = [0.0f32; 8];
+                
+                for j in 0..remaining {
+                    vals[j] = matrix.data[i + j];
+                }
+                
+                let vec = f32x8::from(vals);
+                sum += vec;
+            }
+            
+            // Sum all elements in the SIMD vector
+            let sum_array: [f32; 8] = sum.into();
+            let total_sum = sum_array.iter().sum::<f32>();
+            let mean = total_sum / data_len as f32;
+            
+            // Calculate variance using SIMD
+            let mean_vec = f32x8::splat(mean);
+            let mut variance_sum = f32x8::ZERO;
+            
+            for i in (0..data_len).step_by(8) {
+                let remaining = (data_len - i).min(8);
+                let mut vals = [0.0f32; 8];
+                
+                for j in 0..remaining {
+                    vals[j] = matrix.data[i + j];
+                }
+                
+                let vec = f32x8::from(vals);
+                let diff = vec - mean_vec;
+                variance_sum += diff * diff;
+            }
+            
+            let variance_array: [f32; 8] = variance_sum.into();
+            let total_variance = variance_array.iter().sum::<f32>() / data_len as f32;
+            
+            results.push((total_sum, mean, total_variance));
+        }
+        
+        let duration = start.elapsed();
+        println!("✅ Statistics calculation complete in {:?} (SIMD accelerated)", duration);
+        
+        results
+    }
+
+    async fn post(&self, store: &MemoryStore, exec_res: Self::ExecResult) -> Result<PipelineState, CanoError> {
+        store.put("statistics", exec_res.clone())?;
+        
+        for (i, (sum, mean, variance)) in exec_res.iter().enumerate() {
+            println!("  Matrix {}: sum={:.2}, mean={:.2}, variance={:.2}", 
+                     i + 1, sum, mean, variance);
+        }
+        
+        Ok(PipelineState::Complete)
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("🚀 Starting SIMD Matrix Processing Pipeline");
+    println!("This example demonstrates SIMD-accelerated mathematical operations");
+    println!("using the 'wide' crate in a Cano workflow pipeline.\n");
+
+    // Quick SIMD vs Scalar performance comparison
+    println!("🏁 Quick Performance Comparison (SIMD vs Scalar):");
+    let test_matrix_a = {
+        let mut data = Vec::with_capacity(16 * 16);
+        for _ in 0..(16 * 16) {
+            data.push(rand::random::<f32>() * 10.0);
+        }
+        SimdMatrix::from_data(data, 16, 16)
+    };
+    let test_matrix_b = {
+        let mut data = Vec::with_capacity(16 * 16);
+        for _ in 0..(16 * 16) {
+            data.push(rand::random::<f32>() * 10.0);
+        }
+        SimdMatrix::from_data(data, 16, 16)
+    };
+
+    // Scalar multiplication timing
+    let scalar_start = Instant::now();
+    let _scalar_result = test_matrix_a.multiply_scalar(&test_matrix_b);
+    let scalar_duration = scalar_start.elapsed();
+
+    // SIMD multiplication timing
+    let simd_start = Instant::now();
+    let _simd_result = test_matrix_a.multiply_simd(&test_matrix_b);
+    let simd_duration = simd_start.elapsed();
+
+    println!("  Scalar 16x16 matrix multiplication: {:?}", scalar_duration);
+    println!("  SIMD 16x16 matrix multiplication:   {:?}", simd_duration);
+    if scalar_duration > simd_duration {
+        let speedup = scalar_duration.as_nanos() as f64 / simd_duration.as_nanos() as f64;
+        println!("  🚀 SIMD speedup: {:.2}x faster!\n", speedup);
+    } else {
+        println!("  📊 Results may vary based on CPU architecture\n");
+    }
+
+    let start_time = Instant::now();
+
+    // Create the workflow with SIMD-accelerated nodes
+    let mut workflow = Workflow::new(PipelineState::Generate);
+
+    // Register all pipeline nodes
+    workflow
+        .register_node(PipelineState::Generate, MatrixGenerator::new(64, 20)) // 64x64 matrices, 20 of them
+        .register_node(PipelineState::Multiply, SimdMatrixMultiplier)
+        .register_node(PipelineState::Transform, SimdMatrixTransformer::new(1.5))
+        .register_node(PipelineState::Statistics, SimdStatisticsCalculator)
+        .add_exit_states(vec![PipelineState::Complete, PipelineState::Error]);
+
+    println!("🔧 Pipeline configured with {} nodes", workflow.state_nodes.len());
+    println!("Pipeline: Generate → Multiply → Transform → Statistics → Complete\n");
+
+    // Execute the workflow
+    let store = MemoryStore::default();
+    let _final_state = workflow.orchestrate(&store).await?;
+
+    let total_duration = start_time.elapsed();
+    println!("\n🎉 SIMD Matrix Processing Pipeline completed!");
+    println!("Total execution time: {:?}", total_duration);
+    
+    if let Ok(stats) = store.get::<Vec<(f32, f32, f32)>>("statistics") {
+        println!("📈 Final results: {} statistical summaries generated", stats.len());
+    }
+
+    println!("\n💡 This example showcased:");
+    println!("  • Data generation in the first pipeline stage");
+    println!("  • SIMD-accelerated matrix multiplication");
+    println!("  • SIMD-accelerated element-wise operations");
+    println!("  • SIMD-accelerated statistical calculations");
+    println!("  • Processing 8 float32 values simultaneously using f32x8");
+    println!("  • Three-phase node execution (prep, exec, post)");
+    println!("  • Inter-node communication through shared store");
+
+    Ok(())
+}

--- a/examples/workflow_stack_store.rs
+++ b/examples/workflow_stack_store.rs
@@ -280,7 +280,7 @@ async fn main() -> CanoResult<()> {
     println!("Demonstrating custom store types for node communication\n");
 
     // Create the processing workflow
-    let mut workflow: Workflow<ProcessingState, RequestCtx> =
+    let mut workflow =
         Workflow::new(ProcessingState::IncomingRequest);
 
     workflow

--- a/examples/workflow_stack_store.rs
+++ b/examples/workflow_stack_store.rs
@@ -280,8 +280,7 @@ async fn main() -> CanoResult<()> {
     println!("Demonstrating custom store types for node communication\n");
 
     // Create the processing workflow
-    let mut workflow =
-        Workflow::new(ProcessingState::IncomingRequest);
+    let mut workflow = Workflow::new(ProcessingState::IncomingRequest);
 
     workflow
         .register_node(ProcessingState::IncomingRequest, MetricsNode)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,8 @@ pub use node::{DefaultNodeResult, DefaultParams, DynNode, Node, NodeConfig, Retr
 pub use scheduler::{FlowInfo, Scheduler};
 pub use store::{KeyValueStore, MemoryStore};
 pub use workflow::{
-    ConcurrentWorkflow, ConcurrentWorkflowBuilder, ConcurrentWorkflowStatus, 
-    WaitStrategy, Workflow, WorkflowBuilder, WorkflowResult
+    ConcurrentWorkflow, ConcurrentWorkflowBuilder, ConcurrentWorkflowStatus, WaitStrategy,
+    Workflow, WorkflowBuilder, WorkflowResult,
 };
 
 // Convenience re-exports for common patterns
@@ -98,10 +98,10 @@ pub mod prelude {
     //! Use `use cano::prelude::*;` to import the most commonly used types and traits.
 
     pub use crate::{
-        CanoError, CanoResult, ConcurrentWorkflow, ConcurrentWorkflowBuilder, 
+        CanoError, CanoResult, ConcurrentWorkflow, ConcurrentWorkflowBuilder,
         ConcurrentWorkflowStatus, DefaultNodeResult, DefaultParams, FlowInfo, KeyValueStore,
-        MemoryStore, Node, NodeConfig, RetryMode, Scheduler, WaitStrategy, 
-        Workflow, WorkflowBuilder, WorkflowResult,
+        MemoryStore, Node, NodeConfig, RetryMode, Scheduler, WaitStrategy, Workflow,
+        WorkflowBuilder, WorkflowResult,
     };
 
     // Re-export async_trait for convenience

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,10 @@ pub use error::{CanoError, CanoResult};
 pub use node::{DefaultNodeResult, DefaultParams, DynNode, Node, NodeConfig, RetryMode};
 pub use scheduler::{FlowInfo, Scheduler};
 pub use store::{KeyValueStore, MemoryStore};
-pub use workflow::{Workflow, WorkflowBuilder};
+pub use workflow::{
+    ConcurrentWorkflow, ConcurrentWorkflowBuilder, ConcurrentWorkflowStatus, 
+    WaitStrategy, Workflow, WorkflowBuilder, WorkflowResult
+};
 
 // Convenience re-exports for common patterns
 pub mod prelude {
@@ -95,8 +98,10 @@ pub mod prelude {
     //! Use `use cano::prelude::*;` to import the most commonly used types and traits.
 
     pub use crate::{
-        CanoError, CanoResult, DefaultNodeResult, DefaultParams, FlowInfo, KeyValueStore,
-        MemoryStore, Node, NodeConfig, RetryMode, Scheduler, Workflow, WorkflowBuilder,
+        CanoError, CanoResult, ConcurrentWorkflow, ConcurrentWorkflowBuilder, 
+        ConcurrentWorkflowStatus, DefaultNodeResult, DefaultParams, FlowInfo, KeyValueStore,
+        MemoryStore, Node, NodeConfig, RetryMode, Scheduler, WaitStrategy, 
+        Workflow, WorkflowBuilder, WorkflowResult,
     };
 
     // Re-export async_trait for convenience

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1295,7 +1295,7 @@ mod tests {
         // Create a concurrent workflow
         let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
         let node = TestNode::new_success();
-        concurrent_workflow.register_cloneable_node(TestState::Start, node);
+        concurrent_workflow.register_node(TestState::Start, node);
 
         scheduler
             .manual_concurrent(
@@ -1322,7 +1322,7 @@ mod tests {
         // Create a concurrent workflow
         let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
         let node = TestNode::new_success();
-        concurrent_workflow.register_cloneable_node(TestState::Start, node);
+        concurrent_workflow.register_node(TestState::Start, node);
 
         let info = Arc::new(RwLock::new(FlowInfo {
             id: "test".to_string(),
@@ -1369,7 +1369,7 @@ mod tests {
         template_workflow.add_exit_state(TestState::Complete);
         let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
         let node = TestNode::new_success();
-        concurrent_workflow.register_cloneable_node(TestState::Start, node);
+        concurrent_workflow.register_node(TestState::Start, node);
 
         scheduler
             .manual_concurrent(

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -17,15 +17,15 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> CanoResult<()> {
-//!     let mut scheduler: Scheduler<MyState> = Scheduler::new();
+//!     let mut scheduler = Scheduler::<MyState>::new();
 //!     
 //!     // Create separate workflows for each scheduled task
-//!     let workflow1: Workflow<MyState> = Workflow::new(MyState::Start);
-//!     let workflow2: Workflow<MyState> = Workflow::new(MyState::Start);
-//!     let workflow3: Workflow<MyState> = Workflow::new(MyState::Start);
-//!     let workflow4: Workflow<MyState> = Workflow::new(MyState::Start);
-//!     let workflow5: Workflow<MyState> = Workflow::new(MyState::Start);
-//!     let workflow6: Workflow<MyState> = Workflow::new(MyState::Start);
+//!     let workflow1 = Workflow::new(MyState::Start);
+//!     let workflow2 = Workflow::new(MyState::Start);
+//!     let workflow3 = Workflow::new(MyState::Start);
+//!     let workflow4 = Workflow::new(MyState::Start);
+//!     let workflow5 = Workflow::new(MyState::Start);
+//!     let workflow6 = Workflow::new(MyState::Start);
 //!     
 //!     // Multiple ways to schedule workflows:
 //!     scheduler.every_seconds("task1", workflow1, 30)?;                    // Every 30 seconds
@@ -824,7 +824,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_scheduler_creation() {
-        let scheduler: Scheduler<TestState> = Scheduler::<TestState>::new();
+        let scheduler: Scheduler<TestState> = Scheduler::new();
         assert!(!scheduler.has_running_flows().await);
         assert_eq!(scheduler.running_count().await, 0);
         assert!(scheduler.list().await.is_empty());
@@ -1288,12 +1288,10 @@ mod tests {
     async fn test_concurrent_workflow_scheduling() {
         let mut scheduler: Scheduler<TestState> = Scheduler::new();
 
-        // Create a template workflow for concurrent execution
-        let mut template_workflow = Workflow::new(TestState::Start);
-        template_workflow.add_exit_state(TestState::Complete);
-
         // Create a concurrent workflow
-        let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+        let mut concurrent_workflow = ConcurrentWorkflow::new(TestState::Start);
+        concurrent_workflow.add_exit_state(TestState::Complete);
+
         let node = TestNode::new_success();
         concurrent_workflow.register_node(TestState::Start, node);
 
@@ -1315,12 +1313,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_workflow_status_tracking() {
-        // Create a template workflow
-        let mut template_workflow = Workflow::new(TestState::Start);
-        template_workflow.add_exit_state(TestState::Complete);
-
         // Create a concurrent workflow
-        let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+        let mut concurrent_workflow = ConcurrentWorkflow::new(TestState::Start);
+        concurrent_workflow.add_exit_state(TestState::Complete);
+
         let node = TestNode::new_success();
         concurrent_workflow.register_node(TestState::Start, node);
 
@@ -1365,9 +1361,9 @@ mod tests {
             .unwrap();
 
         // Add a concurrent workflow
-        let mut template_workflow = Workflow::new(TestState::Start);
-        template_workflow.add_exit_state(TestState::Complete);
-        let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+        let mut concurrent_workflow = ConcurrentWorkflow::new(TestState::Start);
+        concurrent_workflow.add_exit_state(TestState::Complete);
+
         let node = TestNode::new_success();
         concurrent_workflow.register_node(TestState::Start, node);
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -43,7 +43,7 @@
 use crate::MemoryStore;
 use crate::error::{CanoError, CanoResult};
 use crate::node::DefaultParams;
-use crate::workflow::Workflow;
+use crate::workflow::{ConcurrentWorkflow, ConcurrentWorkflowStatus, WaitStrategy, Workflow};
 use chrono::{DateTime, Utc};
 use cron::Schedule as CronSchedule;
 use std::collections::HashMap;
@@ -70,15 +70,21 @@ pub enum Status {
     Idle,
     Running,
     Failed(String),
+    /// Concurrent workflow is running with current status
+    ConcurrentRunning(ConcurrentWorkflowStatus),
+    /// Concurrent workflow completed with final status
+    ConcurrentCompleted(ConcurrentWorkflowStatus),
 }
 
-/// Minimal workflow information
+/// Enhanced workflow information with concurrent workflow support
 #[derive(Debug, Clone)]
 pub struct FlowInfo {
     pub id: String,
     pub status: Status,
     pub run_count: u64,
     pub last_run: Option<DateTime<Utc>>,
+    /// Tracks concurrent workflow instances if applicable
+    pub concurrent_instances: Option<usize>,
 }
 
 /// Type alias for the complex workflow data stored in the scheduler
@@ -88,14 +94,35 @@ type FlowData<TState, TStore, TParams> = (
     Arc<RwLock<FlowInfo>>,
 );
 
-/// Simplified scheduler system
+/// Type alias for concurrent workflow data
+type ConcurrentFlowData<TState, TStore, TParams> = (
+    Arc<ConcurrentWorkflow<TState, TStore, TParams>>,
+    Schedule,
+    Arc<RwLock<FlowInfo>>,
+    WaitStrategy, // Wait strategy for concurrent execution
+    usize,        // Number of concurrent instances
+);
+
+/// Enum to distinguish between regular and concurrent workflows
+#[derive(Debug, Clone)]
+enum WorkflowType<TState, TStore, TParams>
+where
+    TState: Clone + Send + Sync + 'static + std::fmt::Debug + std::hash::Hash + Eq,
+    TParams: Clone + Send + Sync + 'static,
+    TStore: Clone + Default + Send + Sync + 'static,
+{
+    Regular(FlowData<TState, TStore, TParams>),
+    Concurrent(ConcurrentFlowData<TState, TStore, TParams>),
+}
+
+/// Enhanced scheduler system with concurrent workflow support
 pub struct Scheduler<TState, TStore = MemoryStore, TParams = DefaultParams>
 where
     TState: Clone + Send + Sync + 'static + std::fmt::Debug + std::hash::Hash + Eq,
     TParams: Clone + Send + Sync + 'static,
     TStore: Clone + Default + Send + Sync + 'static,
 {
-    flows: HashMap<String, FlowData<TState, TStore, TParams>>,
+    workflows: HashMap<String, WorkflowType<TState, TStore, TParams>>,
     command_tx: Option<mpsc::UnboundedSender<String>>,
     running: Arc<RwLock<bool>>,
 }
@@ -109,7 +136,7 @@ where
     /// Create a new scheduler
     pub fn new() -> Self {
         Self {
-            flows: HashMap::new(),
+            workflows: HashMap::new(),
             command_tx: None,
             running: Arc::new(RwLock::new(false)),
         }
@@ -122,7 +149,7 @@ where
         workflow: Workflow<TState, TStore, TParams>,
         interval: Duration,
     ) -> CanoResult<()> {
-        self.add_flow(id, workflow, Schedule::Every(interval))
+        self.add_regular_flow(id, workflow, Schedule::Every(interval))
     }
 
     /// Add a workflow that runs every N seconds (convenience method)
@@ -165,7 +192,7 @@ where
         // Validate cron expression
         CronSchedule::from_str(expr)
             .map_err(|e| CanoError::Configuration(format!("Invalid cron expression: {e}")))?;
-        self.add_flow(id, workflow, Schedule::Cron(expr.to_string()))
+        self.add_regular_flow(id, workflow, Schedule::Cron(expr.to_string()))
     }
 
     /// Add a manually triggered workflow
@@ -174,17 +201,127 @@ where
         id: &str,
         workflow: Workflow<TState, TStore, TParams>,
     ) -> CanoResult<()> {
-        self.add_flow(id, workflow, Schedule::Manual)
+        self.add_regular_flow(id, workflow, Schedule::Manual)
     }
 
-    /// Internal method to add flows
-    fn add_flow(
+    /// Add a concurrent workflow that runs every Duration interval
+    pub fn every_concurrent(
+        &mut self,
+        id: &str,
+        concurrent_workflow: ConcurrentWorkflow<TState, TStore, TParams>,
+        interval: Duration,
+        instances: usize,
+        wait_strategy: WaitStrategy,
+    ) -> CanoResult<()> {
+        self.add_concurrent_flow(
+            id,
+            concurrent_workflow,
+            Schedule::Every(interval),
+            instances,
+            wait_strategy,
+        )
+    }
+
+    /// Add a concurrent workflow that runs every N seconds
+    pub fn every_seconds_concurrent(
+        &mut self,
+        id: &str,
+        concurrent_workflow: ConcurrentWorkflow<TState, TStore, TParams>,
+        seconds: u64,
+        instances: usize,
+        wait_strategy: WaitStrategy,
+    ) -> CanoResult<()> {
+        self.every_concurrent(
+            id,
+            concurrent_workflow,
+            Duration::from_secs(seconds),
+            instances,
+            wait_strategy,
+        )
+    }
+
+    /// Add a concurrent workflow that runs every N minutes
+    pub fn every_minutes_concurrent(
+        &mut self,
+        id: &str,
+        concurrent_workflow: ConcurrentWorkflow<TState, TStore, TParams>,
+        minutes: u64,
+        instances: usize,
+        wait_strategy: WaitStrategy,
+    ) -> CanoResult<()> {
+        self.every_concurrent(
+            id,
+            concurrent_workflow,
+            Duration::from_secs(minutes * 60),
+            instances,
+            wait_strategy,
+        )
+    }
+
+    /// Add a concurrent workflow that runs every N hours
+    pub fn every_hours_concurrent(
+        &mut self,
+        id: &str,
+        concurrent_workflow: ConcurrentWorkflow<TState, TStore, TParams>,
+        hours: u64,
+        instances: usize,
+        wait_strategy: WaitStrategy,
+    ) -> CanoResult<()> {
+        self.every_concurrent(
+            id,
+            concurrent_workflow,
+            Duration::from_secs(hours * 3600),
+            instances,
+            wait_strategy,
+        )
+    }
+
+    /// Add a concurrent workflow with cron schedule
+    pub fn cron_concurrent(
+        &mut self,
+        id: &str,
+        concurrent_workflow: ConcurrentWorkflow<TState, TStore, TParams>,
+        expr: &str,
+        instances: usize,
+        wait_strategy: WaitStrategy,
+    ) -> CanoResult<()> {
+        // Validate cron expression
+        CronSchedule::from_str(expr)
+            .map_err(|e| CanoError::Configuration(format!("Invalid cron expression: {e}")))?;
+        self.add_concurrent_flow(
+            id,
+            concurrent_workflow,
+            Schedule::Cron(expr.to_string()),
+            instances,
+            wait_strategy,
+        )
+    }
+
+    /// Add a manually triggered concurrent workflow
+    pub fn manual_concurrent(
+        &mut self,
+        id: &str,
+        concurrent_workflow: ConcurrentWorkflow<TState, TStore, TParams>,
+        instances: usize,
+        wait_strategy: WaitStrategy,
+    ) -> CanoResult<()> {
+        self.add_concurrent_flow(
+            id,
+            concurrent_workflow,
+            Schedule::Manual,
+            instances,
+            wait_strategy,
+        )
+    }
+
+    /// Internal method to add regular flows
+    fn add_regular_flow(
         &mut self,
         id: &str,
         workflow: Workflow<TState, TStore, TParams>,
         schedule: Schedule,
     ) -> CanoResult<()> {
-        if self.flows.contains_key(id) {
+        if self.workflows.contains_key(id) {
             return Err(CanoError::Configuration(format!(
                 "Workflow '{id}' already exists"
             )));
@@ -195,12 +332,53 @@ where
             status: Status::Idle,
             run_count: 0,
             last_run: None,
+            concurrent_instances: None,
         };
 
-        self.flows.insert(
-            id.to_string(),
-            (Arc::new(workflow), schedule, Arc::new(RwLock::new(info))),
+        let flow_data = (Arc::new(workflow), schedule, Arc::new(RwLock::new(info)));
+        self.workflows
+            .insert(id.to_string(), WorkflowType::Regular(flow_data));
+        Ok(())
+    }
+
+    /// Internal method to add concurrent flows
+    fn add_concurrent_flow(
+        &mut self,
+        id: &str,
+        concurrent_workflow: ConcurrentWorkflow<TState, TStore, TParams>,
+        schedule: Schedule,
+        instances: usize,
+        wait_strategy: WaitStrategy,
+    ) -> CanoResult<()> {
+        if self.workflows.contains_key(id) {
+            return Err(CanoError::Configuration(format!(
+                "Workflow '{id}' already exists"
+            )));
+        }
+
+        if instances == 0 {
+            return Err(CanoError::Configuration(
+                "Concurrent workflow instances must be greater than 0".to_string(),
+            ));
+        }
+
+        let info = FlowInfo {
+            id: id.to_string(),
+            status: Status::Idle,
+            run_count: 0,
+            last_run: None,
+            concurrent_instances: Some(instances),
+        };
+
+        let flow_data = (
+            Arc::new(concurrent_workflow),
+            schedule,
+            Arc::new(RwLock::new(info)),
+            wait_strategy,
+            instances,
         );
+        self.workflows
+            .insert(id.to_string(), WorkflowType::Concurrent(flow_data));
         Ok(())
     }
 
@@ -215,7 +393,7 @@ where
         *self.running.write().await = true;
 
         // Clone data for the scheduler task
-        let flows = self.flows.clone();
+        let workflows = self.workflows.clone();
         let running = Arc::clone(&self.running);
 
         tokio::spawn(async move {
@@ -230,15 +408,31 @@ where
                         }
 
                         let now = Utc::now();
-                        for (id, (workflow, schedule, info)) in &flows {
-                            if should_run(schedule, &mut last_check, id, now) {
-                                let workflow = Arc::clone(workflow);
-                                let info = Arc::clone(info);
-                                let store = TStore::default();
+                        for (id, workflow_type) in &workflows {
+                            match workflow_type {
+                                WorkflowType::Regular((workflow, schedule, info)) => {
+                                    if should_run(schedule, &mut last_check, id, now) {
+                                        let workflow = Arc::clone(workflow);
+                                        let info = Arc::clone(info);
+                                        let store = TStore::default();
 
-                                tokio::spawn(async move {
-                                    execute_flow(workflow, info, store).await;
-                                });
+                                        tokio::spawn(async move {
+                                            execute_regular_flow(workflow, info, store).await;
+                                        });
+                                    }
+                                }
+                                WorkflowType::Concurrent((concurrent_workflow, schedule, info, wait_strategy, instances)) => {
+                                    if should_run(schedule, &mut last_check, id, now) {
+                                        let concurrent_workflow = Arc::clone(concurrent_workflow);
+                                        let info = Arc::clone(info);
+                                        let wait_strategy = wait_strategy.clone();
+                                        let instances = *instances;
+
+                                        tokio::spawn(async move {
+                                            execute_concurrent_flow(concurrent_workflow, info, wait_strategy, instances).await;
+                                        });
+                                    }
+                                }
                             }
                         }
                     }
@@ -246,14 +440,28 @@ where
                     command = rx.recv() => {
                         match command {
                             Some(flow_id) => {
-                                if let Some((workflow, _, info)) = flows.get(&flow_id) {
-                                    let workflow = Arc::clone(workflow);
-                                    let info = Arc::clone(info);
-                                    let store = TStore::default();
+                                if let Some(workflow_type) = workflows.get(&flow_id) {
+                                    match workflow_type {
+                                        WorkflowType::Regular((workflow, _, info)) => {
+                                            let workflow = Arc::clone(workflow);
+                                            let info = Arc::clone(info);
+                                            let store = TStore::default();
 
-                                    tokio::spawn(async move {
-                                        execute_flow(workflow, info, store).await;
-                                    });
+                                            tokio::spawn(async move {
+                                                execute_regular_flow(workflow, info, store).await;
+                                            });
+                                        }
+                                        WorkflowType::Concurrent((concurrent_workflow, _, info, wait_strategy, instances)) => {
+                                            let concurrent_workflow = Arc::clone(concurrent_workflow);
+                                            let info = Arc::clone(info);
+                                            let wait_strategy = wait_strategy.clone();
+                                            let instances = *instances;
+
+                                            tokio::spawn(async move {
+                                                execute_concurrent_flow(concurrent_workflow, info, wait_strategy, instances).await;
+                                            });
+                                        }
+                                    }
                                 }
                             }
                             None => break,
@@ -296,11 +504,18 @@ where
         loop {
             // Check if any flows are still running
             let mut any_running = false;
-            for (_, _, info) in self.flows.values() {
-                let status = &info.read().await.status;
-                if *status == Status::Running {
-                    any_running = true;
-                    break;
+            for workflow_type in self.workflows.values() {
+                let status = match workflow_type {
+                    WorkflowType::Regular((_, _, info)) => &info.read().await.status,
+                    WorkflowType::Concurrent((_, _, info, _, _)) => &info.read().await.status,
+                };
+
+                match status {
+                    Status::Running | Status::ConcurrentRunning(_) => {
+                        any_running = true;
+                        break;
+                    }
+                    _ => {}
                 }
             }
 
@@ -332,9 +547,15 @@ where
 
     /// Check if any flows are currently running
     pub async fn has_running_flows(&self) -> bool {
-        for (_, _, info) in self.flows.values() {
-            if info.read().await.status == Status::Running {
-                return true;
+        for workflow_type in self.workflows.values() {
+            let status = match workflow_type {
+                WorkflowType::Regular((_, _, info)) => &info.read().await.status,
+                WorkflowType::Concurrent((_, _, info, _, _)) => &info.read().await.status,
+            };
+
+            match status {
+                Status::Running | Status::ConcurrentRunning(_) => return true,
+                _ => {}
             }
         }
         false
@@ -343,9 +564,15 @@ where
     /// Get count of currently running flows
     pub async fn running_count(&self) -> usize {
         let mut count = 0;
-        for (_, _, info) in self.flows.values() {
-            if info.read().await.status == Status::Running {
-                count += 1;
+        for workflow_type in self.workflows.values() {
+            let status = match workflow_type {
+                WorkflowType::Regular((_, _, info)) => &info.read().await.status,
+                WorkflowType::Concurrent((_, _, info, _, _)) => &info.read().await.status,
+            };
+
+            match status {
+                Status::Running | Status::ConcurrentRunning(_) => count += 1,
+                _ => {}
             }
         }
         count
@@ -353,7 +580,11 @@ where
 
     /// Get workflow status
     pub async fn status(&self, id: &str) -> Option<FlowInfo> {
-        if let Some((_, _, info)) = self.flows.get(id) {
+        if let Some(workflow_type) = self.workflows.get(id) {
+            let info = match workflow_type {
+                WorkflowType::Regular((_, _, info)) => info,
+                WorkflowType::Concurrent((_, _, info, _, _)) => info,
+            };
             Some(info.read().await.clone())
         } else {
             None
@@ -363,7 +594,11 @@ where
     /// List all flows
     pub async fn list(&self) -> Vec<FlowInfo> {
         let mut result = Vec::new();
-        for (_, _, info) in self.flows.values() {
+        for workflow_type in self.workflows.values() {
+            let info = match workflow_type {
+                WorkflowType::Regular((_, _, info)) => info,
+                WorkflowType::Concurrent((_, _, info, _, _)) => info,
+            };
             result.push(info.read().await.clone());
         }
         result
@@ -425,8 +660,8 @@ fn should_run(
     }
 }
 
-/// Execute a workflow
-async fn execute_flow<TState, TStore, TParams>(
+/// Execute a regular workflow
+async fn execute_regular_flow<TState, TStore, TParams>(
     workflow: Arc<Workflow<TState, TStore, TParams>>,
     info: Arc<RwLock<FlowInfo>>,
     store: TStore,
@@ -451,6 +686,48 @@ async fn execute_flow<TState, TStore, TParams>(
         match result {
             Ok(_) => {
                 info_guard.status = Status::Idle;
+                info_guard.run_count += 1;
+            }
+            Err(e) => {
+                info_guard.status = Status::Failed(e.to_string());
+            }
+        }
+    }
+}
+
+/// Execute a concurrent workflow
+async fn execute_concurrent_flow<TState, TStore, TParams>(
+    concurrent_workflow: Arc<ConcurrentWorkflow<TState, TStore, TParams>>,
+    info: Arc<RwLock<FlowInfo>>,
+    wait_strategy: WaitStrategy,
+    instances: usize,
+) where
+    TState: Clone + Send + Sync + 'static + std::fmt::Debug + std::hash::Hash + Eq,
+    TParams: Clone + Send + Sync + 'static,
+    TStore: Clone + Default + Send + Sync + 'static,
+{
+    // Create stores for each instance
+    let stores: Vec<TStore> = (0..instances).map(|_| TStore::default()).collect();
+
+    // Update status to concurrent running
+    {
+        let mut info_guard = info.write().await;
+        let initial_status = ConcurrentWorkflowStatus::new(instances);
+        info_guard.status = Status::ConcurrentRunning(initial_status);
+        info_guard.last_run = Some(Utc::now());
+    }
+
+    // Execute concurrent workflow
+    let result = concurrent_workflow
+        .execute_concurrent(stores, wait_strategy)
+        .await;
+
+    // Update final status
+    {
+        let mut info_guard = info.write().await;
+        match result {
+            Ok((_, final_status)) => {
+                info_guard.status = Status::ConcurrentCompleted(final_status);
                 info_guard.run_count += 1;
             }
             Err(e) => {
@@ -489,6 +766,10 @@ mod tests {
                 execution_count: Arc::new(AtomicU32::new(0)),
                 should_fail: false,
             }
+        }
+
+        fn new_success() -> Self {
+            Self::new()
         }
 
         fn new_failing() -> Self {
@@ -873,6 +1154,7 @@ mod tests {
             status: Status::Idle,
             run_count: 5,
             last_run: Some(Utc::now()),
+            concurrent_instances: None,
         };
 
         assert_eq!(info.id, "test");
@@ -953,14 +1235,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_execute_flow_function() {
-        // Test the execute_flow function directly
+    async fn test_execute_regular_flow_function() {
+        // Test the execute_regular_flow function directly
         let workflow = Arc::new(create_test_workflow());
         let info = Arc::new(RwLock::new(FlowInfo {
             id: "test".to_string(),
             status: Status::Idle,
             run_count: 0,
             last_run: None,
+            concurrent_instances: None,
         }));
         let store = MemoryStore::default();
 
@@ -969,7 +1252,7 @@ mod tests {
         assert_eq!(info.read().await.run_count, 0);
 
         // Execute
-        execute_flow(workflow, Arc::clone(&info), store).await;
+        execute_regular_flow(workflow, Arc::clone(&info), store).await;
 
         // After execution
         let final_info = info.read().await;
@@ -979,25 +1262,134 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_execute_flow_function_failure() {
-        // Test the execute_flow function with a failing workflow
+    async fn test_execute_regular_flow_function_failure() {
+        // Test the execute_regular_flow function with a failing workflow
         let workflow = Arc::new(create_failing_workflow());
         let info = Arc::new(RwLock::new(FlowInfo {
             id: "test".to_string(),
             status: Status::Idle,
             run_count: 0,
             last_run: None,
+            concurrent_instances: None,
         }));
         let store = MemoryStore::default();
 
         // Execute
-        execute_flow(workflow, Arc::clone(&info), store).await;
+        execute_regular_flow(workflow, Arc::clone(&info), store).await;
 
         // After execution
         let final_info = info.read().await;
         assert!(matches!(final_info.status, Status::Failed(_)));
-        assert_eq!(final_info.run_count, 0); // Should not increment on failure
+        assert_eq!(final_info.run_count, 0);
         assert!(final_info.last_run.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_workflow_scheduling() {
+        let mut scheduler: Scheduler<TestState> = Scheduler::new();
+
+        // Create a template workflow for concurrent execution
+        let mut template_workflow = Workflow::new(TestState::Start);
+        template_workflow.add_exit_state(TestState::Complete);
+
+        // Create a concurrent workflow
+        let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+        let node = TestNode::new_success();
+        concurrent_workflow.register_cloneable_node(TestState::Start, node);
+
+        scheduler
+            .manual_concurrent(
+                "concurrent_test",
+                concurrent_workflow,
+                3, // 3 instances
+                WaitStrategy::WaitForever,
+            )
+            .unwrap();
+
+        // Verify the workflow was added
+        let flows = scheduler.list().await;
+        assert_eq!(flows.len(), 1);
+        assert_eq!(flows[0].id, "concurrent_test");
+        assert_eq!(flows[0].concurrent_instances, Some(3));
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_workflow_status_tracking() {
+        // Create a template workflow
+        let mut template_workflow = Workflow::new(TestState::Start);
+        template_workflow.add_exit_state(TestState::Complete);
+
+        // Create a concurrent workflow
+        let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+        let node = TestNode::new_success();
+        concurrent_workflow.register_cloneable_node(TestState::Start, node);
+
+        let info = Arc::new(RwLock::new(FlowInfo {
+            id: "test".to_string(),
+            status: Status::Idle,
+            run_count: 0,
+            last_run: None,
+            concurrent_instances: Some(3),
+        }));
+
+        // Test concurrent execution
+        execute_concurrent_flow(
+            Arc::new(concurrent_workflow),
+            Arc::clone(&info),
+            WaitStrategy::WaitForever,
+            3,
+        )
+        .await;
+
+        // Check final status
+        let final_info = info.read().await;
+        assert!(matches!(final_info.status, Status::ConcurrentCompleted(_)));
+        assert_eq!(final_info.run_count, 1);
+        assert!(final_info.last_run.is_some());
+
+        if let Status::ConcurrentCompleted(status) = &final_info.status {
+            assert_eq!(status.total_workflows, 3);
+            assert_eq!(status.completed, 3);
+            assert_eq!(status.failed, 0);
+            assert_eq!(status.cancelled, 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_scheduler_with_mixed_workflow_types() {
+        let mut scheduler: Scheduler<TestState> = Scheduler::new();
+
+        // Add a regular workflow
+        scheduler
+            .manual("regular_test", create_test_workflow())
+            .unwrap();
+
+        // Add a concurrent workflow
+        let mut template_workflow = Workflow::new(TestState::Start);
+        template_workflow.add_exit_state(TestState::Complete);
+        let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+        let node = TestNode::new_success();
+        concurrent_workflow.register_cloneable_node(TestState::Start, node);
+
+        scheduler
+            .manual_concurrent(
+                "concurrent_test",
+                concurrent_workflow,
+                2,
+                WaitStrategy::WaitForever,
+            )
+            .unwrap();
+
+        // Verify both workflows were added
+        let flows = scheduler.list().await;
+        assert_eq!(flows.len(), 2);
+
+        // Check workflow types
+        let regular_flow = flows.iter().find(|f| f.id == "regular_test").unwrap();
+        let concurrent_flow = flows.iter().find(|f| f.id == "concurrent_test").unwrap();
+
+        assert_eq!(regular_flow.concurrent_instances, None);
+        assert_eq!(concurrent_flow.concurrent_instances, Some(2));
     }
 
     #[tokio::test]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -56,8 +56,23 @@
 //! - Use store to pass data between nodes
 //! - Keep store keys consistent across your workflow
 //! - Consider using strongly-typed store wrappers for complex data
+//!
+//! ## 🔄 Concurrent Workflows
+//!
+//! The [`ConcurrentWorkflow`] type enables executing multiple workflow instances in parallel:
+//! - Flexible timeout strategies for different execution patterns
+//! - Enhanced monitoring with detailed status tracking
+//! - Configurable completion criteria for batch processing
+//!
+//! ### Timeout Strategies
+//!
+//! - [`WaitStrategy::WaitForever`] - Execute all workflows to completion
+//! - [`WaitStrategy::WaitForQuota(n)`] - Complete a specific number, then cancel the rest
+//! - [`WaitStrategy::WaitDuration(duration)`] - Execute within a time limit
+//! - [`WaitStrategy::WaitQuotaOrDuration`] - Complete quota OR wait for duration, whichever comes first
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use crate::MemoryStore;
 use crate::error::CanoError;
@@ -97,6 +112,97 @@ where
     async fn run(&self, store: &TStore) -> Result<TState, CanoError> {
         // just forward to the inherent `Node::run`
         Node::run(self, store).await
+    }
+}
+
+/// Wait strategy for concurrent workflow execution
+#[derive(Debug, Clone)]
+pub enum WaitStrategy {
+    /// Execute all workflows to completion
+    WaitForever,
+    /// Complete a specific number of workflows, then cancel the rest
+    WaitForQuota(usize),
+    /// Execute workflows within a time limit
+    WaitDuration(Duration),
+    /// Complete quota OR wait for duration, whichever comes first
+    WaitQuotaOrDuration { quota: usize, duration: Duration },
+}
+
+/// Status of a concurrent workflow execution
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConcurrentWorkflowStatus {
+    /// Total number of workflows that were started
+    pub total_workflows: usize,
+    /// Number of workflows that completed successfully
+    pub completed: usize,
+    /// Number of workflows that failed
+    pub failed: usize,
+    /// Number of workflows that were cancelled
+    pub cancelled: usize,
+    /// Execution duration
+    pub duration: Duration,
+}
+
+impl ConcurrentWorkflowStatus {
+    /// Create a new status with zero counts
+    pub fn new(total_workflows: usize) -> Self {
+        Self {
+            total_workflows,
+            completed: 0,
+            failed: 0,
+            cancelled: 0,
+            duration: Duration::from_millis(0),
+        }
+    }
+
+    /// Check if all workflows have finished (completed, failed, or cancelled)
+    pub fn is_complete(&self) -> bool {
+        self.completed + self.failed + self.cancelled >= self.total_workflows
+    }
+
+    /// Get the number of workflows still running
+    pub fn running(&self) -> usize {
+        self.total_workflows.saturating_sub(self.completed + self.failed + self.cancelled)
+    }
+}
+
+/// Result of a single workflow execution in a concurrent batch
+#[derive(Debug, Clone)]
+pub enum WorkflowResult<TState> {
+    /// Workflow completed successfully with final state
+    Success(TState),
+    /// Workflow failed with error
+    Failed(CanoError),
+    /// Workflow was cancelled before completion
+    Cancelled,
+}
+
+/// Type alias for cloneable node trait objects for concurrent workflows
+///
+/// This ensures nodes can be cloned for use across multiple concurrent workflow instances.
+pub type CloneableNode<TState, TStore = MemoryStore, TParams = DefaultParams> =
+    Box<dyn CloneableNodeTrait<TState, TStore, TParams> + Send + Sync>;
+
+/// Trait for nodes that can be cloned for concurrent workflow execution
+pub trait CloneableNodeTrait<TState, TStore = MemoryStore, TParams = DefaultParams>: 
+    DynNodeTrait<TState, TStore, TParams> + Send + Sync
+where
+    TState: Clone + std::fmt::Debug + Send + Sync + 'static,
+{
+    /// Clone the node for concurrent execution
+    fn clone_node(&self) -> CloneableNode<TState, TStore, TParams>;
+}
+
+/// Blanket implementation for any Node that implements Clone
+impl<TState, TStore, TParams, N> CloneableNodeTrait<TState, TStore, TParams> for N
+where
+    TState: Clone + std::fmt::Debug + Send + Sync + 'static,
+    TParams: Clone + Send + Sync + 'static,
+    TStore: Send + Sync + 'static,
+    N: Node<TState, TStore, TParams> + Clone + Send + Sync + 'static,
+{
+    fn clone_node(&self) -> CloneableNode<TState, TStore, TParams> {
+        Box::new(self.clone())
     }
 }
 
@@ -200,6 +306,21 @@ where
     }
 }
 
+impl<TState, TStore, TParams> std::fmt::Debug for Workflow<TState, TStore, TParams>
+where
+    TState: Clone + std::fmt::Debug + std::hash::Hash + Eq + Send + Sync + 'static,
+    TParams: Clone + Send + Sync + 'static,
+    TStore: Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Workflow")
+            .field("start_state", &self.start_state)
+            .field("state_nodes", &format!("{} nodes", self.state_nodes.len()))
+            .field("exit_states", &self.exit_states)
+            .finish()
+    }
+}
+
 /// Builder for creating Workflow instances with a fluent API
 ///
 /// Provides a convenient way to construct flows with method chaining.
@@ -249,6 +370,354 @@ where
     /// Build the final Workflow instance
     pub fn build(self) -> Workflow<TState, TStore, TParams> {
         self.workflow
+    }
+}
+
+/// Concurrent workflow orchestration for executing multiple workflow instances in parallel
+pub struct ConcurrentWorkflow<TState, TStore = MemoryStore, TParams = DefaultParams>
+where
+    TState: Clone + std::fmt::Debug + std::hash::Hash + Eq + Send + Sync + 'static,
+    TParams: Clone + Send + Sync + 'static,
+    TStore: Clone + Send + Sync + 'static,
+{
+    /// Template workflow that will be cloned for each concurrent execution
+    template_workflow: Workflow<TState, TStore, TParams>,
+    /// Cloneable nodes that can be used across multiple workflow instances
+    cloneable_nodes: HashMap<TState, CloneableNode<TState, TStore, TParams>>,
+}
+
+impl<TState, TStore, TParams> ConcurrentWorkflow<TState, TStore, TParams>
+where
+    TState: Clone + std::fmt::Debug + std::hash::Hash + Eq + Send + Sync + 'static,
+    TParams: Clone + Send + Sync + 'static,
+    TStore: Clone + Send + Sync + 'static,
+{
+    /// Create a new ConcurrentWorkflow from a template workflow
+    pub fn new(template_workflow: Workflow<TState, TStore, TParams>) -> Self {
+        Self {
+            template_workflow,
+            cloneable_nodes: HashMap::new(),
+        }
+    }
+
+    /// Register a cloneable node for concurrent execution
+    /// The node must implement Clone to be used across multiple workflow instances
+    pub fn register_cloneable_node<N>(&mut self, state: TState, node: N) -> &mut Self
+    where
+        N: Node<TState, TStore, TParams> + Clone + Send + Sync + 'static,
+    {
+        self.cloneable_nodes.insert(state, Box::new(node));
+        self
+    }
+
+    /// Create a workflow instance for concurrent execution
+    fn create_workflow_instance(&self) -> Result<Workflow<TState, TStore, TParams>, CanoError> {
+        let mut workflow = Workflow {
+            start_state: self.template_workflow.start_state.clone(),
+            state_nodes: HashMap::new(),
+            exit_states: self.template_workflow.exit_states.clone(),
+        };
+
+        // Clone all registered nodes for this instance
+        for (state, cloneable_node) in &self.cloneable_nodes {
+            let cloned_node = cloneable_node.clone_node();
+            workflow.state_nodes.insert(state.clone(), cloned_node);
+        }
+
+        Ok(workflow)
+    }
+
+    /// Execute multiple workflow instances concurrently with the specified wait strategy
+    ///
+    /// This method creates separate workflow instances and executes them in parallel,
+    /// applying the wait strategy to control completion behavior.
+    ///
+    /// ## Arguments
+    ///
+    /// - `stores`: Vector of store instances, one for each workflow
+    /// - `wait_strategy`: Strategy for determining when to complete execution
+    ///
+    /// ## Wait Strategies
+    ///
+    /// - `WaitForever`: All workflows must complete
+    /// - `WaitForQuota(n)`: Stop after n workflows complete
+    /// - `WaitDuration(d)`: Stop after duration d
+    /// - `WaitQuotaOrDuration`: Stop when quota is reached OR duration elapsed
+    ///
+    /// ## Returns
+    ///
+    /// Returns a tuple of:
+    /// - Vector of workflow results (one per workflow)
+    /// - Status information about the execution
+    pub async fn execute_concurrent(
+        &self,
+        stores: Vec<TStore>,
+        wait_strategy: WaitStrategy,
+    ) -> Result<(Vec<WorkflowResult<TState>>, ConcurrentWorkflowStatus), CanoError> {
+        use tokio::time::{timeout, Instant};
+
+        let start_time = Instant::now();
+        let workflow_count = stores.len();
+        let mut status = ConcurrentWorkflowStatus::new(workflow_count);
+
+        if workflow_count == 0 {
+            status.duration = start_time.elapsed();
+            return Ok((Vec::new(), status));
+        }
+
+        // Create workflow instances and spawn tasks
+        let mut tasks = Vec::new();
+        for store in stores {
+            let workflow = self.create_workflow_instance()?;
+            let task = tokio::spawn(async move {
+                match workflow.orchestrate(&store).await {
+                    Ok(final_state) => WorkflowResult::Success(final_state),
+                    Err(error) => WorkflowResult::Failed(error),
+                }
+            });
+            tasks.push(task);
+        }
+
+        let mut results = vec![WorkflowResult::Cancelled; workflow_count];
+
+        match wait_strategy {
+            WaitStrategy::WaitForever => {
+                // Wait for all tasks to complete
+                for (index, task) in tasks.into_iter().enumerate() {
+                    match task.await {
+                        Ok(result) => {
+                            match &result {
+                                WorkflowResult::Success(_) => status.completed += 1,
+                                WorkflowResult::Failed(_) => status.failed += 1,
+                                WorkflowResult::Cancelled => status.cancelled += 1,
+                            }
+                            results[index] = result;
+                        }
+                        Err(_) => {
+                            results[index] = WorkflowResult::Failed(
+                                CanoError::node_execution("Task join error")
+                            );
+                            status.failed += 1;
+                        }
+                    }
+                }
+            }
+
+            WaitStrategy::WaitForQuota(quota) => {
+                // Wait for the specified number of workflows to complete
+                let mut completed_count = 0;
+                let mut pending_tasks = tasks;
+
+                while completed_count < quota && !pending_tasks.is_empty() {
+                    let (result, index, remaining) = futures::future::select_all(pending_tasks).await;
+                    pending_tasks = remaining;
+
+                    match result {
+                        Ok(workflow_result) => {
+                            match &workflow_result {
+                                WorkflowResult::Success(_) => status.completed += 1,
+                                WorkflowResult::Failed(_) => status.failed += 1,
+                                WorkflowResult::Cancelled => status.cancelled += 1,
+                            }
+                            results[index] = workflow_result;
+                            completed_count += 1;
+                        }
+                        Err(_) => {
+                            results[index] = WorkflowResult::Failed(
+                                CanoError::node_execution("Task join error")
+                            );
+                            status.failed += 1;
+                            completed_count += 1;
+                        }
+                    }
+                }
+
+                // Cancel remaining tasks
+                for task in pending_tasks {
+                    task.abort();
+                    status.cancelled += 1;
+                }
+            }
+
+            WaitStrategy::WaitDuration(duration) => {
+                // Wait for the specified duration
+                let timeout_result = timeout(duration, async {
+                    let mut pending_tasks = tasks;
+                    let mut results_temp = Vec::new();
+
+                    while !pending_tasks.is_empty() {
+                        let (result, index, remaining) = futures::future::select_all(pending_tasks).await;
+                        pending_tasks = remaining;
+                        results_temp.push((index, result));
+                    }
+
+                    results_temp
+                }).await;
+
+                match timeout_result {
+                    Ok(completed_tasks) => {
+                        // All tasks completed within the timeout
+                        for (index, result) in completed_tasks {
+                            match result {
+                                Ok(workflow_result) => {
+                                    match &workflow_result {
+                                        WorkflowResult::Success(_) => status.completed += 1,
+                                        WorkflowResult::Failed(_) => status.failed += 1,
+                                        WorkflowResult::Cancelled => status.cancelled += 1,
+                                    }
+                                    results[index] = workflow_result;
+                                }
+                                Err(_) => {
+                                    results[index] = WorkflowResult::Failed(
+                                        CanoError::node_execution("Task join error")
+                                    );
+                                    status.failed += 1;
+                                }
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        // Timeout occurred - we need to handle the tasks that were still running
+                        // For simplicity, we'll count them as cancelled
+                        status.cancelled = workflow_count;
+                    }
+                }
+            }
+
+            WaitStrategy::WaitQuotaOrDuration { quota, duration } => {
+                // Wait for quota completion OR duration timeout, whichever comes first
+                let quota_future = async {
+                    let mut completed_count = 0;
+                    let mut pending_tasks = tasks;
+                    let mut completed_results = Vec::new();
+
+                    while completed_count < quota && !pending_tasks.is_empty() {
+                        let (result, index, remaining) = futures::future::select_all(pending_tasks).await;
+                        pending_tasks = remaining;
+                        completed_results.push((index, result));
+                        completed_count += 1;
+                    }
+
+                    // Cancel remaining tasks
+                    for task in pending_tasks {
+                        task.abort();
+                    }
+
+                    completed_results
+                };
+
+                let timeout_result = timeout(duration, quota_future).await;
+
+                match timeout_result {
+                    Ok(completed_tasks) => {
+                        // Quota was reached within the timeout
+                        for (index, result) in completed_tasks {
+                            match result {
+                                Ok(workflow_result) => {
+                                    match &workflow_result {
+                                        WorkflowResult::Success(_) => status.completed += 1,
+                                        WorkflowResult::Failed(_) => status.failed += 1,
+                                        WorkflowResult::Cancelled => status.cancelled += 1,
+                                    }
+                                    results[index] = workflow_result;
+                                }
+                                Err(_) => {
+                                    results[index] = WorkflowResult::Failed(
+                                        CanoError::node_execution("Task join error")
+                                    );
+                                    status.failed += 1;
+                                }
+                            }
+                        }
+                        
+                        // Mark uncompleted workflows as cancelled
+                        let uncompleted = workflow_count - (status.completed + status.failed);
+                        status.cancelled = uncompleted;
+                    }
+                    Err(_) => {
+                        // Duration timeout occurred before quota was reached
+                        status.cancelled = workflow_count;
+                    }
+                }
+            }
+        }
+
+        status.duration = start_time.elapsed();
+        Ok((results, status))
+    }
+}
+
+impl<TState, TStore, TParams> Clone for ConcurrentWorkflow<TState, TStore, TParams>
+where
+    TState: Clone + std::fmt::Debug + std::hash::Hash + Eq + Send + Sync + 'static,
+    TParams: Clone + Send + Sync + 'static,
+    TStore: Clone + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        // Clone the cloneable nodes
+        let mut cloned_nodes = HashMap::new();
+        for (state, node) in &self.cloneable_nodes {
+            cloned_nodes.insert(state.clone(), node.clone_node());
+        }
+        
+        Self {
+            template_workflow: Workflow::new(
+                self.template_workflow.start_state.as_ref().unwrap().clone()
+            ),
+            cloneable_nodes: cloned_nodes,
+        }
+    }
+}
+
+impl<TState, TStore, TParams> std::fmt::Debug for ConcurrentWorkflow<TState, TStore, TParams>
+where
+    TState: Clone + std::fmt::Debug + std::hash::Hash + Eq + Send + Sync + 'static,
+    TParams: Clone + Send + Sync + 'static,
+    TStore: Clone + Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConcurrentWorkflow")
+            .field("template_workflow", &self.template_workflow)
+            .field("cloneable_nodes", &format!("{} cloneable nodes", self.cloneable_nodes.len()))
+            .finish()
+    }
+}
+
+/// Builder for creating ConcurrentWorkflow instances with a fluent API
+pub struct ConcurrentWorkflowBuilder<TState, TStore = MemoryStore, TParams = DefaultParams>
+where
+    TState: Clone + std::fmt::Debug + std::hash::Hash + Eq + Send + Sync + 'static,
+    TParams: Clone + Send + Sync + 'static,
+    TStore: Clone + Send + Sync + 'static,
+{
+    concurrent_workflow: ConcurrentWorkflow<TState, TStore, TParams>,
+}
+
+impl<TState, TStore, TParams> ConcurrentWorkflowBuilder<TState, TStore, TParams>
+where
+    TState: Clone + std::fmt::Debug + std::hash::Hash + Eq + Send + Sync + 'static,
+    TParams: Clone + Send + Sync + 'static,
+    TStore: Clone + Send + Sync + 'static,
+{
+    /// Create a new ConcurrentWorkflowBuilder from a template workflow
+    pub fn new(template_workflow: Workflow<TState, TStore, TParams>) -> Self {
+        Self {
+            concurrent_workflow: ConcurrentWorkflow::new(template_workflow),
+        }
+    }
+
+    /// Register a cloneable node for concurrent execution
+    pub fn register_cloneable_node<N>(mut self, state: TState, node: N) -> Self
+    where
+        N: Node<TState, TStore, TParams> + Clone + Send + Sync + 'static,
+    {
+        self.concurrent_workflow.register_cloneable_node(state, node);
+        self
+    }
+
+    /// Build the final ConcurrentWorkflow instance
+    pub fn build(self) -> ConcurrentWorkflow<TState, TStore, TParams> {
+        self.concurrent_workflow
     }
 }
 
@@ -854,5 +1323,330 @@ mod tests {
         // Verify data was stored and processed correctly
         let stored_data: String = store.get("workflow_data").unwrap();
         assert_eq!(stored_data, "test_value");
+    }
+
+    // Tests for Concurrent Workflows
+    #[tokio::test]
+    async fn test_concurrent_workflow_creation() {
+        let template_workflow: Workflow<TestState> = Workflow::new(TestState::Start);
+        let concurrent_workflow: ConcurrentWorkflow<TestState> = 
+            ConcurrentWorkflow::new(template_workflow);
+
+        assert!(concurrent_workflow.cloneable_nodes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_workflow_register_cloneable_node() {
+        let template_workflow: Workflow<TestState> = Workflow::new(TestState::Start);
+        let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+
+        let node = SuccessNode::new(TestState::Complete);
+        concurrent_workflow.register_cloneable_node(TestState::Start, node);
+
+        assert_eq!(concurrent_workflow.cloneable_nodes.len(), 1);
+        assert!(concurrent_workflow.cloneable_nodes.contains_key(&TestState::Start));
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_workflow_wait_forever() {
+        let mut template_workflow = Workflow::new(TestState::Start);
+        template_workflow.add_exit_state(TestState::Complete);
+
+        let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+        let node = SuccessNode::new(TestState::Complete);
+        concurrent_workflow.register_cloneable_node(TestState::Start, node);
+
+        // Create multiple stores for concurrent execution
+        let stores = vec![
+            MemoryStore::new(),
+            MemoryStore::new(),
+            MemoryStore::new(),
+        ];
+
+        let (results, status) = concurrent_workflow
+            .execute_concurrent(stores, WaitStrategy::WaitForever)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(status.total_workflows, 3);
+        assert_eq!(status.completed, 3);
+        assert_eq!(status.failed, 0);
+        assert_eq!(status.cancelled, 0);
+        assert!(status.is_complete());
+        assert_eq!(status.running(), 0);
+
+        // Verify all results are successful
+        for result in results {
+            match result {
+                WorkflowResult::Success(state) => assert_eq!(state, TestState::Complete),
+                _ => panic!("Expected success result"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_workflow_wait_for_quota() {
+        let mut template_workflow = Workflow::new(TestState::Start);
+        template_workflow.add_exit_state(TestState::Complete);
+
+        let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+        let node = SuccessNode::new(TestState::Complete);
+        concurrent_workflow.register_cloneable_node(TestState::Start, node);
+
+        // Create multiple stores
+        let stores = vec![
+            MemoryStore::new(),
+            MemoryStore::new(),
+            MemoryStore::new(),
+            MemoryStore::new(),
+            MemoryStore::new(),
+        ];
+
+        let quota = 3;
+        let (results, status) = concurrent_workflow
+            .execute_concurrent(stores, WaitStrategy::WaitForQuota(quota))
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 5);
+        assert_eq!(status.total_workflows, 5);
+        
+        // Should complete at least the quota
+        assert!(status.completed + status.failed >= quota);
+        
+        // Total should add up correctly
+        assert_eq!(
+            status.completed + status.failed + status.cancelled, 
+            status.total_workflows
+        );
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_workflow_wait_duration() {
+        let mut template_workflow = Workflow::new(TestState::Start);
+        template_workflow.add_exit_state(TestState::Complete);
+
+        let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+        let node = SuccessNode::new(TestState::Complete);
+        concurrent_workflow.register_cloneable_node(TestState::Start, node);
+
+        // Create stores
+        let stores = vec![
+            MemoryStore::new(),
+            MemoryStore::new(),
+        ];
+
+        let duration = Duration::from_millis(100);
+        let (results, status) = concurrent_workflow
+            .execute_concurrent(stores, WaitStrategy::WaitDuration(duration))
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(status.total_workflows, 2);
+        
+        // Should complete within reasonable time since our nodes are fast
+        assert!(status.duration <= Duration::from_millis(1000));
+        
+        // All workflows should complete successfully given the simple nature of our test nodes
+        assert_eq!(status.completed, 2);
+        assert_eq!(status.failed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_workflow_wait_quota_or_duration() {
+        let mut template_workflow = Workflow::new(TestState::Start);
+        template_workflow.add_exit_state(TestState::Complete);
+
+        let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+        let node = SuccessNode::new(TestState::Complete);
+        concurrent_workflow.register_cloneable_node(TestState::Start, node);
+
+        // Create stores
+        let stores = vec![
+            MemoryStore::new(),
+            MemoryStore::new(),
+            MemoryStore::new(),
+        ];
+
+        let strategy = WaitStrategy::WaitQuotaOrDuration {
+            quota: 2,
+            duration: Duration::from_millis(100),
+        };
+
+        let (results, status) = concurrent_workflow
+            .execute_concurrent(stores, strategy)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(status.total_workflows, 3);
+        
+        // Should complete quickly since our nodes are simple
+        assert!(status.duration <= Duration::from_millis(1000));
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_workflow_with_errors() {
+        let mut template_workflow = Workflow::new(TestState::Start);
+        template_workflow.add_exit_states(vec![TestState::Complete, TestState::Error]);
+
+        let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+        let failing_node = FailureNode::new("Test failure");
+        concurrent_workflow.register_cloneable_node(TestState::Start, failing_node);
+
+        // Create stores
+        let stores = vec![
+            MemoryStore::new(),
+            MemoryStore::new(),
+        ];
+
+        let (results, status) = concurrent_workflow
+            .execute_concurrent(stores, WaitStrategy::WaitForever)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(status.total_workflows, 2);
+        assert_eq!(status.failed, 2);
+        assert_eq!(status.completed, 0);
+        assert_eq!(status.cancelled, 0);
+
+        // Verify all results are failures
+        for result in results {
+            match result {
+                WorkflowResult::Failed(error) => {
+                    assert!(error.to_string().contains("Preparation error"));
+                }
+                _ => panic!("Expected failed result"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_workflow_empty_stores() {
+        let template_workflow: Workflow<TestState> = Workflow::new(TestState::Start);
+        let concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+
+        let (results, status) = concurrent_workflow
+            .execute_concurrent(Vec::new(), WaitStrategy::WaitForever)
+            .await
+            .unwrap();
+
+        assert!(results.is_empty());
+        assert_eq!(status.total_workflows, 0);
+        assert_eq!(status.completed, 0);
+        assert_eq!(status.failed, 0);
+        assert_eq!(status.cancelled, 0);
+        assert!(status.is_complete());
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_workflow_builder() {
+        let template_workflow: Workflow<TestState> = Workflow::new(TestState::Start);
+        let node = SuccessNode::new(TestState::Complete);
+
+        let concurrent_workflow = ConcurrentWorkflowBuilder::new(template_workflow)
+            .register_cloneable_node(TestState::Start, node)
+            .build();
+
+        assert_eq!(concurrent_workflow.cloneable_nodes.len(), 1);
+        assert!(concurrent_workflow.cloneable_nodes.contains_key(&TestState::Start));
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_workflow_status_tracking() {
+        let mut status = ConcurrentWorkflowStatus::new(10);
+        
+        assert_eq!(status.total_workflows, 10);
+        assert_eq!(status.completed, 0);
+        assert_eq!(status.failed, 0);
+        assert_eq!(status.cancelled, 0);
+        assert_eq!(status.running(), 10);
+        assert!(!status.is_complete());
+
+        // Simulate some completions
+        status.completed = 3;
+        status.failed = 2;
+        status.cancelled = 1;
+        
+        assert_eq!(status.running(), 4);
+        assert!(!status.is_complete());
+        
+        // Complete all
+        status.completed = 5;
+        status.failed = 3;
+        status.cancelled = 2;
+        
+        assert_eq!(status.running(), 0);
+        assert!(status.is_complete());
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_workflow_with_data_sharing() {
+        let mut template_workflow = Workflow::new(TestState::Start);
+        template_workflow.add_exit_state(TestState::Process);
+
+        let mut concurrent_workflow = ConcurrentWorkflow::new(template_workflow);
+        let data_node = DataStoringNode::new("concurrent_data", "test_value", TestState::Process);
+        concurrent_workflow.register_cloneable_node(TestState::Start, data_node);
+
+        // Create stores with different initial data
+        let store1 = MemoryStore::new();
+        let store2 = MemoryStore::new();
+        let store3 = MemoryStore::new();
+        
+        let stores = vec![store1.clone(), store2.clone(), store3.clone()];
+
+        let (results, status) = concurrent_workflow
+            .execute_concurrent(stores, WaitStrategy::WaitForever)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(status.completed, 3);
+
+        // Verify each store has the expected data
+        let data1: String = store1.get("concurrent_data").unwrap();
+        let data2: String = store2.get("concurrent_data").unwrap();
+        let data3: String = store3.get("concurrent_data").unwrap();
+        
+        assert_eq!(data1, "test_value");
+        assert_eq!(data2, "test_value");
+        assert_eq!(data3, "test_value");
+    }
+
+    #[tokio::test]
+    async fn test_wait_strategy_debug() {
+        let wait_forever = WaitStrategy::WaitForever;
+        let wait_quota = WaitStrategy::WaitForQuota(5);
+        let wait_duration = WaitStrategy::WaitDuration(Duration::from_secs(10));
+        let wait_quota_or_duration = WaitStrategy::WaitQuotaOrDuration {
+            quota: 3,
+            duration: Duration::from_secs(5),
+        };
+
+        // Just verify they implement Debug (compilation test)
+        let _debug_strings = [
+            format!("{wait_forever:?}"),
+            format!("{wait_quota:?}"),
+            format!("{wait_duration:?}"),
+            format!("{wait_quota_or_duration:?}"),
+        ];
+    }
+
+    #[tokio::test]
+    async fn test_workflow_result_debug() {
+        let success = WorkflowResult::Success(TestState::Complete);
+        let failed = WorkflowResult::<TestState>::Failed(CanoError::workflow("test error"));
+        let cancelled = WorkflowResult::<TestState>::Cancelled;
+
+        // Just verify they implement Debug (compilation test)  
+        let _debug_strings = [
+            format!("{success:?}"),
+            format!("{failed:?}"),
+            format!("{cancelled:?}"),
+        ];
     }
 }


### PR DESCRIPTION
This PR introduces concurrent workflow execution functionality to Cano, allowing multiple workflow instances to run in parallel with configurable completion strategies. Key additions include:

- New `ConcurrentWorkflow` type with flexible timeout strategies (WaitForever, WaitForQuota, WaitDuration, WaitQuotaOrDuration)
- Enhanced monitoring with detailed status tracking for concurrent executions
- Simplified scheduler API with cleaner workflow registration
- New examples demonstrating concurrent workflows and SIMD matrix processing pipeline
- Updated benchmarks for performance testing of concurrent vs sequential execution
- Dependency updates, including tokio version bump