### PR TITLE
Enhance error handling with Timeout variant and per-attempt timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cano"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "axum",
  "cano-macros",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "cano-macros"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "cano",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["cano", "cano-macros"]
 
 [workspace.package]
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/cano/src/error.rs
+++ b/cano/src/error.rs
@@ -29,6 +29,7 @@
 //! | `Workflow` | Workflow orchestration fails | Verify node registration and routing |
 //! | `Configuration` | Invalid node/workflow config | Check parameters and settings |
 //! | `RetryExhausted` | All retries exhausted | Increase retries or fix root cause |
+//! | `Timeout` | Per-attempt timeout reached | Increase `attempt_timeout` or speed up the task |
 //! | `Generic` | General errors | Check the specific error message |
 //!
 //! ## Using Errors in Your Nodes
@@ -178,6 +179,16 @@ pub enum CanoError {
     /// all configured retry attempts have been used up.
     RetryExhausted(String),
 
+    /// A bounded operation exceeded its deadline.
+    ///
+    /// Emitted by per-attempt task timeouts (see
+    /// [`crate::task::TaskConfig::with_attempt_timeout`]). The retry loop treats
+    /// this as a recoverable failure: each attempt that times out is retried
+    /// (subject to the configured `RetryMode`), and if all attempts time out
+    /// the loop wraps the final timeout error in
+    /// [`CanoError::RetryExhausted`].
+    Timeout(String),
+
     /// General-purpose error for other scenarios
     ///
     /// Use this for errors that don't fit the other categories.
@@ -230,6 +241,11 @@ impl CanoError {
         CanoError::RetryExhausted(msg.into())
     }
 
+    /// Create a new timeout error
+    pub fn timeout<S: Into<String>>(msg: S) -> Self {
+        CanoError::Timeout(msg.into())
+    }
+
     /// Create a new generic error
     pub fn generic<S: Into<String>>(msg: S) -> Self {
         CanoError::Generic(msg.into())
@@ -260,6 +276,7 @@ impl CanoError {
             CanoError::Workflow(msg) => msg,
             CanoError::Configuration(msg) => msg,
             CanoError::RetryExhausted(msg) => msg,
+            CanoError::Timeout(msg) => msg,
             CanoError::Generic(msg) => msg,
             CanoError::ResourceNotFound(msg) => msg,
             CanoError::ResourceTypeMismatch(msg) => msg,
@@ -277,6 +294,7 @@ impl CanoError {
             CanoError::Workflow(_) => "workflow",
             CanoError::Configuration(_) => "configuration",
             CanoError::RetryExhausted(_) => "retry_exhausted",
+            CanoError::Timeout(_) => "timeout",
             CanoError::Generic(_) => "generic",
             CanoError::ResourceNotFound(_) => "resource_not_found",
             CanoError::ResourceTypeMismatch(_) => "resource_type_mismatch",
@@ -295,6 +313,7 @@ impl std::fmt::Display for CanoError {
             CanoError::Workflow(msg) => write!(f, "Workflow error: {msg}"),
             CanoError::Configuration(msg) => write!(f, "Configuration error: {msg}"),
             CanoError::RetryExhausted(msg) => write!(f, "Retry exhausted: {msg}"),
+            CanoError::Timeout(msg) => write!(f, "Timeout error: {msg}"),
             CanoError::Generic(msg) => write!(f, "Error: {msg}"),
             CanoError::ResourceNotFound(msg) => write!(f, "Resource not found: {msg}"),
             CanoError::ResourceTypeMismatch(msg) => write!(f, "Resource type mismatch: {msg}"),
@@ -315,6 +334,7 @@ impl PartialEq for CanoError {
             (CanoError::Workflow(a), CanoError::Workflow(b)) => a == b,
             (CanoError::Configuration(a), CanoError::Configuration(b)) => a == b,
             (CanoError::RetryExhausted(a), CanoError::RetryExhausted(b)) => a == b,
+            (CanoError::Timeout(a), CanoError::Timeout(b)) => a == b,
             (CanoError::Generic(a), CanoError::Generic(b)) => a == b,
             (CanoError::ResourceNotFound(a), CanoError::ResourceNotFound(b)) => a == b,
             (CanoError::ResourceTypeMismatch(a), CanoError::ResourceTypeMismatch(b)) => a == b,
@@ -517,6 +537,30 @@ mod tests {
         let e = CanoError::ResourceTypeMismatch("t".to_string());
         let f = CanoError::ResourceTypeMismatch("t".to_string());
         assert_eq!(e, f);
+    }
+
+    #[test]
+    fn test_timeout_constructor_and_category() {
+        let err = CanoError::timeout("attempt deadline reached");
+        assert_eq!(err.message(), "attempt deadline reached");
+        assert_eq!(err.category(), "timeout");
+        assert_eq!(format!("{err}"), "Timeout error: attempt deadline reached");
+    }
+
+    #[test]
+    fn test_timeout_partial_eq() {
+        let a = CanoError::timeout("d");
+        let b = CanoError::timeout("d");
+        assert_eq!(a, b);
+
+        let c = CanoError::timeout("x");
+        let d = CanoError::timeout("y");
+        assert_ne!(c, d);
+
+        // Distinct from same-message variants
+        let timeout = CanoError::timeout("k");
+        let workflow = CanoError::workflow("k");
+        assert_ne!(timeout, workflow);
     }
 
     #[test]

--- a/cano/src/task.rs
+++ b/cano/src/task.rs
@@ -259,6 +259,12 @@ impl Default for RetryMode {
 pub struct TaskConfig {
     /// Retry strategy for failed executions
     pub retry_mode: RetryMode,
+    /// Optional per-attempt timeout. When set, each attempt inside
+    /// [`run_with_retries`] is wrapped with [`tokio::time::timeout`]; an
+    /// expired attempt produces a [`CanoError::Timeout`] and the retry loop
+    /// continues per `retry_mode`. `None` (the default) preserves the
+    /// previous behavior of letting attempts run unbounded.
+    pub attempt_timeout: Option<Duration>,
 }
 
 impl TaskConfig {
@@ -273,6 +279,7 @@ impl TaskConfig {
     pub fn minimal() -> Self {
         Self {
             retry_mode: RetryMode::None,
+            attempt_timeout: None,
         }
     }
 
@@ -290,6 +297,12 @@ impl TaskConfig {
     /// Convenience method for exponential backoff retry configuration
     pub fn with_exponential_retry(self, max_retries: usize) -> Self {
         self.with_retry(RetryMode::exponential(max_retries))
+    }
+
+    /// Apply a per-attempt timeout. Each retry attempt gets a fresh deadline.
+    pub fn with_attempt_timeout(mut self, timeout: Duration) -> Self {
+        self.attempt_timeout = Some(timeout);
+        self
     }
 }
 
@@ -326,7 +339,19 @@ where
         #[cfg(feature = "tracing")]
         debug!(attempt = attempt + 1, "Executing task attempt");
 
-        match run_fn().await {
+        let attempt_outcome = match config.attempt_timeout {
+            Some(d) => match tokio::time::timeout(d, run_fn()).await {
+                Ok(inner) => inner,
+                Err(_) => Err(CanoError::timeout(format!(
+                    "Task attempt {} exceeded attempt_timeout of {:?}",
+                    attempt + 1,
+                    d
+                ))),
+            },
+            None => run_fn().await,
+        };
+
+        match attempt_outcome {
             Ok(result) => {
                 #[cfg(feature = "tracing")]
                 info!(attempt = attempt + 1, "Task execution successful");
@@ -1167,6 +1192,83 @@ mod tests {
         assert_eq!(result, TaskResult::Single(TestAction::Continue));
         // run_bare must never have been called
         assert_eq!(bare_called.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_attempt_timeout_triggers_retry() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let config = TaskConfig::new()
+            .with_fixed_retry(2, Duration::from_millis(1))
+            .with_attempt_timeout(Duration::from_millis(20));
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = Arc::clone(&counter);
+
+        let result = run_with_retries::<TaskResult<String>, _, _>(&config, || {
+            let counter = Arc::clone(&counter_clone);
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                Ok::<TaskResult<String>, CanoError>(TaskResult::Single("never".to_string()))
+            }
+        })
+        .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, CanoError::RetryExhausted(_)),
+            "expected RetryExhausted, got: {err}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Timeout error") || msg.contains("attempt_timeout"),
+            "expected timeout context in error, got: {msg}"
+        );
+        // 1 initial + 2 retries — every attempt times out before the sleep returns.
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_attempt_timeout_none_unchanged() {
+        let config = TaskConfig::new();
+        assert!(config.attempt_timeout.is_none());
+
+        let result = run_with_retries::<TaskResult<String>, _, _>(&config, || async {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            Ok::<TaskResult<String>, CanoError>(TaskResult::Single("ok".to_string()))
+        })
+        .await
+        .unwrap();
+        assert_eq!(result, TaskResult::Single("ok".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_attempt_timeout_resets_per_attempt() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // First attempt sleeps long enough to trip the timeout; second attempt
+        // returns immediately. Verifies each attempt gets a fresh deadline.
+        let config = TaskConfig::new()
+            .with_fixed_retry(1, Duration::from_millis(1))
+            .with_attempt_timeout(Duration::from_millis(30));
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = Arc::clone(&counter);
+
+        let result = run_with_retries::<TaskResult<String>, _, _>(&config, || {
+            let counter = Arc::clone(&counter_clone);
+            async move {
+                let n = counter.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+                Ok::<TaskResult<String>, CanoError>(TaskResult::Single("ok".to_string()))
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(result, TaskResult::Single("ok".to_string()));
+        assert_eq!(counter.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/cano/src/workflow.rs
+++ b/cano/src/workflow.rs
@@ -74,12 +74,26 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::hash::Hash;
+use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
+
+use futures_util::FutureExt;
 
 use crate::error::CanoError;
 use crate::resource::Resources;
 use crate::task::{Task, TaskResult};
+
+/// Best-effort extraction of a human-readable message from a panic payload.
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}
 
 #[cfg(feature = "tracing")]
 use tracing::{Span, debug, info, info_span, warn};
@@ -211,6 +225,13 @@ pub struct JoinConfig<TState> {
     pub timeout: Option<Duration>,
     /// State to transition to after join condition is met
     pub join_state: TState,
+    /// Optional bulkhead: maximum number of split tasks allowed to run
+    /// concurrently. When `None` (default) all tasks run as soon as the
+    /// runtime can schedule them. When `Some(n)`, a `tokio::sync::Semaphore`
+    /// with `n` permits gates each task body, so excess tasks queue until
+    /// a permit is free. `Some(0)` is rejected at execution time with
+    /// [`CanoError::Configuration`].
+    pub bulkhead: Option<usize>,
 }
 
 impl<TState> JoinConfig<TState>
@@ -223,6 +244,7 @@ where
             strategy,
             timeout: None,
             join_state,
+            bulkhead: None,
         }
     }
 
@@ -235,6 +257,13 @@ where
     /// Set the state to transition to after the join condition is met
     pub fn with_join_state(mut self, state: TState) -> Self {
         self.join_state = state;
+        self
+    }
+
+    /// Cap concurrent split task execution at `n`. `0` is rejected when the
+    /// split runs.
+    pub fn with_bulkhead(mut self, n: usize) -> Self {
+        self.bulkhead = Some(n);
         self
     }
 }
@@ -629,10 +658,14 @@ where
             tracing::Span::none()
         };
 
-        // Use cached config (captured at registration), don't recompute.
-        #[cfg(feature = "tracing")]
-        let result = {
-            let _enter = task_span.enter();
+        // Wrap the retry-driving future in `catch_unwind` so a panic inside
+        // the task body becomes a `CanoError::TaskExecution` instead of
+        // unwinding through the workflow loop and aborting the runtime
+        // worker. Splits already isolate panics through tokio's `JoinSet`
+        // (a panicked split task surfaces as a `JoinError` to
+        // `collect_results`), so panic safety is added only on the single
+        // path here.
+        let run_future = async {
             run_with_retries(&config, || {
                 let task_clone = task.clone();
                 let resources_clone = Arc::clone(&self.resources);
@@ -641,13 +674,27 @@ where
             .await
         };
 
+        #[cfg(feature = "tracing")]
+        let unwind_result = {
+            let _enter = task_span.enter();
+            AssertUnwindSafe(run_future).catch_unwind().await
+        };
+
         #[cfg(not(feature = "tracing"))]
-        let result = run_with_retries(&config, || {
-            let task_clone = task.clone();
-            let resources_clone = Arc::clone(&self.resources);
-            async move { task_clone.run(&*resources_clone).await }
-        })
-        .await;
+        let unwind_result = AssertUnwindSafe(run_future).catch_unwind().await;
+
+        let result = match unwind_result {
+            Ok(inner) => inner,
+            Err(payload) => {
+                // Forward the inner trait object so `downcast_ref` inspects
+                // the actual panic payload type rather than the surrounding
+                // `Box<dyn Any>`.
+                let payload_str = panic_payload_message(&*payload);
+                #[cfg(feature = "tracing")]
+                tracing::error!(panic = %payload_str, "Single task panicked");
+                Err(CanoError::task_execution(format!("panic: {payload_str}")))
+            }
+        };
 
         match result? {
             TaskResult::Single(next_state) => {
@@ -692,6 +739,17 @@ where
                 "Percentage strategy requires a value in (0.0, 1.0], got {p}"
             )));
         }
+        if let Some(0) = join_config.bulkhead {
+            return Err(CanoError::configuration(
+                "bulkhead requires a positive permit count, got 0",
+            ));
+        }
+
+        // Optional bulkhead: gate task bodies on a shared semaphore so at
+        // most `n` split tasks execute concurrently.
+        let bulkhead = join_config
+            .bulkhead
+            .map(|n| Arc::new(tokio::sync::Semaphore::new(n)));
 
         let mut join_set: tokio::task::JoinSet<(usize, Result<TaskResult<TState>, CanoError>)> =
             tokio::task::JoinSet::new();
@@ -703,6 +761,7 @@ where
             // Use cached config from registration time, not task.config().
             let config = Arc::clone(&configs[idx]);
             let resources_clone = Arc::clone(&resources);
+            let bulkhead_clone = bulkhead.clone();
 
             #[cfg(feature = "tracing")]
             let task_span = if tracing::enabled!(tracing::Level::INFO) {
@@ -717,6 +776,25 @@ where
 
                 #[cfg(feature = "tracing")]
                 debug!(task_id = idx, "Executing split task");
+
+                // Hold the permit (if any) until this future returns. The
+                // semaphore is never closed here, so `acquire_owned` only
+                // fails if it has been closed elsewhere — treat that as a
+                // task-execution error rather than panicking.
+                let _permit = match bulkhead_clone {
+                    Some(sem) => match sem.acquire_owned().await {
+                        Ok(p) => Some(p),
+                        Err(e) => {
+                            return (
+                                idx,
+                                Err(CanoError::task_execution(format!(
+                                    "bulkhead semaphore closed: {e}"
+                                ))),
+                            );
+                        }
+                    },
+                    None => None,
+                };
 
                 let result = run_with_retries(&config, || {
                     let t = task.clone();
@@ -2014,5 +2092,144 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result, TestState::Complete);
+    }
+
+    // ------------------------------------------------------------------
+    // Resilience primitives: panic safety + bulkhead
+    // ------------------------------------------------------------------
+
+    struct PanickingTask;
+
+    #[task]
+    impl Task<TestState> for PanickingTask {
+        fn config(&self) -> crate::task::TaskConfig {
+            crate::task::TaskConfig::minimal()
+        }
+
+        async fn run_bare(&self) -> Result<TaskResult<TestState>, CanoError> {
+            panic!("boom");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_single_task_panic_caught() {
+        let workflow = Workflow::bare()
+            .register(TestState::Start, PanickingTask)
+            .add_exit_state(TestState::Complete);
+
+        let err = workflow
+            .orchestrate(TestState::Start)
+            .await
+            .expect_err("panic must surface as Err");
+        match err {
+            CanoError::TaskExecution(msg) => {
+                assert!(msg.contains("panic"), "expected 'panic' in: {msg}");
+                assert!(msg.contains("boom"), "expected 'boom' in: {msg}");
+            }
+            other => panic!("expected TaskExecution, got {other:?}"),
+        }
+    }
+
+    #[derive(Clone)]
+    struct ConcurrencyProbe {
+        live: Arc<std::sync::atomic::AtomicUsize>,
+        max: Arc<std::sync::atomic::AtomicUsize>,
+        sleep: Duration,
+    }
+
+    #[task]
+    impl Task<TestState> for ConcurrencyProbe {
+        fn config(&self) -> crate::task::TaskConfig {
+            crate::task::TaskConfig::minimal()
+        }
+
+        async fn run_bare(&self) -> Result<TaskResult<TestState>, CanoError> {
+            let now = self.live.fetch_add(1, Ordering::SeqCst) + 1;
+            // Update peak via a CAS loop.
+            let mut peak = self.max.load(Ordering::SeqCst);
+            while now > peak {
+                match self
+                    .max
+                    .compare_exchange(peak, now, Ordering::SeqCst, Ordering::SeqCst)
+                {
+                    Ok(_) => break,
+                    Err(actual) => peak = actual,
+                }
+            }
+            tokio::time::sleep(self.sleep).await;
+            self.live.fetch_sub(1, Ordering::SeqCst);
+            Ok(TaskResult::Single(TestState::Complete))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_split_bulkhead_caps_concurrency() {
+        let live = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let max = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let tasks: Vec<ConcurrencyProbe> = (0..10)
+            .map(|_| ConcurrencyProbe {
+                live: Arc::clone(&live),
+                max: Arc::clone(&max),
+                sleep: Duration::from_millis(50),
+            })
+            .collect();
+
+        let join_config = JoinConfig::new(JoinStrategy::All, TestState::Complete).with_bulkhead(2);
+        let workflow = Workflow::bare()
+            .register_split(TestState::Start, tasks, join_config)
+            .add_exit_state(TestState::Complete);
+
+        let result = workflow.orchestrate(TestState::Start).await.unwrap();
+        assert_eq!(result, TestState::Complete);
+        let observed = max.load(Ordering::SeqCst);
+        assert!(
+            observed <= 2,
+            "bulkhead breached: observed concurrency = {observed}"
+        );
+        assert!(observed >= 1, "no tasks ran?");
+    }
+
+    #[tokio::test]
+    async fn test_split_bulkhead_zero_rejected() {
+        let tasks = vec![SimpleTask::new(TestState::Complete)];
+        let join_config = JoinConfig::new(JoinStrategy::All, TestState::Complete).with_bulkhead(0);
+        let workflow = Workflow::bare()
+            .register_split(TestState::Start, tasks, join_config)
+            .add_exit_state(TestState::Complete);
+
+        let err = workflow
+            .orchestrate(TestState::Start)
+            .await
+            .expect_err("bulkhead=0 must error");
+        assert!(matches!(err, CanoError::Configuration(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn test_attempt_timeout_via_workflow_retries() {
+        // Sanity check: per-attempt timeout integrates with the workflow's
+        // single-task path through TaskConfig.
+        struct SlowTask;
+
+        #[task]
+        impl Task<TestState> for SlowTask {
+            fn config(&self) -> crate::task::TaskConfig {
+                crate::task::TaskConfig::new()
+                    .with_fixed_retry(1, Duration::from_millis(1))
+                    .with_attempt_timeout(Duration::from_millis(20))
+            }
+
+            async fn run_bare(&self) -> Result<TaskResult<TestState>, CanoError> {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                Ok(TaskResult::Single(TestState::Complete))
+            }
+        }
+
+        let err = Workflow::bare()
+            .register(TestState::Start, SlowTask)
+            .add_exit_state(TestState::Complete)
+            .orchestrate(TestState::Start)
+            .await
+            .expect_err("expected attempt timeout to exhaust retries");
+        assert!(matches!(err, CanoError::RetryExhausted(_)), "got {err:?}");
     }
 }

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -7,7 +7,7 @@ build_search_index = false
 generate_feeds = false
 
 [extra]
-version = "0.10.2"
+version = "0.10.3"
 github_url = "https://github.com/nassor/cano"
 crates_url = "https://crates.io/crates/cano"
 docsrs_url = "https://docs.rs/cano"

--- a/docs/content/nodes.md
+++ b/docs/content/nodes.md
@@ -28,7 +28,7 @@ so all three phases must be idempotent. <code>prep</code> and <code>post</code> 
 <div class="page-toc-title">On this page</div>
 <ol>
 <li><a href="#three-phases">The Three Phases</a></li>
-<li><a href="#quick-start">Quick Start with <code>#[node(state = ...)]</code></a></li>
+<li><a href="#quick-start">Quick Start with Nodes</a></li>
 <li><a href="#implementing">Implementing a Node (Explicit Form)</a></li>
 <li><a href="#nodes-vs-tasks">Nodes vs Tasks</a></li>
 <li><a href="#patterns">Real-World Node Patterns</a></li>
@@ -620,6 +620,11 @@ let workflow = Workflow::new(Resources::new().insert("store", store.clone()))
 <td>Rate-limited APIs</td>
 <td>External API calls</td>
 </tr>
+<tr>
+<td><code>with_attempt_timeout(d)</code></td>
+<td>Bound each prep&rarr;exec&rarr;post attempt</td>
+<td>Slow downstreams, hung connections</td>
+</tr>
 </tbody>
 </table>
 
@@ -629,6 +634,16 @@ let workflow = Workflow::new(Resources::new().insert("store", store.clone()))
 On any phase failure, the entire <code>prep</code> &rarr; <code>exec</code> &rarr; <code>post</code> pipeline
 restarts from the beginning. All three phases must be idempotent — side effects in <code>prep</code> or
 <code>exec</code> (e.g. writing to an external system) will be repeated on every retry attempt.
+</p>
+</div>
+
+<div class="callout callout-info">
+<div class="callout-label">Per-attempt timeout</div>
+<p>
+Nodes share <code>TaskConfig</code> with tasks, so <code>.with_attempt_timeout(d)</code> applies to the
+full <code>prep</code> &rarr; <code>exec</code> &rarr; <code>post</code> attempt. If the deadline elapses,
+the in-flight phase is dropped, a <code>CanoError::Timeout</code> is fed into the retry loop, and the
+configured <code>RetryMode</code> decides whether to restart the pipeline.
 </p>
 </div>
 </div>

--- a/docs/content/resources.md
+++ b/docs/content/resources.md
@@ -39,7 +39,7 @@ for the <code>run</code> / <code>prep</code> / <code>post</code> signatures that
 <nav class="page-toc" aria-label="Table of contents">
 <div class="page-toc-title">On this page</div>
 <ol>
-<li><a href="#derive-macros">Derive Macros: <code>#[derive(Resource)]</code> and <code>#[derive(FromResources)]</code></a></li>
+<li><a href="#derive-macros">Derive Macros for Resources</a></li>
 <li><a href="#resource-trait">The Resource Trait</a></li>
 <li><a href="#resources-container">Resources Container</a></li>
 <li><a href="#key-types">Key Types: String vs Enum</a></li>

--- a/docs/content/task.md
+++ b/docs/content/task.md
@@ -167,6 +167,27 @@ T-->>W: Success ✓
 <pre><code class="language-rust">TaskConfig::minimal()</code></pre>
 </div>
 </div>
+<div class="card">
+<h3>Per-Attempt Timeout</h3>
+<p>Bound each attempt with a fresh deadline. Composes with any retry mode.</p>
+<div class="code-block">
+<span class="code-block-label">Attempt timeout config</span>
+<pre><code class="language-rust">TaskConfig::default()
+    .with_exponential_retry(3)
+    .with_attempt_timeout(Duration::from_secs(2))</code></pre>
+</div>
+</div>
+</div>
+
+<div class="callout callout-info">
+<div class="callout-label">How attempt timeouts compose with retries</div>
+<p>
+When <code>attempt_timeout</code> is set, each attempt inside <code>run_with_retries</code> is wrapped in
+<code>tokio::time::timeout</code>. An expired attempt produces a <code>CanoError::Timeout</code>, which is
+fed through the same retry path as any other failure — so the configured <code>RetryMode</code> decides
+whether to retry. The deadline resets on every attempt, and retry exhaustion still surfaces as
+<code>CanoError::RetryExhausted</code> wrapping the underlying timeout context.
+</p>
 </div>
 
 <h3>Real-World Example: API Client with Retry</h3>

--- a/docs/content/workflows.md
+++ b/docs/content/workflows.md
@@ -204,9 +204,19 @@ during execution. Understanding these errors helps you build robust error recove
 <td>Add <code>.with_timeout(duration)</code> to <code>JoinConfig</code></td>
 </tr>
 <tr>
+<td><code>CanoError::Timeout</code></td>
+<td>Per-attempt timeout from <code>TaskConfig::attempt_timeout</code> elapsed</td>
+<td>Increase <code>with_attempt_timeout()</code> or speed up the task; combine with a <code>RetryMode</code> if transient</td>
+</tr>
+<tr>
 <td><code>CanoError::RetryExhausted</code></td>
 <td>All retry attempts exhausted by a Node</td>
 <td>Increase retry count or fix the underlying transient failure</td>
+</tr>
+<tr>
+<td><code>CanoError::TaskExecution</code></td>
+<td>Single task panicked (message is prefixed with <code>"panic:"</code>)</td>
+<td>Inspect the panic payload in the message; fix the underlying invariant in the task body</td>
 </tr>
 <tr>
 <td><code>CanoError::*</code></td>
@@ -216,10 +226,21 @@ during execution. Understanding these errors helps you build robust error recove
 </tbody>
 </table>
 
+<div class="callout callout-info">
+<div class="callout-label">Panic safety</div>
+<p>
+Single-task execution is wrapped in <code>catch_unwind</code>: a panicking task surfaces as
+<code>CanoError::TaskExecution("panic: …")</code> rather than aborting the workflow. Split tasks are
+already isolated by <code>tokio::task::JoinSet</code>, so panics there propagate as task failures
+through the join strategy.
+</p>
+</div>
+
 <pre><code class="language-rust">match workflow.orchestrate(State::Start).await {
     Ok(final_state) => println!("Completed: {:?}", final_state),
     Err(CanoError::Workflow(msg)) => eprintln!("Workflow error: {}", msg),
     Err(CanoError::Configuration(msg)) => eprintln!("Config error: {}", msg),
+    Err(CanoError::Timeout(msg)) => eprintln!("Attempt timed out: {}", msg),
     Err(CanoError::RetryExhausted(msg)) => eprintln!("Retries exhausted: {}", msg),
     Err(e) => eprintln!("Task error: {}", e),
 }</code></pre>
@@ -280,6 +301,30 @@ E -->|Failed/Timeout| G[Error State]
 <p>Accept whatever completes before <strong>timeout</strong> expires. Requires <code>.with_timeout()</code>.</p>
 <pre><code class="language-rust">JoinStrategy::PartialTimeout</code></pre>
 </div>
+</div>
+
+<h3 id="bulkhead"><a href="#bulkhead" class="anchor-link" aria-hidden="true">#</a>Bounding Concurrency with a Bulkhead</h3>
+<p>
+A split fans out as many tasks as the runtime can schedule. When you need to cap concurrent in-flight
+work — to bound resource use, protect a downstream service, or stabilise tail latency — set a
+<strong>bulkhead</strong> on the <code>JoinConfig</code>. Internally this gates each spawned task body on
+a shared <code>tokio::sync::Semaphore</code>; excess tasks queue until a permit is free, but the join
+strategy still applies once results come in.
+</p>
+
+<div class="code-block">
+<span class="code-block-label">Bulkhead config</span>
+<pre><code class="language-rust">let join_config = JoinConfig::new(JoinStrategy::All, State::Aggregate)
+    .with_bulkhead(4); // at most 4 split tasks run at once</code></pre>
+</div>
+
+<div class="callout callout-warning">
+<div class="callout-label">Validation</div>
+<p>
+<code>with_bulkhead(0)</code> is rejected at execution time with <code>CanoError::Configuration</code>.
+Leave the bulkhead unset (<code>None</code>) for unbounded concurrency. Bulkheads compose with
+<code>PartialTimeout</code> and any other join strategy.
+</p>
 </div>
 
 <h3 id="complete-example"><a href="#complete-example" class="anchor-link" aria-hidden="true">#</a>Complete Example</h3>

--- a/docs/static/styles.css
+++ b/docs/static/styles.css
@@ -65,7 +65,7 @@
     /* Layout */
     --nav-height: 60px;
     --sidebar-width: 272px;
-    --content-max-width: 900px;
+    --content-max-width: 1600px;
 
     /* Border radius */
     --radius-sm: 6px;
@@ -312,6 +312,7 @@ img {
 
 .content-wrapper {
     max-width: var(--content-max-width);
+    width: 100%;
 }
 
 /* --------------------------------------------------------------------------
@@ -1917,5 +1918,12 @@ code {
 @media (min-width: 1400px) {
     .main-content {
         padding: var(--space-16) var(--space-20);
+    }
+}
+
+/* Ultrawide displays */
+@media (min-width: 1800px) {
+    .main-content {
+        padding: var(--space-16) var(--space-24);
     }
 }


### PR DESCRIPTION
- Added `Timeout` variant to `CanoError` for bounded operation deadline exceedance.
- Introduced `attempt_timeout` in `TaskConfig` to wrap attempts in `tokio::time::timeout`.
- Updated documentation to reflect new timeout features and their integration with retries.
- Improved panic safety in workflows by catching panics and returning `CanoError::TaskExecution`.
- Added tests for timeout behavior and bulkhead concurrency limits.

Update the lib to 0.10.3