### PR TITLE
Tracing Feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
 
 [[package]]
 name = "cano"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "cargo-audit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3290,15 +3290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3613,9 +3604,7 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "slab",
  "socket2 0.6.0",
  "tokio-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,8 @@ dependencies = [
  "reqwest",
  "rig-core",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "wide",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,12 @@ rand = "0.9"
 chrono = { version = "0.4", features = ["serde"], optional = true }
 cron = { version = "0.15", optional = true }
 futures = "0.3"
+tracing = { version = "0.1", optional = true }
 
 [features]
 scheduler = ["dep:chrono", "dep:cron"]
+tracing = ["dep:tracing"]
+all = ["scheduler", "tracing"]
 
 [dev-dependencies]
 cargo-audit = "0.21.2"
@@ -28,6 +31,8 @@ criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
 reqwest = { version = "0.12", features = ["json"] }
 rig-core = "0.16"
 wide = "0.7"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+chrono = { version = "0.4", features = ["serde"] }
 
 [[example]]
 name = "ai_workflow_yes_and"
@@ -86,6 +91,11 @@ required-features = ["scheduler"]
 name = "scheduler_book_prepositions"
 path = "examples/scheduler_book_prepositions.rs"
 required-features = ["scheduler"]
+
+[[example]]
+name = "tracing_demo"
+path = "examples/tracing_demo.rs"
+required-features = ["tracing", "scheduler"]
 
 [[bench]]
 name = "workflow_performance"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,12 @@ authors = ["Nassor Frazier-Silva"]
 async-trait = "0.1"
 tokio = { version = "1.47.1", features = ["full"] }
 rand = "0.9"
-cron = "0.15"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"], optional = true }
+cron = { version = "0.15", optional = true }
 futures = "0.3"
+
+[features]
+scheduler = ["dep:chrono", "dep:cron"]
 
 [dev-dependencies]
 cargo-audit = "0.21.2"
@@ -33,10 +36,6 @@ path = "examples/ai_workflow_yes_and.rs"
 [[example]]
 name = "workflow_concurrent"
 path = "examples/workflow_concurrent.rs"
-
-[[example]]
-name = "scheduler_mixed_workflows"
-path = "examples/scheduler_mixed_workflows.rs"
 
 [[example]]
 name = "workflow_simple"
@@ -59,20 +58,34 @@ name = "workflow_stack_store"
 path = "examples/workflow_stack_store.rs"
 
 [[example]]
+name = "scheduler_mixed_workflows"
+path = "examples/scheduler_mixed_workflows.rs"
+required-features = ["scheduler"]
+
+[[example]]
 name = "scheduler_scheduling"
 path = "examples/scheduler_scheduling.rs"
+required-features = ["scheduler"]
 
 [[example]]
 name = "scheduler_concurrent_workflows"
 path = "examples/scheduler_concurrent_workflows.rs"
+required-features = ["scheduler"]
 
 [[example]]
 name = "scheduler_duration_scheduling"
 path = "examples/scheduler_duration_scheduling.rs"
+required-features = ["scheduler"]
 
 [[example]]
 name = "scheduler_graceful_shutdown"
 path = "examples/scheduler_graceful_shutdown.rs"
+required-features = ["scheduler"]
+
+[[example]]
+name = "scheduler_book_prepositions"
+path = "examples/scheduler_book_prepositions.rs"
+required-features = ["scheduler"]
 
 [[bench]]
 name = "workflow_performance"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["Nassor Frazier-Silva"]
 
 [dependencies]
 async-trait = "0.1"
-tokio = { version = "1.47.1", features = ["full"] }
+tokio = { version = "1.47.1", features = ["macros", "sync", "time", "rt-multi-thread"] }
 rand = "0.9"
 chrono = { version = "0.4", features = ["serde"], optional = true }
 cron = { version = "0.15", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cano"
-version = "0.5.1"
+version = "0.6.0"
 homepage = "https://github.com/nassor/cano"
 edition = "2024"
 description = "Simple & Fast Async Workflows in Rust - Build data processing pipelines with Tasks and Nodes"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add Cano to your `Cargo.toml`:
 [dependencies]
 cano = "0.5"
 async-trait = "0.1"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros", "sync", "time", "rt-multi-thread"] }
 ```
 
 For scheduler support:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The engine is built on three core concepts: **Tasks** and **Nodes** to encapsula
 - **Flexible Storage**: Built-in `MemoryStore` or custom struct types for data sharing
 - **Workflow Scheduling** (optional `scheduler` feature): Built-in scheduler with intervals, cron schedules, and manual triggers
 - **Concurrent Execution**: Execute multiple workflow instances in parallel with timeout strategies
+- **Observability** (optional `tracing` feature): Comprehensive tracing and observability for workflow execution
+- **All Features** (optional `all` feature): Convenience feature that enables both `scheduler` and `tracing`
 - **Performance**: Minimal overhead with direct execution and zero-cost abstractions
 
 ## Getting Started
@@ -30,9 +32,34 @@ Add Cano to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-cano = { version = "0.5", features = ["scheduler"] }
+cano = "0.5"
 async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
+```
+
+For scheduler support:
+
+```toml
+[dependencies]
+cano = { version = "0.5", features = ["scheduler"] }
+```
+
+For observability and tracing:
+
+```toml
+[dependencies]
+cano = { version = "0.5", features = ["tracing"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+```
+
+Or use the `all` feature for convenience:
+
+```toml
+[dependencies]
+cano = { version = "0.5", features = ["all"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
 ```
 
 ### Basic Example
@@ -544,6 +571,115 @@ async fn main() -> CanoResult<()> {
 - **Status Monitoring**: Check workflow status, run counts, and execution times
 - **Graceful Shutdown**: Stop with timeout for running flows to complete
 - **Concurrent Execution**: Multiple flows can run simultaneously
+
+## Workflow Observability & Tracing
+
+Cano provides comprehensive observability through the optional `tracing` feature using the [tracing](https://docs.rs/tracing/latest/tracing/) library.
+
+### Enable Tracing
+
+```toml
+[dependencies]
+cano = { version = "0.5", features = ["tracing"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+```
+
+### What Gets Traced
+
+- **Workflow Level**: Orchestration start/completion, state transitions, final states
+- **Task Level**: Task execution with retry logic, attempts, delays, success/failure outcomes
+- **Node Level**: Three-phase lifecycle (prep, exec, post), retry attempts with detailed context
+- **Scheduler Level**: Workflow scheduling, concurrent execution, run counts, durations
+- **Concurrent Workflows**: Individual instance tracking and aggregate statistics
+
+### Basic Usage
+
+```rust
+use cano::prelude::*;
+use tracing::{info_span, info};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[tokio::main]
+async fn main() -> Result<(), CanoError> {
+    // Set up tracing subscriber
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    // Create workflow with custom tracing span
+    let workflow_span = info_span!(
+        "user_data_processing", 
+        user_id = "12345", 
+        batch_id = "batch_001"
+    );
+    
+    let mut workflow = Workflow::new(MyState::Start)
+        .with_tracing_span(workflow_span);
+    
+    workflow.register(MyState::Start, MyProcessingNode);
+    
+    // All execution will be traced under your custom span
+    let result = workflow.orchestrate(&store).await?;
+    
+    Ok(())
+}
+```
+
+### Advanced Tracing
+
+```rust
+// Custom spans for concurrent workflows
+let concurrent_span = info_span!("batch_processing", batch_size = 5);
+let mut concurrent_workflow = ConcurrentWorkflow::new(MyState::Start)
+    .with_tracing_span(concurrent_span);
+
+// Custom tracing in nodes
+#[async_trait]
+impl Node<MyState> for TracedNode {
+    async fn prep(&self, store: &MemoryStore) -> Result<String, CanoError> {
+        info!(node_id = %self.id, "Starting data preparation");
+        // Your prep logic - automatically traced
+        Ok("prepared".to_string())
+    }
+    
+    async fn exec(&self, prep_result: String) -> bool {
+        info!("Processing data: {}", prep_result);
+        true
+    }
+    
+    async fn post(&self, store: &MemoryStore, success: bool) -> Result<MyState, CanoError> {
+        info!(success, "Node execution completed");
+        Ok(MyState::Complete)
+    }
+}
+```
+
+### Tracing Output
+
+With `RUST_LOG=info cargo run`, you'll see structured output like:
+
+```
+INFO user_data_processing{user_id="12345" batch_id="batch_001"}: Starting workflow orchestration
+  INFO user_data_processing{user_id="12345" batch_id="batch_001"}:task_execution{state=Start}:run_with_retries{max_attempts=4}: Starting task execution with retry logic
+    INFO user_data_processing{user_id="12345" batch_id="batch_001"}:task_execution{state=Start}:run_with_retries{max_attempts=4}:task_attempt{attempt=1}: Starting data preparation node_id=processor_1
+    INFO user_data_processing{user_id="12345" batch_id="batch_001"}:task_execution{state=Start}:run_with_retries{max_attempts=4}:task_attempt{attempt=1}: Node execution completed success=true
+  INFO user_data_processing{user_id="12345" batch_id="batch_001"}:task_execution{state=Start}:run_with_retries{max_attempts=4}: Task execution successful attempt=1
+INFO user_data_processing{user_id="12345" batch_id="batch_001"}: Workflow completed successfully final_state=Complete
+```
+
+### Performance
+
+- **Zero-cost when disabled**: No overhead when tracing feature is not enabled
+- **Minimal impact when enabled**: Structured logging with efficient processing
+- **Conditional compilation**: Tracing code only compiled when feature is enabled
+
+Run the tracing demo:
+
+```bash
+RUST_LOG=info cargo run --example tracing_demo --features tracing,scheduler
+```
 
 ## Examples and Testing
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The engine is built on three core concepts: **Tasks** and **Nodes** to encapsula
 - **State Machines**: Type-safe enum-driven state transitions with compile-time checking
 - **Retry Strategies**: None, fixed delays, and exponential backoff with jitter (for both Tasks and Nodes)
 - **Flexible Storage**: Built-in `MemoryStore` or custom struct types for data sharing
-- **Workflow Scheduling**: Built-in scheduler with intervals, cron schedules, and manual triggers
+- **Workflow Scheduling** (optional `scheduler` feature): Built-in scheduler with intervals, cron schedules, and manual triggers
 - **Concurrent Execution**: Execute multiple workflow instances in parallel with timeout strategies
 - **Performance**: Minimal overhead with direct execution and zero-cost abstractions
 
@@ -30,7 +30,7 @@ Add Cano to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-cano = "0.5"
+cano = { version = "0.5", features = ["scheduler"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ For observability and tracing:
 [dependencies]
 cano = { version = "0.5", features = ["tracing"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
 ```
 
 Or use the `all` feature for convenience:
@@ -59,7 +58,6 @@ Or use the `all` feature for convenience:
 [dependencies]
 cano = { version = "0.5", features = ["all"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
 ```
 
 ### Basic Example

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add Cano to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-cano = "0.5"
+cano = "0.6"
 async-trait = "0.1"
 tokio = { version = "1", features = ["macros", "sync", "time", "rt-multi-thread"] }
 ```
@@ -41,14 +41,14 @@ For scheduler support:
 
 ```toml
 [dependencies]
-cano = { version = "0.5", features = ["scheduler"] }
+cano = { version = "0.6", features = ["scheduler"] }
 ```
 
 For observability and tracing:
 
 ```toml
 [dependencies]
-cano = { version = "0.5", features = ["tracing"] }
+cano = { version = "0.6", features = ["tracing"] }
 tracing = "0.1"
 ```
 
@@ -56,7 +56,7 @@ Or use the `all` feature for convenience:
 
 ```toml
 [dependencies]
-cano = { version = "0.5", features = ["all"] }
+cano = { version = "0.6", features = ["all"] }
 tracing = "0.1"
 ```
 
@@ -578,7 +578,7 @@ Cano provides comprehensive observability through the optional `tracing` feature
 
 ```toml
 [dependencies]
-cano = { version = "0.5", features = ["tracing"] }
+cano = { version = "0.6", features = ["tracing"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```

--- a/examples/scheduler_book_prepositions.rs
+++ b/examples/scheduler_book_prepositions.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "scheduler")]
 //! # Book Preposition Analysis with Scheduler: Concurrent Downloads + Sequential Analysis
 //!
 //! This example demonstrates a sophisticated book analysis system that combines:

--- a/examples/scheduler_concurrent_workflows.rs
+++ b/examples/scheduler_concurrent_workflows.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "scheduler")]
 //! # Concurrent Workflow Execution Demo
 //!
 //! This example specifically demonstrates how the Scheduler scheduler can run

--- a/examples/scheduler_duration_scheduling.rs
+++ b/examples/scheduler_duration_scheduling.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "scheduler")]
 //! # Duration-based Scheduling Example
 //!
 //! This example demonstrates how to use the Scheduler with custom Duration intervals:

--- a/examples/scheduler_graceful_shutdown.rs
+++ b/examples/scheduler_graceful_shutdown.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "scheduler")]
 //! # Graceful Shutdown with Timeout Example
 //!
 //! This example demonstrates how to implement graceful shutdown handling in the Scheduler:

--- a/examples/scheduler_mixed_workflows.rs
+++ b/examples/scheduler_mixed_workflows.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "scheduler")]
 //! # Enhanced Scheduler with Concurrent Workflows Example
 //!
 //! This example demonstrates the enhanced scheduler that supports both regular

--- a/examples/scheduler_scheduling.rs
+++ b/examples/scheduler_scheduling.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "scheduler")]
 //! # Scheduler Scheduling Example
 //!
 //! This example demonstrates the Scheduler scheduler with multiple flows:

--- a/examples/tracing_demo.rs
+++ b/examples/tracing_demo.rs
@@ -88,7 +88,7 @@ impl Node<WorkflowState> for TracedDataProcessor {
 
             prep_result
                 .into_iter()
-                .map(|item| format!("processed_{}", item))
+                .map(|item| format!("processed_{item}"))
                 .collect::<Vec<_>>()
         }
         .instrument(processing_span)
@@ -262,7 +262,7 @@ async fn main() -> CanoResult<()> {
         let result = workflow.orchestrate(&store).await?;
         info!(final_state = ?result, "Workflow completed");
 
-        println!("✅ Basic workflow completed with state: {:?}\n", result);
+        println!("✅ Basic workflow completed with state: {result:?}\n");
     }
 
     // Example 2: Concurrent workflow with tracing
@@ -338,9 +338,9 @@ async fn main() -> CanoResult<()> {
         );
 
         println!("✅ Task-based workflow completed:");
-        println!("   - Final state: {:?}", result);
-        println!("   - Math result: {}", math_result);
-        println!("   - Completed by: {}\n", completed_by);
+        println!("   - Final state: {result:?}");
+        println!("   - Math result: {math_result}");
+        println!("   - Completed by: {completed_by}\n");
     }
 
     // Example 4: Scheduler with tracing
@@ -418,7 +418,7 @@ async fn main() -> CanoResult<()> {
         info!("Starting workflow that will encounter validation failure...");
         let result = error_workflow.orchestrate(&store).await?;
 
-        println!("✅ Error workflow completed with state: {:?}", result);
+        println!("✅ Error workflow completed with state: {result:?}");
 
         match result {
             WorkflowState::Error => {

--- a/examples/tracing_demo.rs
+++ b/examples/tracing_demo.rs
@@ -25,12 +25,9 @@ use tracing::{Instrument, info, info_span, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[allow(dead_code)] // Some variants used for demonstration purposes
 enum WorkflowState {
     Start,
-    DataValidation,
     Processing,
-    PostProcessing,
     Complete,
     Error,
 }

--- a/examples/tracing_demo.rs
+++ b/examples/tracing_demo.rs
@@ -1,0 +1,445 @@
+#![cfg(feature = "tracing")]
+//! # Tracing Demo Example
+//!
+//! This example demonstrates the tracing feature in Cano workflows and schedulers.
+//! It shows how to:
+//! 1. Enable tracing with spans for workflows
+//! 2. Use custom tracing spans for better observability  
+//! 3. Track workflow execution through the scheduler
+//! 4. Monitor node execution phases (prep, exec, post)
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example tracing_demo --features tracing
+//! ```
+//!
+//! For better tracing output, you can also run with a tracing subscriber:
+//! ```bash
+//! RUST_LOG=info cargo run --example tracing_demo --features tracing
+//! ```
+
+use async_trait::async_trait;
+use cano::prelude::*;
+use std::time::Duration;
+use tracing::{Instrument, info, info_span, warn};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[allow(dead_code)] // Some variants used for demonstration purposes
+enum WorkflowState {
+    Start,
+    DataValidation,
+    Processing,
+    PostProcessing,
+    Complete,
+    Error,
+}
+
+/// A node that demonstrates tracing in the prep, exec, and post phases
+#[derive(Clone)]
+struct TracedDataProcessor {
+    processor_id: String,
+    simulate_delay_ms: u64,
+}
+
+impl TracedDataProcessor {
+    fn new(processor_id: &str, simulate_delay_ms: u64) -> Self {
+        Self {
+            processor_id: processor_id.to_string(),
+            simulate_delay_ms,
+        }
+    }
+}
+
+#[async_trait]
+impl Node<WorkflowState> for TracedDataProcessor {
+    type PrepResult = Vec<String>;
+    type ExecResult = Vec<String>;
+
+    fn config(&self) -> TaskConfig {
+        TaskConfig::default()
+    }
+
+    async fn prep(&self, store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+        info!(processor_id = %self.processor_id, "Starting data preparation");
+
+        // Simulate some prep work
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let data = vec![
+            "record_1".to_string(),
+            "record_2".to_string(),
+            "record_3".to_string(),
+        ];
+
+        store.put("prep_timestamp", chrono::Utc::now().to_rfc3339())?;
+
+        info!(processor_id = %self.processor_id, record_count = data.len(), "Data preparation completed");
+        Ok(data)
+    }
+
+    async fn exec(&self, prep_result: Self::PrepResult) -> Self::ExecResult {
+        info!(processor_id = %self.processor_id, input_records = prep_result.len(), "Starting data processing");
+
+        // Simulate processing work with custom span
+        let processing_span = info_span!("data_processing", processor_id = %self.processor_id);
+        let processed_data = async {
+            tokio::time::sleep(Duration::from_millis(self.simulate_delay_ms)).await;
+
+            prep_result
+                .into_iter()
+                .map(|item| format!("processed_{}", item))
+                .collect::<Vec<_>>()
+        }
+        .instrument(processing_span)
+        .await;
+
+        info!(processor_id = %self.processor_id, output_records = processed_data.len(), "Data processing completed");
+        processed_data
+    }
+
+    async fn post(
+        &self,
+        store: &MemoryStore,
+        exec_result: Self::ExecResult,
+    ) -> Result<WorkflowState, CanoError> {
+        info!(processor_id = %self.processor_id, "Starting post-processing");
+
+        // Store results
+        let result_summary = format!("Processed {} records", exec_result.len());
+        store.put("processing_result", result_summary)?;
+        store.put("completion_timestamp", chrono::Utc::now().to_rfc3339())?;
+
+        // Simulate some post-processing delay
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        info!(processor_id = %self.processor_id, processed_count = exec_result.len(), "Post-processing completed");
+        Ok(WorkflowState::Complete)
+    }
+}
+
+/// A simple validation node
+#[derive(Clone)]
+struct ValidationNode {
+    should_pass: bool,
+}
+
+impl ValidationNode {
+    fn new(should_pass: bool) -> Self {
+        Self { should_pass }
+    }
+}
+
+#[async_trait]
+impl Node<WorkflowState> for ValidationNode {
+    type PrepResult = String;
+    type ExecResult = bool;
+
+    async fn prep(&self, _store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+        info!("Preparing validation");
+        Ok("validation_data".to_string())
+    }
+
+    async fn exec(&self, _prep_result: Self::PrepResult) -> Self::ExecResult {
+        info!(should_pass = self.should_pass, "Running validation");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        self.should_pass
+    }
+
+    async fn post(
+        &self,
+        _store: &MemoryStore,
+        exec_result: Self::ExecResult,
+    ) -> Result<WorkflowState, CanoError> {
+        if exec_result {
+            info!("Validation passed");
+            Ok(WorkflowState::Processing)
+        } else {
+            warn!("Validation failed");
+            Ok(WorkflowState::Error)
+        }
+    }
+}
+
+/// A simple task that demonstrates Task-level tracing (simpler than Node)
+#[derive(Clone)]
+struct SimpleMathTask {
+    task_id: String,
+    operation: String,
+}
+
+impl SimpleMathTask {
+    fn new(task_id: &str, operation: &str) -> Self {
+        Self {
+            task_id: task_id.to_string(),
+            operation: operation.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl Task<WorkflowState> for SimpleMathTask {
+    fn config(&self) -> TaskConfig {
+        TaskConfig::default().with_fixed_retry(2, Duration::from_millis(100))
+    }
+
+    async fn run(&self, store: &MemoryStore) -> Result<WorkflowState, CanoError> {
+        info!(task_id = %self.task_id, operation = %self.operation, "Starting math task");
+
+        // Simulate some computation work
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        // Get operands from store or use defaults
+        let a: i32 = store.get("operand_a").unwrap_or(10);
+        let b: i32 = store.get("operand_b").unwrap_or(5);
+
+        let result = match self.operation.as_str() {
+            "add" => a + b,
+            "multiply" => a * b,
+            "subtract" => a - b,
+            _ => {
+                warn!(operation = %self.operation, "Unknown operation, defaulting to addition");
+                a + b
+            }
+        };
+
+        store.put("math_result", result)?;
+        store.put("task_completed_by", self.task_id.clone())?;
+
+        info!(
+            task_id = %self.task_id,
+            operation = %self.operation,
+            operand_a = a,
+            operand_b = b,
+            result,
+            "Math task completed"
+        );
+
+        Ok(WorkflowState::Complete)
+    }
+}
+
+async fn setup_tracing() {
+    // Initialize tracing subscriber for better output
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer().with_target(false))
+        .init();
+}
+
+#[tokio::main]
+async fn main() -> CanoResult<()> {
+    setup_tracing().await;
+
+    info!("🔍 Starting Cano Tracing Demo");
+    info!("=============================");
+
+    // Example 1: Basic workflow with tracing spans
+    {
+        info!("📋 Example 1: Basic Workflow with Custom Tracing Span");
+
+        let workflow_span = info_span!(
+            "user_data_workflow",
+            workflow_type = "basic",
+            user_id = "12345"
+        );
+
+        let mut workflow = Workflow::new(WorkflowState::Start).with_tracing_span(workflow_span);
+
+        workflow
+            .register(WorkflowState::Start, ValidationNode::new(true))
+            .register(
+                WorkflowState::Processing,
+                TracedDataProcessor::new("basic_processor", 200),
+            )
+            .add_exit_states(vec![WorkflowState::Complete, WorkflowState::Error]);
+
+        let store = MemoryStore::new();
+
+        info!("Starting workflow execution...");
+        let result = workflow.orchestrate(&store).await?;
+        info!(final_state = ?result, "Workflow completed");
+
+        println!("✅ Basic workflow completed with state: {:?}\n", result);
+    }
+
+    // Example 2: Concurrent workflow with tracing
+    {
+        info!("📋 Example 2: Concurrent Workflow with Tracing");
+
+        let concurrent_span = info_span!("batch_processing_workflow", batch_size = 3);
+
+        let mut concurrent_workflow =
+            ConcurrentWorkflow::new(WorkflowState::Start).with_tracing_span(concurrent_span);
+
+        concurrent_workflow
+            .register(WorkflowState::Start, ValidationNode::new(true))
+            .register(
+                WorkflowState::Processing,
+                TracedDataProcessor::new("concurrent_processor", 300),
+            )
+            .add_exit_state(WorkflowState::Complete);
+
+        let stores = vec![MemoryStore::new(), MemoryStore::new(), MemoryStore::new()];
+
+        info!("Starting concurrent workflow execution...");
+        let (_results, status) = concurrent_workflow
+            .execute_concurrent(stores, WaitStrategy::WaitForever)
+            .await?;
+
+        info!(
+            completed = status.completed,
+            failed = status.failed,
+            duration_ms = status.duration.as_millis(),
+            "Concurrent execution completed"
+        );
+
+        println!("✅ Concurrent workflow completed:");
+        println!("   - Total workflows: {}", status.total_workflows);
+        println!("   - Completed: {}", status.completed);
+        println!("   - Failed: {}", status.failed);
+        println!("   - Duration: {:?}\n", status.duration);
+    }
+
+    // Example 3: Simple Task with Tracing and Retry Logic
+    {
+        info!("📋 Example 3: Simple Task with Tracing and Retry");
+
+        let task_span = info_span!("math_computation_workflow", workflow_type = "task_based");
+
+        let mut task_workflow = Workflow::new(WorkflowState::Start).with_tracing_span(task_span);
+
+        task_workflow
+            .register(
+                WorkflowState::Start,
+                SimpleMathTask::new("math_task_1", "multiply"),
+            )
+            .add_exit_state(WorkflowState::Complete);
+
+        let store = MemoryStore::new();
+
+        // Set some operands for the math task
+        store.put("operand_a", 7)?;
+        store.put("operand_b", 6)?;
+
+        info!("Starting task-based workflow execution...");
+        let result = task_workflow.orchestrate(&store).await?;
+
+        let math_result: i32 = store.get("math_result").unwrap_or(0);
+        let completed_by: String = store.get("task_completed_by").unwrap_or_default();
+
+        info!(
+            final_state = ?result,
+            math_result,
+            completed_by = %completed_by,
+            "Task-based workflow completed"
+        );
+
+        println!("✅ Task-based workflow completed:");
+        println!("   - Final state: {:?}", result);
+        println!("   - Math result: {}", math_result);
+        println!("   - Completed by: {}\n", completed_by);
+    }
+
+    // Example 4: Scheduler with tracing
+    #[cfg(feature = "scheduler")]
+    {
+        info!("📋 Example 4: Scheduler with Workflow Tracing");
+
+        let scheduler_span = info_span!("scheduled_workflows");
+        let _scheduler_enter = scheduler_span.enter();
+
+        let mut scheduler = Scheduler::new();
+
+        // Create a workflow with a custom span for scheduled execution
+        let scheduled_span = info_span!(
+            "scheduled_data_processing",
+            schedule_type = "every_2_seconds"
+        );
+        let mut scheduled_workflow =
+            Workflow::new(WorkflowState::Start).with_tracing_span(scheduled_span);
+
+        scheduled_workflow
+            .register(WorkflowState::Start, ValidationNode::new(true))
+            .register(
+                WorkflowState::Processing,
+                TracedDataProcessor::new("scheduled_processor", 150),
+            )
+            .add_exit_state(WorkflowState::Complete);
+
+        scheduler.every_seconds("traced_workflow", scheduled_workflow, 2)?;
+
+        info!("Starting scheduler...");
+        scheduler.start().await?;
+
+        // Let it run for a few iterations
+        info!("Letting scheduler run for 6 seconds...");
+        tokio::time::sleep(Duration::from_secs(6)).await;
+
+        // Check status
+        if let Some(flow_info) = scheduler.status("traced_workflow").await {
+            info!(
+                workflow_id = %flow_info.id,
+                run_count = flow_info.run_count,
+                status = ?flow_info.status,
+                "Workflow status"
+            );
+
+            println!(
+                "✅ Scheduled workflow executed {} times",
+                flow_info.run_count
+            );
+        }
+
+        info!("Stopping scheduler...");
+        scheduler.stop().await?;
+    }
+
+    // Example 5: Error handling with tracing
+    {
+        info!("📋 Example 5: Error Handling with Tracing");
+
+        let error_span = info_span!("error_handling_demo");
+
+        let mut error_workflow = Workflow::new(WorkflowState::Start).with_tracing_span(error_span);
+
+        error_workflow
+            .register(WorkflowState::Start, ValidationNode::new(false)) // This will fail
+            .register(
+                WorkflowState::Processing,
+                TracedDataProcessor::new("error_processor", 100),
+            )
+            .add_exit_states(vec![WorkflowState::Complete, WorkflowState::Error]);
+
+        let store = MemoryStore::new();
+
+        info!("Starting workflow that will encounter validation failure...");
+        let result = error_workflow.orchestrate(&store).await?;
+
+        println!("✅ Error workflow completed with state: {:?}", result);
+
+        match result {
+            WorkflowState::Error => {
+                println!(
+                    "   As expected, the workflow ended in error state due to validation failure"
+                );
+            }
+            _ => {
+                println!("   Unexpected result");
+            }
+        }
+    }
+
+    info!("🎉 Tracing demo completed!");
+    println!("\n🔍 Tracing Demo Summary:");
+    println!("• Workflows can be instrumented with custom tracing spans");
+    println!("• Node execution phases (prep, exec, post) are automatically traced");
+    println!("• Concurrent workflows trace each instance separately");
+    println!("• Schedulers trace workflow executions with context");
+    println!("• Error paths are traced with appropriate log levels");
+    println!("\nTo see more detailed tracing output, run with RUST_LOG=debug");
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //! - **[`workflow`]**: Core workflow orchestration
 //!   - [`Workflow`] for state machine-based workflows
 //!
-//! - **[`scheduler`]**: Advanced workflow scheduling
+//! - **[`scheduler`]** (optional `scheduler` feature): Advanced workflow scheduling
 //!   - [`Scheduler`] for managing multiple flows with cron support
 //!   - Time-based and event-driven scheduling
 //!
@@ -87,21 +87,25 @@
 
 pub mod error;
 pub mod node;
-pub mod scheduler;
 pub mod store;
 pub mod task;
 pub mod workflow;
 
+#[cfg(feature = "scheduler")]
+pub mod scheduler;
+
 // Core public API - simplified imports
 pub use error::{CanoError, CanoResult};
 pub use node::{DefaultNodeResult, DefaultParams, DynNode, Node};
-pub use scheduler::{FlowInfo, Scheduler};
 pub use store::{KeyValueStore, MemoryStore};
 pub use task::{DefaultTaskParams, DynTask, RetryMode, Task, TaskConfig, TaskObject};
 pub use workflow::{
     ConcurrentWorkflow, ConcurrentWorkflowBuilder, ConcurrentWorkflowStatus, WaitStrategy,
     Workflow, WorkflowBuilder, WorkflowResult,
 };
+
+#[cfg(feature = "scheduler")]
+pub use scheduler::{FlowInfo, Scheduler};
 
 // Convenience re-exports for common patterns
 pub mod prelude {
@@ -111,10 +115,13 @@ pub mod prelude {
 
     pub use crate::{
         CanoError, CanoResult, ConcurrentWorkflow, ConcurrentWorkflowBuilder,
-        ConcurrentWorkflowStatus, DefaultNodeResult, DefaultParams, DefaultTaskParams, FlowInfo,
-        KeyValueStore, MemoryStore, Node, RetryMode, Scheduler, Task, TaskConfig, TaskObject,
-        WaitStrategy, Workflow, WorkflowBuilder, WorkflowResult,
+        ConcurrentWorkflowStatus, DefaultNodeResult, DefaultParams, DefaultTaskParams,
+        KeyValueStore, MemoryStore, Node, RetryMode, Task, TaskConfig, TaskObject, WaitStrategy,
+        Workflow, WorkflowBuilder, WorkflowResult,
     };
+
+    #[cfg(feature = "scheduler")]
+    pub use crate::{FlowInfo, Scheduler};
 
     // Re-export async_trait for convenience
     pub use async_trait::async_trait;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,9 @@ pub mod workflow;
 #[cfg(feature = "scheduler")]
 pub mod scheduler;
 
+#[cfg(all(test, feature = "tracing"))]
+mod tracing_tests;
+
 // Core public API - simplified imports
 pub use error::{CanoError, CanoResult};
 pub use node::{DefaultNodeResult, DefaultParams, DynNode, Node};

--- a/src/node.rs
+++ b/src/node.rs
@@ -223,8 +223,6 @@ where
         );
 
         loop {
-            attempt += 1;
-
             #[cfg(feature = "tracing")]
             tracing::debug!(attempt = attempt, "Starting node execution attempt");
 
@@ -275,6 +273,8 @@ where
                             return Ok(result);
                         }
                         Err(e) => {
+                            attempt += 1;
+
                             #[cfg(feature = "tracing")]
                             tracing::warn!(attempt = attempt, error = ?e, max_attempts = max_attempts, "Post phase failed");
 
@@ -297,6 +297,8 @@ where
                     }
                 }
                 Err(e) => {
+                    attempt += 1;
+
                     #[cfg(feature = "tracing")]
                     tracing::warn!(attempt = attempt, error = ?e, max_attempts = max_attempts, "Prep phase failed");
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -11,7 +11,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! cano = { version = "0.5", features = ["scheduler"] }
+//! cano = { version = "0.6", features = ["scheduler"] }
 //! ```
 //!
 //! ```rust

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "scheduler")]
 //! # Simplified Scheduler API
 //!
 //! A simplified scheduler that focuses on ease of use while maintaining

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "scheduler")]
 //! # Simplified Scheduler API
 //!
 //! A simplified scheduler that focuses on ease of use while maintaining
@@ -5,6 +6,14 @@
 //! unified registration using the `.register()` method.
 //!
 //! ## 🚀 Quick Start
+//!
+//! > **Note:** The scheduler is an optional feature. To use it, you must enable
+//! > the `"scheduler"` feature in your `Cargo.toml`.
+//!
+//! ```toml
+//! [dependencies]
+//! cano = { version = "0.5", features = ["scheduler"] }
+//! ```
 //!
 //! ```rust
 //! use cano::prelude::*;

--- a/src/tracing_tests.rs
+++ b/src/tracing_tests.rs
@@ -1,0 +1,134 @@
+#[cfg(feature = "tracing")]
+mod tracing_tests {
+    use crate::prelude::*;
+    use async_trait::async_trait;
+    use tracing::info_span;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    enum TestState {
+        Start,
+        Processing,
+        Complete,
+    }
+
+    #[derive(Clone)]
+    struct TestNode {
+        id: String,
+    }
+
+    impl TestNode {
+        fn new(id: &str) -> Self {
+            Self { id: id.to_string() }
+        }
+    }
+
+    #[async_trait]
+    impl Node<TestState> for TestNode {
+        type PrepResult = String;
+        type ExecResult = String;
+
+        async fn prep(&self, _store: &MemoryStore) -> Result<Self::PrepResult, CanoError> {
+            Ok(format!("prep_{}", self.id))
+        }
+
+        async fn exec(&self, prep_result: Self::PrepResult) -> Self::ExecResult {
+            format!("exec_{}", prep_result)
+        }
+
+        async fn post(
+            &self,
+            _store: &MemoryStore,
+            exec_result: Self::ExecResult,
+        ) -> Result<TestState, CanoError> {
+            if exec_result.contains("processing") {
+                Ok(TestState::Complete)
+            } else {
+                Ok(TestState::Processing)
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_workflow_with_tracing_span() {
+        let span = info_span!("test_workflow", test_id = "workflow_span_test");
+
+        let mut workflow = Workflow::new(TestState::Start).with_tracing_span(span);
+
+        workflow
+            .register(TestState::Start, TestNode::new("start"))
+            .register(TestState::Processing, TestNode::new("processing"))
+            .add_exit_state(TestState::Complete);
+
+        let store = MemoryStore::new();
+        let result = workflow.orchestrate(&store).await.unwrap();
+
+        assert_eq!(result, TestState::Complete);
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_workflow_with_tracing_span() {
+        let span = info_span!("test_concurrent_workflow", test_id = "concurrent_span_test");
+
+        let mut concurrent_workflow =
+            ConcurrentWorkflow::new(TestState::Start).with_tracing_span(span);
+
+        concurrent_workflow
+            .register(TestState::Start, TestNode::new("start"))
+            .register(TestState::Processing, TestNode::new("processing"))
+            .add_exit_state(TestState::Complete);
+
+        let stores = vec![MemoryStore::new(), MemoryStore::new()];
+        let (results, status) = concurrent_workflow
+            .execute_concurrent(stores, WaitStrategy::WaitForever)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(status.completed, 2);
+        assert_eq!(status.failed, 0);
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "scheduler")]
+    async fn test_scheduler_with_tracing() {
+        let span = info_span!("test_scheduler_workflow", test_id = "scheduler_span_test");
+
+        let mut workflow = Workflow::new(TestState::Start).with_tracing_span(span);
+
+        workflow
+            .register(TestState::Start, TestNode::new("start"))
+            .register(TestState::Processing, TestNode::new("processing"))
+            .add_exit_state(TestState::Complete);
+
+        let mut scheduler = Scheduler::new();
+        scheduler.manual("test_workflow", workflow).unwrap();
+
+        scheduler.start().await.unwrap();
+        scheduler.trigger("test_workflow").await.unwrap();
+
+        // Give some time for execution
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        let status = scheduler.status("test_workflow").await;
+        assert!(status.is_some());
+        assert_eq!(status.unwrap().run_count, 1);
+
+        scheduler.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_workflow_tracing_without_custom_span() {
+        // Test that workflows work fine without custom spans when tracing is enabled
+        let mut workflow = Workflow::new(TestState::Start);
+
+        workflow
+            .register(TestState::Start, TestNode::new("start"))
+            .register(TestState::Processing, TestNode::new("processing"))
+            .add_exit_state(TestState::Complete);
+
+        let store = MemoryStore::new();
+        let result = workflow.orchestrate(&store).await.unwrap();
+
+        assert_eq!(result, TestState::Complete);
+    }
+}

--- a/src/tracing_tests.rs
+++ b/src/tracing_tests.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "tracing")]
-mod tracing_tests {
+mod tests {
     use crate::prelude::*;
     use async_trait::async_trait;
     use tracing::info_span;

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -694,7 +694,8 @@ where
 
         // Create workflow instances and spawn tasks
         let mut tasks = Vec::new();
-        #[cfg_attr(not(feature = "tracing"), allow(unused_variables))] // idx is only used with tracing feature
+        #[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
+        // idx is only used with tracing feature
         for (idx, store) in stores.into_iter().enumerate() {
             let workflow = self.create_workflow_instance()?;
 

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -694,7 +694,7 @@ where
 
         // Create workflow instances and spawn tasks
         let mut tasks = Vec::new();
-        #[allow(unused_variables)] // idx is only used with tracing feature
+        #[cfg_attr(not(feature = "tracing"), allow(unused_variables))] // idx is only used with tracing feature
         for (idx, store) in stores.into_iter().enumerate() {
             let workflow = self.create_workflow_instance()?;
 

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -350,8 +350,7 @@ where
         #[cfg(feature = "tracing")]
         let workflow_span = self
             .tracing_span
-            .as_ref()
-            .map(|span| span.clone())
+            .clone()
             .unwrap_or_else(|| tracing::info_span!("workflow_orchestrate"));
 
         #[cfg(feature = "tracing")]
@@ -675,8 +674,7 @@ where
         #[cfg(feature = "tracing")]
         let concurrent_span = self
             .tracing_span
-            .as_ref()
-            .map(|span| span.clone())
+            .clone()
             .unwrap_or_else(|| tracing::info_span!("concurrent_workflow_execute"));
 
         #[cfg(feature = "tracing")]


### PR DESCRIPTION
-   **✨ New `tracing` Feature**:
    -   Integrated the `tracing` library to provide detailed observability into workflow execution.
    -   Added `with_tracing_span` methods to `Workflow` and `ConcurrentWorkflow` to allow users to attach custom tracing spans.
    -   Instrumented key components for detailed logging:
        -   **Workflow**: Orchestration lifecycle (start, completion, state transitions).
        -   **Node**: Execution phases (`prep`, `exec`, `post`) and retry attempts.
        -   **Task**: Execution and retry logic.
        -   **Scheduler**: Scheduled and concurrent workflow executions.
    -   Added a new `tracing_demo` example to showcase the latest capabilities.
    -   Added `tracing_tests` to validate the integration.

-   **📦 Optional Scheduler**:
    -   The `scheduler` module is now an optional feature. To use it, enable the `scheduler` feature in `Cargo.toml`.
    -   This reduces the core library's dependencies for users who do not require scheduling.
    -   Updated scheduler-related examples to use `required-features = ["scheduler"]`.

-   **🔧 Build & Configuration**:
    -   Added `tracing`, `scheduler`, and `all` feature flags to `Cargo.toml`.
    -   Updated `tokio` dependencies to be more granular, reducing unused features for minimal builds.
    -   Updated README.md with detailed documentation for the new features and how to enable them.

### How to Use the `tracing` Feature

1.  **Enable the feature in Cargo.toml**:
    ```toml
    [dependencies]
    cano = { version = "0.5", features = ["tracing"] }
    tracing = "0.1"
    tracing-subscriber = "0.3"
    ```

2.  **Initialize a tracing subscriber**:
    ```rust
    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};

    tracing_subscriber::registry()
        .with(tracing_subscriber::EnvFilter::from_default_env())
        .with(tracing_subscriber::fmt::layer())
        .init();
    ```

3.  **Attach a custom span to a workflow**:
    ```rust
    use cano::prelude::*;
    use tracing::info_span;

    let workflow_span = info_span!("my_workflow", user_id = "123");
    let mut workflow = Workflow::new(MyState::Start)
        .with_tracing_span(workflow_span);
    ```

All operations within the workflow will now be traced under the provided span, offering rich, structured logs for debugging and monitoring.

This PR significantly improves the library's utility for building robust, observable, and modular applications.