### PR TITLE
Workflow versioning for checkpoint rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cano"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "axum",
  "cano-macros",
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "cano-e2e"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "cano",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "cano-macros"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cano",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["cano", "cano-macros", "cano-e2e"]
 default-members = ["cano", "cano-macros"]
 
 [workspace.package]
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 rust-version = "1.89.0"
 license = "MIT OR Apache-2.0"

--- a/cano-e2e/src/lib.rs
+++ b/cano-e2e/src/lib.rs
@@ -78,14 +78,17 @@ async fn migrate(client: &Client) -> anyhow::Result<()> {
     client
         .batch_execute(
             "CREATE TABLE IF NOT EXISTS cano_checkpoints (
-                 workflow_id text     NOT NULL,
-                 sequence    bigint   NOT NULL,
-                 state       text     NOT NULL,
-                 task_id     text     NOT NULL,
-                 output_blob bytea,
-                 kind        smallint NOT NULL DEFAULT 0,
+                 workflow_id      text     NOT NULL,
+                 sequence         bigint   NOT NULL,
+                 state            text     NOT NULL,
+                 task_id          text     NOT NULL,
+                 output_blob      bytea,
+                 kind             smallint NOT NULL DEFAULT 0,
+                 workflow_version bigint   NOT NULL DEFAULT 0,
                  PRIMARY KEY (workflow_id, sequence)
              );
+             ALTER TABLE cano_checkpoints
+                 ADD COLUMN IF NOT EXISTS workflow_version bigint NOT NULL DEFAULT 0;
              CREATE TABLE IF NOT EXISTS ledger (
                  workflow_id text   NOT NULL,
                  account     text   NOT NULL,
@@ -138,12 +141,13 @@ impl CheckpointStore for PostgresCheckpointStore {
     async fn append(&self, workflow_id: &str, row: CheckpointRow) -> Result<(), CanoError> {
         let seq = row.sequence as i64;
         let kind = row_kind_to_db(&row.kind);
+        let workflow_version = row.workflow_version as i64;
         let res = self
             .client
             .execute(
                 "INSERT INTO cano_checkpoints \
-                     (workflow_id, sequence, state, task_id, output_blob, kind) \
-                 VALUES ($1, $2, $3, $4, $5, $6)",
+                     (workflow_id, sequence, state, task_id, output_blob, kind, workflow_version) \
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)",
                 &[
                     &workflow_id,
                     &seq,
@@ -151,6 +155,7 @@ impl CheckpointStore for PostgresCheckpointStore {
                     &row.task_id,
                     &row.output_blob,
                     &kind,
+                    &workflow_version,
                 ],
             )
             .await;
@@ -169,26 +174,32 @@ impl CheckpointStore for PostgresCheckpointStore {
         let rows = self
             .client
             .query(
-                "SELECT sequence, state, task_id, output_blob, kind FROM cano_checkpoints
-                 WHERE workflow_id = $1 ORDER BY sequence ASC",
+                "SELECT sequence, state, task_id, output_blob, kind, workflow_version \
+                 FROM cano_checkpoints WHERE workflow_id = $1 ORDER BY sequence ASC",
                 &[&workflow_id],
             )
             .await
             .map_err(|e| CanoError::checkpoint_store(format!("load_run: {e}")))?;
-        Ok(rows
-            .iter()
+        rows.iter()
             .map(|r| {
                 let seq: i64 = r.get(0);
                 let kind_int: i16 = r.get(4);
-                CheckpointRow {
+                let workflow_version_i64: i64 = r.get(5);
+                let workflow_version: u32 = workflow_version_i64.try_into().map_err(|_| {
+                    CanoError::checkpoint_store(format!(
+                        "workflow_version {workflow_version_i64} out of u32 range"
+                    ))
+                })?;
+                Ok(CheckpointRow {
                     sequence: seq as u64,
                     state: r.get(1),
                     task_id: r.get(2),
                     output_blob: r.get(3),
                     kind: row_kind_from_db(kind_int),
-                }
+                    workflow_version,
+                })
             })
-            .collect())
+            .collect()
     }
 
     async fn clear(&self, workflow_id: &str) -> Result<(), CanoError> {

--- a/cano/src/error.rs
+++ b/cano/src/error.rs
@@ -208,6 +208,20 @@ pub enum CanoError {
 
     /// A resource key was inserted twice into the same Resources map
     ResourceDuplicateKey(String),
+
+    /// A persisted checkpoint row's workflow version does not match the
+    /// version configured on this workflow.
+    ///
+    /// Emitted when resuming a checkpointed run whose stored schema version
+    /// differs from what the current workflow expects. The run cannot safely
+    /// continue because the on-disk state was produced by an incompatible
+    /// workflow definition.
+    WorkflowVersionMismatch {
+        /// The version recorded on the persisted checkpoint row.
+        stored: u32,
+        /// The version configured on this workflow.
+        expected: u32,
+    },
 }
 
 impl CanoError {
@@ -277,6 +291,12 @@ impl CanoError {
         CanoError::ResourceDuplicateKey(msg.into())
     }
 
+    /// Create a new workflow-version-mismatch error from the stored and
+    /// expected version numbers.
+    pub fn workflow_version_mismatch(stored: u32, expected: u32) -> Self {
+        CanoError::WorkflowVersionMismatch { stored, expected }
+    }
+
     /// Get the error message as a string slice
     pub fn message(&self) -> &str {
         match self {
@@ -295,6 +315,9 @@ impl CanoError {
             CanoError::ResourceNotFound(msg) => msg,
             CanoError::ResourceTypeMismatch(msg) => msg,
             CanoError::ResourceDuplicateKey(msg) => msg,
+            CanoError::WorkflowVersionMismatch { .. } => {
+                "workflow version mismatch (stored vs expected)"
+            }
         }
     }
 
@@ -314,6 +337,7 @@ impl CanoError {
             CanoError::ResourceNotFound(_) => "resource_not_found",
             CanoError::ResourceTypeMismatch(_) => "resource_type_mismatch",
             CanoError::ResourceDuplicateKey(_) => "resource_duplicate_key",
+            CanoError::WorkflowVersionMismatch { .. } => "workflow_version_mismatch",
         }
     }
 }
@@ -344,6 +368,10 @@ impl std::fmt::Display for CanoError {
             CanoError::ResourceNotFound(msg) => write!(f, "Resource not found: {msg}"),
             CanoError::ResourceTypeMismatch(msg) => write!(f, "Resource type mismatch: {msg}"),
             CanoError::ResourceDuplicateKey(msg) => write!(f, "Resource duplicate key: {msg}"),
+            CanoError::WorkflowVersionMismatch { stored, expected } => write!(
+                f,
+                "Workflow version mismatch: stored={stored}, expected={expected}"
+            ),
         }
     }
 }
@@ -369,6 +397,16 @@ impl PartialEq for CanoError {
             (CanoError::ResourceNotFound(a), CanoError::ResourceNotFound(b)) => a == b,
             (CanoError::ResourceTypeMismatch(a), CanoError::ResourceTypeMismatch(b)) => a == b,
             (CanoError::ResourceDuplicateKey(a), CanoError::ResourceDuplicateKey(b)) => a == b,
+            (
+                CanoError::WorkflowVersionMismatch {
+                    stored: s1,
+                    expected: e1,
+                },
+                CanoError::WorkflowVersionMismatch {
+                    stored: s2,
+                    expected: e2,
+                },
+            ) => s1 == s2 && e1 == e2,
             _ => false,
         }
     }
@@ -686,5 +724,25 @@ mod tests {
         let mismatch = CanoError::resource_type_mismatch("key");
         // Same message, different variants — must not be equal
         assert_ne!(not_found, mismatch);
+    }
+
+    #[test]
+    fn test_workflow_version_mismatch_constructor_category_and_display() {
+        let err = CanoError::workflow_version_mismatch(1, 2);
+        assert_eq!(err.category(), "workflow_version_mismatch");
+        assert!(err.message().contains("stored"));
+        let shown = format!("{err}");
+        assert!(shown.contains("Workflow version mismatch"));
+        assert!(shown.contains("stored=1"));
+        assert!(shown.contains("expected=2"));
+    }
+
+    #[test]
+    fn test_workflow_version_mismatch_partial_eq() {
+        let a = CanoError::workflow_version_mismatch(0, 1);
+        let b = CanoError::workflow_version_mismatch(0, 1);
+        assert_eq!(a, b);
+        let c = CanoError::workflow_version_mismatch(1, 2);
+        assert_ne!(a, c);
     }
 }

--- a/cano/src/lib.rs
+++ b/cano/src/lib.rs
@@ -157,6 +157,13 @@
 //! `RedbCheckpointStore` is a ready-made embedded, ACID implementation. Workflows
 //! without a checkpoint store pay nothing. See the `workflow_recovery` example.
 //!
+//! [`Workflow::with_workflow_version`] stamps a `u32` version onto every appended
+//! [`CheckpointRow`] (default `0`); [`Workflow::resume_from`] then refuses to replay a
+//! checkpoint whose stored version differs, returning
+//! [`CanoError::WorkflowVersionMismatch`]. Bump it when the FSM shape changes between
+//! deploys (added/removed states, cursor schema, compensation output layout) to avoid
+//! silently resuming onto an incompatible workflow definition.
+//!
 //! ### Sagas & Compensation
 //!
 //! For steps that mutate external systems, implement [`CompensatableTask`] (its `run`

--- a/cano/src/recovery.rs
+++ b/cano/src/recovery.rs
@@ -19,6 +19,13 @@
 //! - **Optional default.** With the `recovery` feature enabled, [`RedbCheckpointStore`]
 //!   provides an embedded, ACID, daemon-free implementation backed by
 //!   [`redb`](https://docs.rs/redb). The default build pulls in no extra dependencies.
+//! - **Versioned.** Each [`CheckpointRow`] carries a user-stamped
+//!   [`workflow_version`](CheckpointRow::workflow_version) tag (default `0`); set it via
+//!   [`Workflow::with_workflow_version`](crate::workflow::Workflow::with_workflow_version)
+//!   and [`resume_from`](crate::workflow::Workflow::resume_from) will reject any row
+//!   whose stored version disagrees. Rows written by builds that predate this field
+//!   decode as `workflow_version = 0`, so existing checkpoint databases keep replaying
+//!   under a workflow that hasn't opted in to a non-zero version.
 //!
 //! ## Example
 //!
@@ -112,6 +119,9 @@ pub struct CheckpointRow {
     /// Why this row was written; drives how [`resume_from`](crate::workflow::Workflow::resume_from)
     /// routes the row during replay.
     pub kind: RowKind,
+    /// User-declared workflow version stamped at append time. Default `0` for rows
+    /// written by a workflow that did not call `Workflow::with_workflow_version`.
+    pub workflow_version: u32,
 }
 
 impl CheckpointRow {
@@ -123,6 +133,7 @@ impl CheckpointRow {
             task_id: task_id.into(),
             output_blob: None,
             kind: RowKind::StateEntry,
+            workflow_version: 0,
         }
     }
 
@@ -145,6 +156,14 @@ impl CheckpointRow {
     pub fn with_cursor(mut self, cursor_blob: Vec<u8>) -> Self {
         self.output_blob = Some(cursor_blob);
         self.kind = RowKind::StepCursor;
+        self
+    }
+
+    /// Stamp this row with the workflow's user-declared version. Chained with `new`
+    /// (and optionally `with_output` / `with_cursor`) at append time so each row carries
+    /// the version of the workflow definition that produced it.
+    pub fn with_workflow_version(mut self, version: u32) -> Self {
+        self.workflow_version = version;
         self
     }
 }
@@ -291,6 +310,18 @@ mod tests {
     async fn load_run_unknown_id_is_empty() {
         let store = InMemoryStore::default();
         assert!(store.load_run("nope").await.unwrap().is_empty());
+    }
+
+    #[test]
+    fn checkpoint_row_default_workflow_version_is_zero() {
+        let row = CheckpointRow::new(0, "Start", "task");
+        assert_eq!(row.workflow_version, 0);
+    }
+
+    #[test]
+    fn checkpoint_row_with_workflow_version_sets_field() {
+        let row = CheckpointRow::new(0, "Start", "task").with_workflow_version(42);
+        assert_eq!(row.workflow_version, 42);
     }
 
     #[tokio::test]

--- a/cano/src/recovery/redb.rs
+++ b/cano/src/recovery/redb.rs
@@ -35,6 +35,17 @@ struct StoredRow {
     task_id: String,
     output_blob: Option<Vec<u8>>,
     kind: super::RowKind,
+    workflow_version: u32,
+}
+
+/// Pre-versioning on-disk shape. Kept solely as a decode fallback so existing
+/// redb databases written before `workflow_version` was added still load.
+#[derive(serde::Deserialize)]
+struct StoredRowV0 {
+    state: String,
+    task_id: String,
+    output_blob: Option<Vec<u8>>,
+    kind: super::RowKind,
 }
 
 /// The key range covering every row for `workflow_id`, in ascending `sequence` order.
@@ -84,6 +95,7 @@ impl CheckpointStore for RedbCheckpointStore {
             task_id: row.task_id,
             output_blob: row.output_blob,
             kind: row.kind,
+            workflow_version: row.workflow_version,
         };
         let bytes = postcard::to_stdvec(&payload)
             .map_err(|e| CanoError::CheckpointStore(format!("encode checkpoint row: {e}")))?;
@@ -121,16 +133,33 @@ impl CheckpointStore for RedbCheckpointStore {
         for entry in table.range(workflow_range(workflow_id)).map_err(redb_err)? {
             let (key, value) = entry.map_err(redb_err)?;
             let sequence = key.value().1;
-            let payload: StoredRow = postcard::from_bytes(value.value())
-                .map_err(|e| CanoError::CheckpointStore(format!("decode checkpoint row: {e}")))?;
-
-            rows.push(CheckpointRow {
-                sequence,
-                state: payload.state,
-                task_id: payload.task_id,
-                output_blob: payload.output_blob,
-                kind: payload.kind,
-            });
+            let bytes = value.value();
+            let row = match postcard::from_bytes::<StoredRow>(bytes) {
+                Ok(payload) => CheckpointRow {
+                    sequence,
+                    state: payload.state,
+                    task_id: payload.task_id,
+                    output_blob: payload.output_blob,
+                    kind: payload.kind,
+                    workflow_version: payload.workflow_version,
+                },
+                Err(new_err) => match postcard::from_bytes::<StoredRowV0>(bytes) {
+                    Ok(legacy) => CheckpointRow {
+                        sequence,
+                        state: legacy.state,
+                        task_id: legacy.task_id,
+                        output_blob: legacy.output_blob,
+                        kind: legacy.kind,
+                        workflow_version: 0,
+                    },
+                    Err(_) => {
+                        return Err(CanoError::CheckpointStore(format!(
+                            "decode checkpoint row: {new_err}"
+                        )));
+                    }
+                },
+            };
+            rows.push(row);
         }
         Ok(rows)
     }
@@ -476,5 +505,66 @@ mod tests {
         assert_eq!(rows[2].state, "C");
         assert_eq!(rows[2].kind, super::super::RowKind::StepCursor);
         assert_eq!(rows[2].output_blob.as_deref(), Some(&[4u8, 5][..]));
+    }
+
+    // -- workflow_version persistence ---------------------------------------
+
+    #[tokio::test]
+    async fn workflow_version_roundtrips_through_redb_store() {
+        let dir = tempdir().unwrap();
+        let store = RedbCheckpointStore::new(dir.path().join("ckpt.redb")).unwrap();
+        let row = CheckpointRow::new(0, "Start", "task").with_workflow_version(7);
+        store.append("wf-roundtrip", row).await.unwrap();
+        let loaded = store.load_run("wf-roundtrip").await.unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].workflow_version, 7);
+    }
+
+    #[tokio::test]
+    async fn legacy_stored_row_decodes_as_workflow_version_zero() {
+        // Mirror of the pre-versioning on-disk shape so the test can *write*
+        // a legacy blob. The production `StoredRowV0` is Deserialize-only by
+        // design (it only ever has to read old data), so we define a local
+        // serializable twin here with the exact same field order.
+        #[derive(serde::Serialize)]
+        struct LegacyWrite {
+            state: String,
+            task_id: String,
+            output_blob: Option<Vec<u8>>,
+            kind: super::super::RowKind,
+        }
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("ckpt.redb");
+
+        // Write a V0-shape blob (no workflow_version field) directly into the
+        // table to simulate a database written before versioning existed.
+        {
+            let db = Database::create(&path).unwrap();
+            let tx = db.begin_write().unwrap();
+            {
+                let mut table = tx.open_table(CHECKPOINTS).unwrap();
+                let legacy = LegacyWrite {
+                    state: "Start".into(),
+                    task_id: "task".into(),
+                    output_blob: None,
+                    kind: super::super::RowKind::StateEntry,
+                };
+                let bytes = postcard::to_stdvec(&legacy).unwrap();
+                table.insert(("wf-legacy", 0u64), bytes.as_slice()).unwrap();
+            }
+            tx.commit().unwrap();
+        }
+
+        // Now open the store the normal way and confirm the legacy row decodes
+        // with workflow_version defaulted to 0.
+        let store = RedbCheckpointStore::new(&path).unwrap();
+        let rows = store.load_run("wf-legacy").await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].sequence, 0);
+        assert_eq!(rows[0].state, "Start");
+        assert_eq!(rows[0].task_id, "task");
+        assert_eq!(rows[0].kind, super::super::RowKind::StateEntry);
+        assert_eq!(rows[0].workflow_version, 0);
     }
 }

--- a/cano/src/workflow.rs
+++ b/cano/src/workflow.rs
@@ -165,6 +165,11 @@ where
     /// is set on that path (the first checkpoint write errors if it's missing);
     /// [`resume_from`](Self::resume_from) takes the id explicitly.
     workflow_id: Option<String>,
+    /// Version stamped onto every [`CheckpointRow`](crate::recovery::CheckpointRow) the
+    /// engine appends, and checked against the persisted version when
+    /// [`resume_from`](Self::resume_from) replays a run. Defaults to `0`; set via
+    /// [`with_workflow_version`](Self::with_workflow_version).
+    workflow_version: u32,
     /// Optional tracing span
     #[cfg(feature = "tracing")]
     tracing_span: Option<Span>,
@@ -187,6 +192,7 @@ where
             compensators: HashMap::new(),
             checkpoint_store: None,
             workflow_id: None,
+            workflow_version: 0,
             #[cfg(feature = "tracing")]
             tracing_span: None,
         }
@@ -466,6 +472,42 @@ where
         self
     }
 
+    /// Stamp this version onto every [`CheckpointRow`](crate::recovery::CheckpointRow)
+    /// the engine appends, and reject [`resume_from`](Self::resume_from) when the
+    /// persisted version differs. Defaults to `0`.
+    ///
+    /// Bump the version whenever the FSM shape changes between deploys (added or
+    /// removed states, cursor schema, compensation output layout) so a resumed run
+    /// can't silently land on an incompatible workflow definition — the mismatch
+    /// surfaces as [`CanoError::WorkflowVersionMismatch`](crate::CanoError::WorkflowVersionMismatch).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cano::prelude::*;
+    ///
+    /// # #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    /// # enum State { Start, Done }
+    /// # #[derive(Clone)]
+    /// # struct MyTask;
+    /// # #[task]
+    /// # impl Task<State> for MyTask {
+    /// #     async fn run_bare(&self) -> Result<TaskResult<State>, CanoError> {
+    /// #         Ok(TaskResult::Single(State::Done))
+    /// #     }
+    /// # }
+    /// let workflow = Workflow::bare()
+    ///     .register(State::Start, MyTask)
+    ///     .add_exit_state(State::Done)
+    ///     .with_workflow_version(2);
+    ///
+    /// assert!(workflow.validate().is_ok());
+    /// ```
+    pub fn with_workflow_version(mut self, version: u32) -> Self {
+        self.workflow_version = version;
+        self
+    }
+
     /// Set a tracing span for this workflow (requires "tracing" feature)
     #[cfg(feature = "tracing")]
     pub fn with_tracing_span(mut self, span: Span) -> Self {
@@ -737,6 +779,7 @@ where
             compensators: self.compensators.clone(),
             checkpoint_store: self.checkpoint_store.clone(),
             workflow_id: self.workflow_id.clone(),
+            workflow_version: self.workflow_version,
             #[cfg(feature = "tracing")]
             tracing_span: self.tracing_span.clone(),
         }
@@ -796,6 +839,7 @@ where
             .field("exit_states", &self.exit_states)
             .field("workflow_timeout", &self.workflow_timeout)
             .field("workflow_id", &self.workflow_id)
+            .field("workflow_version", &self.workflow_version)
             .field("checkpoint_store", &self.checkpoint_store.is_some())
             .field(
                 "compensators",

--- a/cano/src/workflow/compensation.rs
+++ b/cano/src/workflow/compensation.rs
@@ -281,6 +281,12 @@ where
                 "no checkpoint rows for workflow id {workflow_id:?}"
             ))
         })?;
+        if last.workflow_version != self.workflow_version {
+            return Err(CanoError::workflow_version_mismatch(
+                last.workflow_version,
+                self.workflow_version,
+            ));
+        }
         let resume_state = self.state_from_label(&last.state).ok_or_else(|| {
             CanoError::workflow(format!(
                 "checkpoint state {:?} is not a registered or exit state of this workflow",
@@ -2264,6 +2270,41 @@ mod tests {
             vec![("A".to_string(), 42u32)],
             "StepCursor row must not become a compensation entry"
         );
+    }
+
+    #[tokio::test]
+    async fn workflow_version_is_stamped_on_every_appended_row() {
+        let store = Arc::new(MemCheckpoints::default());
+        let workflow = Workflow::bare()
+            .register(TestState::Start, SimpleTask::new(TestState::Process))
+            .register(TestState::Process, SimpleTask::new(TestState::Complete))
+            .add_exit_state(TestState::Complete)
+            .with_checkpoint_store(store.clone())
+            .with_workflow_id("ver-run")
+            .with_workflow_version(7);
+        workflow.orchestrate(TestState::Start).await.unwrap();
+        let rows = store.audit_rows("ver-run");
+        assert!(rows.iter().all(|r| r.workflow_version == 7));
+        assert!(!rows.is_empty(), "expected at least one appended row");
+    }
+
+    #[tokio::test]
+    async fn resume_from_rejects_workflow_version_mismatch() {
+        let store = Arc::new(MemCheckpoints::default());
+        store
+            .append(
+                "ver-mismatch",
+                CheckpointRow::new(0, "Start", "").with_workflow_version(1),
+            )
+            .await
+            .unwrap();
+        let workflow = Workflow::bare()
+            .register(TestState::Start, SimpleTask::new(TestState::Complete))
+            .add_exit_state(TestState::Complete)
+            .with_checkpoint_store(store.clone())
+            .with_workflow_version(2);
+        let err = workflow.resume_from("ver-mismatch").await.unwrap_err();
+        assert_eq!(err, CanoError::workflow_version_mismatch(1, 2));
     }
 }
 

--- a/cano/src/workflow/execution.rs
+++ b/cano/src/workflow/execution.rs
@@ -262,7 +262,11 @@ where
                     _ => String::new(),
                 };
                 let append_result = store
-                    .append(wf_id, CheckpointRow::new(sequence, label, task_id))
+                    .append(
+                        wf_id,
+                        CheckpointRow::new(sequence, label, task_id)
+                            .with_workflow_version(self.workflow_version),
+                    )
                     .await;
                 #[cfg(feature = "metrics")]
                 crate::metrics::checkpoint_append(append_result.is_ok());
@@ -348,7 +352,8 @@ where
                             {
                                 let label = state_label.as_deref().unwrap_or_default();
                                 let row = CheckpointRow::new(sequence, label, task_name.clone())
-                                    .with_output(output_blob.clone());
+                                    .with_output(output_blob.clone())
+                                    .with_workflow_version(self.workflow_version);
                                 let comp_append_result = store.append(wf_id, row).await;
                                 #[cfg(feature = "metrics")]
                                 crate::metrics::checkpoint_append(comp_append_result.is_ok());
@@ -592,7 +597,8 @@ where
                         (&self.checkpoint_store, workflow_id.as_deref())
                     {
                         let row = CheckpointRow::new(*sequence, state_label, task_name.as_ref())
-                            .with_cursor(new_cursor_bytes.clone());
+                            .with_cursor(new_cursor_bytes.clone())
+                            .with_workflow_version(self.workflow_version);
                         let cursor_append_result = store.append(wf_id, row).await;
                         #[cfg(feature = "metrics")]
                         crate::metrics::checkpoint_append(cursor_append_result.is_ok());

--- a/cano/tests/recovery_version_compat.rs
+++ b/cano/tests/recovery_version_compat.rs
@@ -1,0 +1,131 @@
+//! Migration-compatibility for redb databases written before `workflow_version`
+//! existed.
+//!
+//! These tests construct a *real* redb file by hand and write rows in the legacy
+//! byte format (no `workflow_version` field), then drive the full
+//! [`Workflow::resume_from`] path through [`RedbCheckpointStore`]:
+//!
+//! 1. A workflow with the default `workflow_version = 0` resumes such a database
+//!    cleanly — the decode fallback in `RedbCheckpointStore` treats the missing
+//!    field as `0`, and the version check passes.
+//! 2. The same database against a workflow that bumped to `with_workflow_version(1)`
+//!    is rejected with [`CanoError::WorkflowVersionMismatch`].
+//!
+//! The unit-level legacy-decode test in `cano/src/recovery/redb.rs` already proves
+//! that the decode path works; these tests are the integration-level safety net
+//! around `resume_from`.
+#![cfg(feature = "recovery")]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use cano::prelude::*;
+use cano::recovery::RowKind;
+use redb::{Database, TableDefinition};
+use tempfile::tempdir;
+
+/// Must mirror the production constant in `cano/src/recovery/redb.rs` byte-for-byte;
+/// the integration test is asserting on-disk binary compatibility, so reach in
+/// through the redb API rather than the public store wrapper.
+const CHECKPOINTS: TableDefinition<(&str, u64), &[u8]> = TableDefinition::new("cano_checkpoints");
+
+/// Pre-versioning on-disk shape (a serializable twin of `StoredRowV0`). Field order
+/// MUST match `cano/src/recovery/redb.rs`'s `StoredRowV0` exactly so postcard emits
+/// the same bytes a real legacy database would contain.
+#[derive(serde::Serialize)]
+struct LegacyWrite {
+    state: String,
+    task_id: String,
+    output_blob: Option<Vec<u8>>,
+    kind: RowKind,
+}
+
+/// Write a single legacy-shape `StateEntry` row for `workflow_id` at sequence 0,
+/// labelled "Start", straight into the redb table.
+fn seed_legacy_row(path: &Path, workflow_id: &str) {
+    let db = Database::create(path).expect("create redb file");
+    let tx = db.begin_write().expect("begin write txn");
+    {
+        let mut table = tx.open_table(CHECKPOINTS).expect("open checkpoints table");
+        let legacy = LegacyWrite {
+            state: "Start".into(),
+            task_id: "legacy-task".into(),
+            output_blob: None,
+            kind: RowKind::StateEntry,
+        };
+        let bytes = postcard::to_stdvec(&legacy).expect("encode legacy row");
+        table
+            .insert((workflow_id, 0u64), bytes.as_slice())
+            .expect("insert legacy row");
+    }
+    tx.commit().expect("commit legacy txn");
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum St {
+    Start,
+    Done,
+}
+
+/// Trivial idempotent task: re-running it on resume just transitions to `Done`.
+#[derive(Clone)]
+struct StartTask;
+
+#[task]
+impl Task<St> for StartTask {
+    async fn run_bare(&self) -> Result<TaskResult<St>, CanoError> {
+        Ok(TaskResult::Single(St::Done))
+    }
+}
+
+#[tokio::test]
+async fn legacy_redb_row_resumes_under_default_workflow_version() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ckpt.redb");
+    let wf_id = "legacy-wf";
+
+    // Pre-populate the redb file with a single legacy-shape row, then drop the
+    // direct database handle so `RedbCheckpointStore::new` can take its own.
+    seed_legacy_row(&path, wf_id);
+
+    let store: Arc<dyn CheckpointStore> =
+        Arc::new(RedbCheckpointStore::new(&path).expect("open redb store over seeded file"));
+
+    // Default workflow_version is 0 — matches the legacy row's defaulted version.
+    let workflow = Workflow::bare()
+        .register(St::Start, StartTask)
+        .add_exit_state(St::Done)
+        .with_checkpoint_store(store);
+
+    let final_state = workflow
+        .resume_from(wf_id)
+        .await
+        .expect("legacy row must resume cleanly under default workflow_version");
+    assert_eq!(final_state, St::Done);
+}
+
+#[tokio::test]
+async fn legacy_redb_row_rejected_when_workflow_version_bumped() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ckpt.redb");
+    let wf_id = "legacy-wf";
+
+    seed_legacy_row(&path, wf_id);
+
+    let store: Arc<dyn CheckpointStore> =
+        Arc::new(RedbCheckpointStore::new(&path).expect("open redb store over seeded file"));
+
+    // Bumping to v1 must surface the stored-vs-expected mismatch as a
+    // WorkflowVersionMismatch error (stored = 0 from legacy fallback, expected = 1).
+    let workflow = Workflow::bare()
+        .register(St::Start, StartTask)
+        .add_exit_state(St::Done)
+        .with_checkpoint_store(store)
+        .with_workflow_version(1);
+
+    let err = workflow
+        .resume_from(wf_id)
+        .await
+        .expect_err("bumped workflow_version must reject the legacy row");
+    assert_eq!(err, CanoError::workflow_version_mismatch(0, 1));
+}

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -7,7 +7,7 @@ build_search_index = false
 generate_feeds = false
 
 [extra]
-version = "0.13.1"
+version = "0.13.2"
 github_url = "https://github.com/nassor/cano"
 crates_url = "https://crates.io/crates/cano"
 docsrs_url = "https://docs.rs/cano"

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -70,7 +70,7 @@ It excels at managing complex lifecycles where state transitions matter:
 <div class="feature-card animate-in">
 <div class="feature-icon" aria-hidden="true">&#128190;</div>
 <h3>Crash Recovery</h3>
-<p>Pluggable <code>CheckpointStore</code> records every state entry; <code>resume_from</code> rehydrates a crashed run. Embedded, ACID <code>RedbCheckpointStore</code> behind the <code>recovery</code> feature.</p>
+<p>Pluggable <code>CheckpointStore</code> records every state entry with an optional <code>workflow_version</code> stamp; <code>resume_from</code> rehydrates a crashed run and refuses checkpoints whose version disagrees with the workflow. Embedded, ACID <code>RedbCheckpointStore</code> behind the <code>recovery</code> feature.</p>
 </div>
 <div class="feature-card animate-in">
 <div class="feature-icon secondary" aria-hidden="true">&#8634;</div>

--- a/docs/content/recovery.md
+++ b/docs/content/recovery.md
@@ -29,6 +29,7 @@ implementation. A workflow with no checkpoint store keeps its zero-overhead beha
 <li><a href="#attaching">Attaching a Checkpoint Store</a></li>
 <li><a href="#what-is-recorded">What Gets Recorded</a></li>
 <li><a href="#resuming">Resuming a Run</a></li>
+<li><a href="#versioning">Workflow Versioning</a></li>
 <li><a href="#idempotency">The Idempotency Contract</a></li>
 <li><a href="#trait">The <code>CheckpointStore</code> Trait</a></li>
 <li><a href="#redb">Built-in: <code>RedbCheckpointStore</code></a></li>
@@ -99,6 +100,7 @@ pub struct CheckpointRow {
     pub task_id: String,          // Task::name() for a single-task state; "" for split / exit
     pub kind: RowKind,            // what this row records — see RowKind
     pub output_blob: Option<Vec<u8>>,  // serialized payload for compensation / stepped cursor (else None)
+    pub workflow_version: u32,    // user-stamped version; see `Workflow::with_workflow_version` (default 0)
 }
 
 #[non_exhaustive]
@@ -173,8 +175,57 @@ assert_eq!(final_state, Step::Done);
 
 <p>
 <code>resume_from</code> errors with <code>CanoError::CheckpointStore</code> when the store fails or
-there are no rows for the id, and with <code>CanoError::Workflow</code> when the recorded state
-label doesn't match any state of <em>this</em> workflow definition.
+there are no rows for the id, with <code>CanoError::Workflow</code> when the recorded state
+label doesn't match any state of <em>this</em> workflow definition, and with
+<code>CanoError::WorkflowVersionMismatch { stored, expected }</code> when the latest row's
+<code>workflow_version</code> disagrees with the version configured on this workflow — see
+<a href="#versioning">Workflow Versioning</a> below.
+</p>
+<hr class="section-divider">
+
+<h2 id="versioning"><a href="#versioning" class="anchor-link" aria-hidden="true">#</a>Workflow Versioning</h2>
+<p>
+When the FSM shape changes between deploys — states added or removed, a cursor schema renamed,
+split branches reordered — a checkpoint written by the old shape can no longer be safely resumed
+under the new shape. Re-entering a state that no longer exists, or feeding the wrong cursor format
+to a <a href="../stepped-task/">SteppedTask</a>, produces silent corruption rather than a clean
+error. <code>Workflow::with_workflow_version(u32)</code> is the opt-in guard against that.
+</p>
+
+```rust
+let workflow = Workflow::new(resources)
+    .register(MyState::Start, StartTask)
+    .register(MyState::Process, ProcessTask)
+    .add_exit_state(MyState::Done)
+    .with_checkpoint_store(checkpoint_store)
+    .with_workflow_id("orders-v2")
+    .with_workflow_version(2);
+```
+
+<p>
+Every appended <code>CheckpointRow</code> is stamped with the configured version (default
+<code>0</code> for workflows that never call the builder). On <code>resume_from</code>, the engine
+compares the highest-sequence row's <code>workflow_version</code> against
+<code>self.workflow_version</code> <em>before</em> resources' <code>setup_all</code> or any FSM entry
+runs. A mismatch returns <code>CanoError::WorkflowVersionMismatch { stored, expected }</code>
+immediately — no task re-runs, no partial side effects.
+</p>
+
+<p>
+<strong>Operator guidance:</strong> bump the version whenever a deploy changes the FSM in a way
+that would make a pre-change checkpoint nonsensical — renamed or removed states, changed
+<a href="../stepped-task/">SteppedTask</a> cursor format, reordered split branches, restructured
+<a href="../saga/">compensation</a> outputs. Leave it alone for behavior-preserving changes:
+retry-policy tweaks, observability additions, internal refactors, new states added <em>after</em>
+the current exit state.
+</p>
+
+<p>
+Workflows that never call <code>with_workflow_version</code> use <code>0</code> on both sides, so
+the equality check is a no-op and behavior is identical to a pre-versioning workflow. Rows written
+by older versions of the library — before <code>workflow_version</code> existed on disk — decode as
+<code>0</code> via a backward-compatibility fallback in <code>RedbCheckpointStore</code>, so
+existing databases resume transparently with no migration step.
 </p>
 <hr class="section-divider">
 
@@ -227,15 +278,16 @@ impl InMemoryStore {
 ```
 
 <p>
-Contract: <code>append</code> durably persists the row — <strong>including its <code>kind</code> and
-<code>output_blob</code></strong> — and must <strong>reject a duplicate <code>(workflow_id, sequence)</code></strong>
+Contract: <code>append</code> durably persists the row — <strong>including its <code>kind</code>,
+<code>output_blob</code>, and <code>workflow_version</code></strong> — and must <strong>reject a duplicate <code>(workflow_id, sequence)</code></strong>
 with an <code>Err</code> rather than overwriting (a collision means two runs share a workflow id;
 <code>RedbCheckpointStore</code> enforces this via its composite key, as does the Postgres impl in
 <code>cano-e2e</code> via its primary key). <code>load_run</code> returns every row ever appended for
 the id, <strong>sorted ascending by <code>sequence</code></strong>, or an empty <code>Vec</code> for
 an unknown id; <code>clear</code> removes a run's rows and must not touch any other id (clearing an
 unknown id is a no-op). The example above stores the whole <code>CheckpointRow</code>, so it carries
-<code>kind</code> for free — a store that maps rows to columns needs a <code>kind</code> column. The
+<code>kind</code> and <code>workflow_version</code> for free — a store that maps rows to columns
+needs columns for both (see <a href="#versioning">Workflow Versioning</a>). The
 engine calls <code>clear</code> automatically when a run reaches an exit state — and after a fully successful
 <a href="../saga/">compensation rollback</a> — so a finished run leaves no recovery log behind
 (it's best-effort: a <code>clear</code> failure is logged, not fatal). Implementations must be

--- a/docs/content/saga.md
+++ b/docs/content/saga.md
@@ -207,6 +207,10 @@ discriminant keeps the two apart.)</li>
 work purely from <code>(res, output)</code>, and the workflow definition (state labels +
 <code>register_with_compensation</code> calls) must match across processes — the same constraint that
 already applies to resume itself.</li>
+<li>If the resuming workflow's <a href="../recovery/#versioning"><code>workflow_version</code></a>
+disagrees with the version stamped on the persisted rows, <code>resume_from</code> returns
+<code>CanoError::WorkflowVersionMismatch</code> <em>before</em> the compensation stack is
+rehydrated — <strong>so there is no rollback to perform when versions don't match.</strong></li>
 </ul>
 
 <div class="callout callout-tip">

--- a/docs/content/workflows.md
+++ b/docs/content/workflows.md
@@ -187,7 +187,7 @@ will warn you if you discard the return value. If you forget to capture it, the 
 
 <p>
 The same builder also carries the cross-cutting concerns: <code>with_checkpoint_store</code> /
-<code>with_workflow_id</code> / <code>resume_from</code> for <a href="../recovery/">crash recovery</a>,
+<code>with_workflow_id</code> / <code>with_workflow_version</code> / <code>resume_from</code> for <a href="../recovery/">crash recovery</a>,
 <code>register_with_compensation</code> for <a href="../saga/">sagas</a>, <code>with_observer</code> for
 <a href="../observers/">observers</a>, and per-task <code>TaskConfig</code> for retries, timeouts, and
 <a href="../resilience/">circuit breakers</a>.


### PR DESCRIPTION
## Workflow versioning for checkpoint rows

Adds an opt-in `workflow_version: u32` tag on every `CheckpointRow` so a resumed run can't silently land on an incompatible workflow definition (renamed states, changed cursor schema, reshaped compensation outputs, etc.).

### What changed

- `Workflow::with_workflow_version(u32)` — builder that stamps the version onto every appended row. Defaults to `0`.
- `resume_from` now reads the latest row's stamped version and returns the new `CanoError::WorkflowVersionMismatch { stored, expected }` if it differs from the workflow's configured version.
- `CheckpointRow::with_workflow_version` + persistence updates in `cano/src/recovery/redb.rs` and the Postgres e2e store in `cano-e2e/src/lib.rs`, both with a `V0` decode fallback so rows from older builds keep replaying as `workflow_version = 0`.
- Docs updated (`docs/content/recovery.md`, `docs/content/saga.md`) and version bumped to `0.13.2`.

### Compatibility

Backward-compatible by default: any workflow that doesn't call `with_workflow_version` keeps the version at `0`, matching pre-existing rows.

### Tests

New coverage in `cano/tests/recovery_version_compat.rs` plus unit tests for the error variant, the row field, and resume-rejection — all gates passing locally.
