### PR TITLE
Add a public `testing` module with batteries-included test fixtures

### DIFF
--- a/cano/Cargo.toml
+++ b/cano/Cargo.toml
@@ -31,8 +31,9 @@ metrics = { version = "0.24.5", optional = true }
 scheduler = ["dep:chrono", "dep:cron", "tokio/signal"]
 tracing = ["dep:tracing"]
 recovery = ["dep:redb", "dep:postcard"]
-all = ["scheduler", "tracing", "recovery", "metrics"]
 metrics = ["dep:metrics"]
+testing = []
+all = ["scheduler", "tracing", "recovery", "metrics", "testing"]
 
 [dev-dependencies]
 axum = "0.8.9"
@@ -262,6 +263,11 @@ path = "examples/store_custom_backend.rs"
 [[example]]
 name = "resources_advanced"
 path = "examples/resources_advanced.rs"
+
+[[example]]
+name = "testing_helpers"
+path = "examples/testing_helpers.rs"
+required-features = ["testing"]
 
 [[bench]]
 name = "workflow_performance"

--- a/cano/examples/testing_helpers.rs
+++ b/cano/examples/testing_helpers.rs
@@ -1,0 +1,161 @@
+//! # `cano::testing` — batteries-included test fixtures
+//!
+//! Run with: `cargo run --example testing_helpers --features testing`
+//!
+//! Everything here lives behind the `testing` feature and is imported wholesale with
+//! `use cano::testing::*;`. This example exercises each helper the way a test would:
+//!
+//! - [`RecordingObserver`] — capture and assert the path a workflow took.
+//! - [`InMemoryCheckpointStore`] — a process-local checkpoint store (no `recovery`
+//!   feature, no on-disk file) whose `Checkpoint` events the observer records.
+//! - [`TestResources`] — build the [`Resources`] a workflow needs in one chain.
+//! - [`panic_on_attempt`] — a task that panics; the engine converts it to an error
+//!   (panic safety) and fails fast.
+//! - [`assert_compensation_ran`] — assert the order a saga rolled back in.
+
+use std::sync::{Arc, Mutex};
+
+use cano::prelude::*;
+use cano::testing::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Step {
+    Start,
+    Work,
+    Finish,
+    Done,
+}
+
+struct StartTask;
+#[task(state = Step)]
+impl StartTask {
+    async fn run_bare(&self) -> Result<TaskResult<Step>, CanoError> {
+        Ok(TaskResult::Single(Step::Work))
+    }
+}
+
+struct WorkTask;
+#[task(state = Step)]
+impl WorkTask {
+    async fn run(&self, res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        let store = res.get::<MemoryStore, _>("store")?;
+        store.put("processed", 42_u32)?;
+        Ok(TaskResult::Single(Step::Done))
+    }
+}
+
+// ---- A tiny saga whose compensations record the order they undo in. -------------------
+
+/// Shared, ordered log of which compensations ran. Registered as a resource so every
+/// step can reach it; `Clone` shares the inner `Arc`, so a handle kept outside the
+/// workflow reads the same `Vec`.
+#[derive(Default, Clone)]
+struct CompensationLog(Arc<Mutex<Vec<String>>>);
+#[resource]
+impl Resource for CompensationLog {}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct Unit;
+
+struct Reserve;
+#[saga::task(state = Step)]
+impl Reserve {
+    type Output = Unit;
+    async fn run(&self, _res: &Resources) -> Result<(TaskResult<Step>, Unit), CanoError> {
+        Ok((TaskResult::Single(Step::Work), Unit))
+    }
+    async fn compensate(&self, res: &Resources, _out: Unit) -> Result<(), CanoError> {
+        res.get::<CompensationLog, _>("log")?
+            .0
+            .lock()
+            .unwrap()
+            .push("reserve".into());
+        Ok(())
+    }
+}
+
+struct Charge;
+#[saga::task(state = Step)]
+impl Charge {
+    type Output = Unit;
+    async fn run(&self, _res: &Resources) -> Result<(TaskResult<Step>, Unit), CanoError> {
+        Ok((TaskResult::Single(Step::Finish), Unit))
+    }
+    async fn compensate(&self, res: &Resources, _out: Unit) -> Result<(), CanoError> {
+        res.get::<CompensationLog, _>("log")?
+            .0
+            .lock()
+            .unwrap()
+            .push("charge".into());
+        Ok(())
+    }
+}
+
+struct Boom;
+#[task(state = Step)]
+impl Boom {
+    fn config(&self) -> TaskConfig {
+        TaskConfig::minimal()
+    }
+    async fn run_bare(&self) -> Result<TaskResult<Step>, CanoError> {
+        Err(CanoError::task_execution("boom"))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. RecordingObserver + InMemoryCheckpointStore + TestResources --------------------
+    let observer = Arc::new(RecordingObserver::new());
+    let checkpoints = Arc::new(InMemoryCheckpointStore::new());
+    let resources = TestResources::new().with_store("store").build();
+
+    let workflow = Workflow::new(resources)
+        .register(Step::Start, StartTask)
+        .register(Step::Work, WorkTask)
+        .add_exit_state(Step::Done)
+        .with_observer(observer.clone())
+        .with_checkpoint_store(checkpoints.clone())
+        .with_workflow_id("demo-run");
+
+    let final_state = workflow.orchestrate(Step::Start).await?;
+    assert_eq!(final_state, Step::Done);
+
+    // The observer captured the whole path and the checkpoint appends along the way.
+    observer.assert_path(&["Start", "Work", "Done"]);
+    observer.assert_completed_with("Done");
+    let checkpoint_events = observer
+        .events()
+        .into_iter()
+        .filter(|e| matches!(e, RecordedEvent::Checkpoint { .. }))
+        .count();
+    println!("observer recorded path {:?}", observer.states_entered());
+    println!("observer saw {checkpoint_events} checkpoint append(s)");
+
+    // 2. panic_on_attempt — panic safety: the panic becomes an error, fails fast. -------
+    let panicky = Workflow::bare()
+        .register(Step::Start, panic_on_attempt(1, Step::Done))
+        .add_exit_state(Step::Done);
+    match panicky.orchestrate(Step::Start).await {
+        Ok(_) => unreachable!("the task panics on its first attempt"),
+        Err(e) => println!("panic_on_attempt surfaced as error: {e}"),
+    }
+
+    // 3. assert_compensation_ran — a saga that rolls back in reverse. --------------------
+    let log = CompensationLog::default();
+    let handle = log.clone();
+    let saga_resources = Resources::new().insert("log", log);
+    let saga = Workflow::new(saga_resources)
+        .register_with_compensation(Step::Start, Reserve)
+        .register_with_compensation(Step::Work, Charge)
+        .register(Step::Finish, Boom) // fails → drains the compensation stack in reverse
+        .add_exit_state(Step::Done);
+    let _ = saga.orchestrate(Step::Start).await; // expected to fail and roll back
+
+    let ran = handle.0.lock().unwrap().clone();
+    // Charge ran last, so it compensates first; then Reserve.
+    assert_compensation_ran(&ran, &["charge", "reserve"]);
+    println!("compensation ran in order: {ran:?}");
+
+    println!("\nall testing helpers exercised ✔");
+    Ok(())
+}

--- a/cano/src/lib.rs
+++ b/cano/src/lib.rs
@@ -217,6 +217,11 @@
 //! - [`saga`]: [`CompensatableTask`] — pair a forward step with a compensating action; failures roll back via [`Workflow::register_with_compensation`]
 //! - [`rate_limit`]: [`RateLimiter`] (token bucket) and [`WindowedRateLimiter`] (fixed window) throttles, both implementing [`Meter`] so they compose into a [`MultiRateLimiter`] that enforces several weighted tiers (e.g. a 5h + 7d + per-model limit) at once
 //! - [`store`]: [`MemoryStore`] — a typed in-memory store that implements [`Resource`]
+//! - `testing` (requires `testing` feature): batteries-included test fixtures —
+//!   a `RecordingObserver`, a public `InMemoryCheckpointStore`, a `TestResources`
+//!   builder, a `panic_on_attempt` task factory and an `assert_compensation_ran`
+//!   saga helper. Import explicitly with `use cano::testing::*;` — it is deliberately
+//!   **not** in the [`prelude`] so production code never picks it up by accident.
 //! - [`error`]: [`CanoError`] variants and the [`CanoResult`] alias
 //!
 //! ## Getting Started
@@ -241,6 +246,9 @@ pub mod metrics;
 
 #[cfg(feature = "scheduler")]
 pub mod scheduler;
+
+#[cfg(feature = "testing")]
+pub mod testing;
 
 // Core public API - simplified imports
 pub use circuit::{CircuitBreaker, CircuitPolicy, CircuitState, Permit as CircuitPermit};

--- a/cano/src/observer.rs
+++ b/cano/src/observer.rs
@@ -315,45 +315,10 @@ impl WorkflowObserver for MetricsObserver {
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;
+    use crate::workflow::test_support::EventLog;
     use std::borrow::Cow;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
     use std::time::Duration;
-
-    /// Test observer that appends a stringified record of every event it receives.
-    #[derive(Default)]
-    struct RecordingObserver {
-        events: Mutex<Vec<String>>,
-    }
-
-    impl RecordingObserver {
-        fn events(&self) -> Vec<String> {
-            self.events.lock().unwrap().clone()
-        }
-        fn record(&self, event: String) {
-            self.events.lock().unwrap().push(event);
-        }
-    }
-
-    impl WorkflowObserver for RecordingObserver {
-        fn on_state_enter(&self, state: &str) {
-            self.record(format!("state_enter:{state}"));
-        }
-        fn on_task_start(&self, task_id: &str) {
-            self.record(format!("task_start:{task_id}"));
-        }
-        fn on_task_success(&self, task_id: &str) {
-            self.record(format!("task_success:{task_id}"));
-        }
-        fn on_task_failure(&self, task_id: &str, _err: &CanoError) {
-            self.record(format!("task_failure:{task_id}"));
-        }
-        fn on_retry(&self, task_id: &str, attempt: u32) {
-            self.record(format!("retry:{task_id}:{attempt}"));
-        }
-        fn on_circuit_open(&self, task_id: &str) {
-            self.record(format!("circuit_open:{task_id}"));
-        }
-    }
 
     #[derive(Clone, Debug, PartialEq, Eq, Hash)]
     enum S {
@@ -411,15 +376,15 @@ mod tests {
 
     #[tokio::test]
     async fn observer_fires_on_success_path() {
-        let observer = Arc::new(RecordingObserver::default());
+        let (obs, rec) = EventLog::new();
         let workflow = Workflow::bare()
             .register(S::Start, OkTask)
             .add_exit_state(S::Done)
-            .with_observer(observer.clone());
+            .with_observer(Arc::new(obs));
 
         assert_eq!(workflow.orchestrate(S::Start).await.unwrap(), S::Done);
 
-        let events = observer.events();
+        let events = rec.labels();
         assert!(
             events.contains(&"state_enter:Start".to_string()),
             "{events:?}"
@@ -444,15 +409,15 @@ mod tests {
 
     #[tokio::test]
     async fn observer_fires_on_retry_and_failure() {
-        let observer = Arc::new(RecordingObserver::default());
+        let (obs, rec) = EventLog::new();
         let workflow = Workflow::bare()
             .register(S::Start, FailTask)
             .add_exit_state(S::Done)
-            .with_observer(observer.clone());
+            .with_observer(Arc::new(obs));
 
         assert!(workflow.orchestrate(S::Start).await.is_err());
 
-        let events = observer.events();
+        let events = rec.labels();
         assert!(
             events.contains(&"task_start:FailTask".to_string()),
             "{events:?}"
@@ -487,7 +452,7 @@ mod tests {
         let permit = breaker.try_acquire().expect("closed breaker admits");
         breaker.record_failure(permit);
 
-        let observer = Arc::new(RecordingObserver::default());
+        let (obs, rec) = EventLog::new();
         let workflow = Workflow::bare()
             .register(
                 S::Start,
@@ -496,13 +461,13 @@ mod tests {
                 },
             )
             .add_exit_state(S::Done)
-            .with_observer(observer.clone());
+            .with_observer(Arc::new(obs));
 
         let err = workflow.orchestrate(S::Start).await.unwrap_err();
         // The FSM wraps the failure with state context; the inner is CircuitOpen.
         assert!(matches!(err.inner(), CanoError::CircuitOpen(_)), "{err}");
 
-        let events = observer.events();
+        let events = rec.labels();
         assert!(
             events.contains(&"circuit_open:CircuitTask".to_string()),
             "{events:?}"
@@ -571,21 +536,12 @@ mod tests {
 
     #[test]
     fn on_workflow_timeout_can_be_overridden_to_record_event() {
-        use std::sync::{Arc, Mutex};
-        use std::time::Duration;
-        #[derive(Default)]
-        struct Recorder(Mutex<Vec<(Duration, Duration)>>);
-        impl WorkflowObserver for Recorder {
-            fn on_workflow_timeout(&self, elapsed: Duration, limit: Duration) {
-                self.0.lock().unwrap().push((elapsed, limit));
-            }
-        }
-        let obs = Arc::new(Recorder::default());
-        let dyn_obs: Arc<dyn WorkflowObserver> = obs.clone();
+        // `EventLog` is itself a custom override — proves the hook can be observed.
+        let (obs, rec) = EventLog::new();
+        let dyn_obs: Arc<dyn WorkflowObserver> = Arc::new(obs);
         dyn_obs.on_workflow_timeout(Duration::from_millis(150), Duration::from_millis(100));
-        let events = obs.0.lock().unwrap().clone();
         assert_eq!(
-            events,
+            rec.timeouts(),
             vec![(Duration::from_millis(150), Duration::from_millis(100))]
         );
     }

--- a/cano/src/testing.rs
+++ b/cano/src/testing.rs
@@ -1,0 +1,658 @@
+//! # Testing helpers — batteries-included fixtures for workflow tests
+//!
+//! Everything in this module is gated behind the `testing` feature and is meant
+//! to be pulled in wholesale from a test module:
+//!
+//! ```rust
+//! use cano::testing::*;
+//! ```
+//!
+//! It wraps existing public surface ([`WorkflowObserver`],
+//! [`CheckpointStore`], [`Resources`],
+//! [`MemoryStore`], [`Task`]) — it adds **no** new
+//! traits and changes **no** existing public items, so a typical workflow test drops from a
+//! pile of bespoke fixtures to a handful of lines.
+//!
+//! | helper | what it gives you |
+//! |---|---|
+//! | [`RecordingObserver`] | a [`WorkflowObserver`] that captures every lifecycle event into an inspectable [`Vec<RecordedEvent>`] |
+//! | [`InMemoryCheckpointStore`] | a process-local [`CheckpointStore`] for resume/recovery tests, with no `recovery` feature or on-disk file needed |
+//! | [`TestResources`] | a tiny builder for the [`Resources`] dictionary a workflow needs |
+//! | [`panic_on_attempt`] | a [`Task`] that panics on its first *N* attempts — exercises the panic-safety path (panics fail fast, they are not retried) |
+//! | [`assert_compensation_ran`] | a saga assertion that compares the recorded compensation order against an expected sequence |
+//!
+//! This module is **not** in the [`prelude`](crate::prelude) — import it explicitly with
+//! `use cano::testing::*;` so production code never picks these up by accident.
+//!
+//! ## Example
+//!
+//! ```rust
+//! use cano::prelude::*;
+//! use cano::testing::*;
+//! use std::sync::Arc;
+//!
+//! #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+//! enum S { Start, Done }
+//!
+//! struct OkTask;
+//! #[task]
+//! impl Task<S> for OkTask {
+//!     async fn run_bare(&self) -> Result<TaskResult<S>, CanoError> {
+//!         Ok(TaskResult::Single(S::Done))
+//!     }
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() {
+//! let observer = Arc::new(RecordingObserver::new());
+//! let wf = Workflow::bare()
+//!     .register(S::Start, OkTask)
+//!     .add_exit_state(S::Done)
+//!     .with_observer(observer.clone());
+//! assert_eq!(wf.orchestrate(S::Start).await.unwrap(), S::Done);
+//! observer.assert_path(&["Start", "Done"]);
+//! # }
+//! ```
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use parking_lot::Mutex;
+
+use crate::error::CanoError;
+use crate::observer::WorkflowObserver;
+use crate::recovery::{CheckpointRow, CheckpointStore};
+use crate::resource::{Resource, Resources};
+use crate::store::MemoryStore;
+use crate::task::{Task, TaskConfig, TaskResult};
+
+/// A single event captured by [`RecordingObserver`].
+///
+/// Mirrors the [`WorkflowObserver`] hooks. It is
+/// `#[non_exhaustive]` because the observer trait may grow more hooks — match with a
+/// wildcard arm.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecordedEvent {
+    /// The FSM entered a state. Carries the `Debug` rendering of the state.
+    StateEntered(String),
+    /// A task began executing (before its retry loop).
+    TaskStarted {
+        /// The task's [`name`](crate::task::Task::name).
+        state: String,
+    },
+    /// A task completed successfully.
+    TaskSucceeded {
+        /// The task's [`name`](crate::task::Task::name).
+        state: String,
+    },
+    /// A task ultimately failed.
+    TaskFailed {
+        /// The task's [`name`](crate::task::Task::name).
+        state: String,
+        /// The failing error's `Display` rendering.
+        error: String,
+    },
+    /// A retry was scheduled after a failed attempt.
+    Retry {
+        /// The task's [`name`](crate::task::Task::name).
+        state: String,
+        /// The 1-based number of the attempt that just failed.
+        attempt: u32,
+    },
+    /// A circuit breaker rejected the call.
+    CircuitOpen {
+        /// The task's [`name`](crate::task::Task::name).
+        state: String,
+    },
+    /// A checkpoint row was durably appended.
+    Checkpoint {
+        /// The workflow id the row was written for.
+        workflow_id: String,
+        /// The appended row's sequence.
+        sequence: u64,
+    },
+    /// A run was resumed from a checkpoint log.
+    Resume {
+        /// The resumed workflow id.
+        workflow_id: String,
+        /// The sequence of the last persisted row.
+        sequence: u64,
+    },
+}
+
+/// A [`WorkflowObserver`] that records every event it
+/// receives into an inspectable list.
+///
+/// Wrap it in an `Arc`, attach it with
+/// [`Workflow::with_observer`](crate::workflow::Workflow::with_observer), drive the
+/// workflow, then assert against [`events`](Self::events) / [`states_entered`](Self::states_entered)
+/// or use the [`assert_path`](Self::assert_path) / [`assert_completed_with`](Self::assert_completed_with)
+/// convenience checks.
+#[derive(Default, Debug)]
+pub struct RecordingObserver {
+    events: Mutex<Vec<RecordedEvent>>,
+}
+
+impl RecordingObserver {
+    /// Create an empty `RecordingObserver`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot every recorded event, in arrival order.
+    #[must_use]
+    pub fn events(&self) -> Vec<RecordedEvent> {
+        self.events.lock().clone()
+    }
+
+    /// The `Debug`-rendered state labels, in the order they were entered.
+    #[must_use]
+    pub fn states_entered(&self) -> Vec<String> {
+        self.events
+            .lock()
+            .iter()
+            .filter_map(|e| match e {
+                RecordedEvent::StateEntered(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Drop every recorded event. Useful to reset between phases of a test that
+    /// reuses one observer.
+    pub fn clear(&self) {
+        self.events.lock().clear();
+    }
+
+    /// Assert that the last state the FSM entered is `final_state`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no states were entered, or if the last differs from `final_state`.
+    pub fn assert_completed_with(&self, final_state: &str) {
+        let last = self.states_entered().last().cloned();
+        assert_eq!(last.as_deref(), Some(final_state));
+    }
+
+    /// Assert the full sequence of states entered equals `expected`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the recorded path differs from `expected`.
+    pub fn assert_path(&self, expected: &[&str]) {
+        let actual = self.states_entered();
+        let actual_refs: Vec<&str> = actual.iter().map(String::as_str).collect();
+        assert_eq!(actual_refs.as_slice(), expected);
+    }
+}
+
+impl WorkflowObserver for RecordingObserver {
+    fn on_state_enter(&self, state: &str) {
+        self.events
+            .lock()
+            .push(RecordedEvent::StateEntered(state.into()));
+    }
+    fn on_task_start(&self, task_id: &str) {
+        self.events.lock().push(RecordedEvent::TaskStarted {
+            state: task_id.into(),
+        });
+    }
+    fn on_task_success(&self, task_id: &str) {
+        self.events.lock().push(RecordedEvent::TaskSucceeded {
+            state: task_id.into(),
+        });
+    }
+    fn on_task_failure(&self, task_id: &str, err: &CanoError) {
+        self.events.lock().push(RecordedEvent::TaskFailed {
+            state: task_id.into(),
+            error: err.to_string(),
+        });
+    }
+    fn on_retry(&self, task_id: &str, attempt: u32) {
+        self.events.lock().push(RecordedEvent::Retry {
+            state: task_id.into(),
+            attempt,
+        });
+    }
+    fn on_circuit_open(&self, task_id: &str) {
+        self.events.lock().push(RecordedEvent::CircuitOpen {
+            state: task_id.into(),
+        });
+    }
+    fn on_checkpoint(&self, workflow_id: &str, sequence: u64) {
+        self.events.lock().push(RecordedEvent::Checkpoint {
+            workflow_id: workflow_id.into(),
+            sequence,
+        });
+    }
+    fn on_resume(&self, workflow_id: &str, sequence: u64) {
+        self.events.lock().push(RecordedEvent::Resume {
+            workflow_id: workflow_id.into(),
+            sequence,
+        });
+    }
+}
+
+/// A process-local [`CheckpointStore`] for resume /
+/// recovery tests.
+///
+/// It needs neither the `recovery` feature nor an on-disk file — a single
+/// `Arc<InMemoryCheckpointStore>` can be shared across an
+/// [`orchestrate`](crate::workflow::Workflow::orchestrate) run and a later
+/// [`resume_from`](crate::workflow::Workflow::resume_from) to exercise the crash-recovery
+/// path entirely in memory. It honors the full trait contract: duplicate
+/// `(workflow_id, sequence)` is rejected, [`load_run`](Self::load_run) returns rows sorted by
+/// sequence, and [`clear`](Self::clear) is per-id.
+#[derive(Default, Debug)]
+pub struct InMemoryCheckpointStore {
+    inner: Mutex<HashMap<String, Vec<CheckpointRow>>>,
+}
+
+impl InMemoryCheckpointStore {
+    /// Create an empty store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[crate::checkpoint_store]
+impl CheckpointStore for InMemoryCheckpointStore {
+    async fn append(&self, workflow_id: &str, row: CheckpointRow) -> Result<(), CanoError> {
+        let mut runs = self.inner.lock();
+        let rows = runs.entry(workflow_id.to_string()).or_default();
+        if rows.iter().any(|r| r.sequence == row.sequence) {
+            return Err(CanoError::checkpoint_store(format!(
+                "checkpoint conflict: {workflow_id:?} already has sequence {}",
+                row.sequence
+            )));
+        }
+        rows.push(row);
+        Ok(())
+    }
+
+    async fn load_run(&self, workflow_id: &str) -> Result<Vec<CheckpointRow>, CanoError> {
+        let mut rows = self
+            .inner
+            .lock()
+            .get(workflow_id)
+            .cloned()
+            .unwrap_or_default();
+        rows.sort_by_key(|r| r.sequence);
+        Ok(rows)
+    }
+
+    async fn clear(&self, workflow_id: &str) -> Result<(), CanoError> {
+        self.inner.lock().remove(workflow_id);
+        Ok(())
+    }
+}
+
+/// A small builder for the [`Resources`] dictionary a workflow
+/// needs.
+///
+/// Saves the `Resources::new().insert(..).insert(..)` ceremony, and gives a one-call
+/// [`with_store`](Self::with_store) for the common case of "I just need a
+/// [`MemoryStore`] at some key".
+///
+/// ```rust
+/// use cano::testing::TestResources;
+///
+/// let resources = TestResources::new().with_store("store").build();
+/// assert!(resources.get::<cano::MemoryStore, _>("store").is_ok());
+/// ```
+#[derive(Default)]
+pub struct TestResources {
+    inner: Resources,
+}
+
+impl TestResources {
+    /// Start an empty builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a fresh [`MemoryStore`] at `key`.
+    #[must_use]
+    pub fn with_store(mut self, key: &'static str) -> Self {
+        self.inner = std::mem::take(&mut self.inner).insert(key, MemoryStore::new());
+        self
+    }
+
+    /// Insert an arbitrary [`Resource`] at `key`.
+    #[must_use]
+    pub fn with_resource<R: Resource + 'static>(mut self, key: &'static str, resource: R) -> Self {
+        self.inner = std::mem::take(&mut self.inner).insert(key, resource);
+        self
+    }
+
+    /// Finish building and hand back the [`Resources`].
+    #[must_use]
+    pub fn build(self) -> Resources {
+        self.inner
+    }
+}
+
+/// A [`Task`] that panics on its first `n` attempts, then transitions to a
+/// fixed next state. Build it with [`panic_on_attempt`].
+///
+/// The engine converts a panicking task into a `CanoError`
+/// ([`task_execution`](crate::error::CanoError::task_execution) whose message starts with
+/// `"panic: "`) rather than unwinding the workflow loop — this is the helper for exercising
+/// that **panic-safety** path.
+///
+/// Note that the engine wraps its catch-unwind around the *whole* retry loop, so a panic
+/// **fails fast — panics are never retried** (only a returned `Err` is). A
+/// [`with_config`](Self::with_config) retry policy therefore has no effect on a panicking
+/// attempt; with `n >= 1` the run fails on the first attempt, and the `next_state` success
+/// branch is only reached when `n == 0`.
+pub struct PanicOnAttempt<TState> {
+    panics: u32,
+    next_state: TState,
+    attempts: AtomicU32,
+    config: TaskConfig,
+}
+
+impl<TState> PanicOnAttempt<TState> {
+    /// Override the retry configuration (default: [`TaskConfig::minimal`], no retries).
+    ///
+    /// Mostly useful to assert that panics are *not* retried — the engine fails a panicking
+    /// task fast regardless of the policy set here.
+    #[must_use]
+    pub fn with_config(mut self, config: TaskConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Total number of attempts seen so far (panicking attempts included).
+    #[must_use]
+    pub fn attempts(&self) -> u32 {
+        self.attempts.load(Ordering::SeqCst)
+    }
+}
+
+/// Build a [`PanicOnAttempt`] task that panics on its first `panics` attempts, then
+/// transitions to `next_state`.
+///
+/// With `panics >= 1` the first attempt panics and the run fails with a `"panic: ..."`
+/// error — panics are never retried (see [`PanicOnAttempt`]). Pass `panics == 0` for a
+/// task that simply transitions on its first attempt.
+///
+/// ```rust
+/// use cano::prelude::*;
+/// use cano::testing::panic_on_attempt;
+///
+/// # #[derive(Clone, Debug, PartialEq, Eq, Hash)] enum S { Start, Done }
+/// // Panics on the first attempt; the run fails fast with a "panic: ..." error.
+/// let task = panic_on_attempt(1, S::Done);
+/// # let _ = task;
+/// ```
+pub fn panic_on_attempt<TState>(panics: u32, next_state: TState) -> PanicOnAttempt<TState> {
+    PanicOnAttempt {
+        panics,
+        next_state,
+        attempts: AtomicU32::new(0),
+        config: TaskConfig::minimal(),
+    }
+}
+
+#[crate::task]
+impl<TState> Task<TState> for PanicOnAttempt<TState>
+where
+    TState: Clone + std::fmt::Debug + Send + Sync + 'static,
+{
+    fn config(&self) -> TaskConfig {
+        self.config.clone()
+    }
+
+    fn name(&self) -> Cow<'static, str> {
+        "PanicOnAttempt".into()
+    }
+
+    async fn run_bare(&self) -> Result<TaskResult<TState>, CanoError> {
+        let attempt = self.attempts.fetch_add(1, Ordering::SeqCst) + 1;
+        if attempt <= self.panics {
+            panic!("panic_on_attempt: forced panic on attempt {attempt}");
+        }
+        Ok(TaskResult::Single(self.next_state.clone()))
+    }
+}
+
+/// Assert that a saga's recorded compensation order matches `expected`.
+///
+/// Collect the names (or labels) of the compensations that ran — typically by having each
+/// `compensate` push its identifier into a shared `Vec` in [`Resources`] —
+/// and pass that slice as `actual`. Compensations drain in reverse of completion order, so
+/// `expected` should list them in the order you expect them to *undo*.
+///
+/// # Panics
+///
+/// Panics with a diff-style message when the orders differ.
+///
+/// ```rust
+/// use cano::testing::assert_compensation_ran;
+///
+/// let ran = vec!["charge".to_string(), "reserve".to_string()];
+/// assert_compensation_ran(&ran, &["charge", "reserve"]);
+/// ```
+pub fn assert_compensation_ran<S: AsRef<str>>(actual: &[S], expected: &[&str]) {
+    let actual_refs: Vec<&str> = actual.iter().map(AsRef::as_ref).collect();
+    assert_eq!(
+        actual_refs.as_slice(),
+        expected,
+        "compensation order mismatch:\n  expected: {expected:?}\n  actual:   {actual_refs:?}"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prelude::*;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    enum S {
+        Start,
+        Done,
+    }
+
+    struct OkTask;
+    #[task]
+    impl Task<S> for OkTask {
+        async fn run_bare(&self) -> Result<TaskResult<S>, CanoError> {
+            Ok(TaskResult::Single(S::Done))
+        }
+        fn name(&self) -> Cow<'static, str> {
+            "OkTask".into()
+        }
+    }
+
+    #[tokio::test]
+    async fn recording_observer_captures_success_path() {
+        let observer = Arc::new(RecordingObserver::default());
+        let wf = Workflow::bare()
+            .register(S::Start, OkTask)
+            .add_exit_state(S::Done)
+            .with_observer(observer.clone());
+        assert_eq!(wf.orchestrate(S::Start).await.unwrap(), S::Done);
+        observer.assert_path(&["Start", "Done"]);
+        observer.assert_completed_with("Done");
+        assert!(observer.events().contains(&RecordedEvent::TaskSucceeded {
+            state: "OkTask".into()
+        }));
+    }
+
+    #[tokio::test]
+    async fn recording_observer_clear_resets_events() {
+        let observer = Arc::new(RecordingObserver::new());
+        let wf = Workflow::bare()
+            .register(S::Start, OkTask)
+            .add_exit_state(S::Done)
+            .with_observer(observer.clone());
+        wf.orchestrate(S::Start).await.unwrap();
+        assert!(!observer.events().is_empty());
+        observer.clear();
+        assert!(observer.events().is_empty());
+    }
+
+    #[tokio::test]
+    async fn in_memory_checkpoint_store_roundtrip() {
+        let store = InMemoryCheckpointStore::new();
+        store
+            .append("run", CheckpointRow::new(0, "A", "t0"))
+            .await
+            .unwrap();
+        store
+            .append("run", CheckpointRow::new(1, "B", "t1"))
+            .await
+            .unwrap();
+        let rows = store.load_run("run").await.unwrap();
+        assert_eq!(
+            rows.iter().map(|r| r.sequence).collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+    }
+
+    #[tokio::test]
+    async fn in_memory_checkpoint_store_sorts_on_load() {
+        let store = InMemoryCheckpointStore::new();
+        store
+            .append("run", CheckpointRow::new(2, "C", "t2"))
+            .await
+            .unwrap();
+        store
+            .append("run", CheckpointRow::new(0, "A", "t0"))
+            .await
+            .unwrap();
+        let rows = store.load_run("run").await.unwrap();
+        assert_eq!(
+            rows.iter().map(|r| r.sequence).collect::<Vec<_>>(),
+            vec![0, 2]
+        );
+    }
+
+    #[tokio::test]
+    async fn in_memory_checkpoint_store_rejects_duplicate_sequence() {
+        let store = InMemoryCheckpointStore::new();
+        store
+            .append("run", CheckpointRow::new(0, "A", "t0"))
+            .await
+            .unwrap();
+        let err = store
+            .append("run", CheckpointRow::new(0, "A2", "t0"))
+            .await
+            .expect_err("duplicate sequence must be rejected");
+        assert_eq!(err.category(), "checkpoint_store");
+    }
+
+    #[tokio::test]
+    async fn in_memory_checkpoint_store_clear_is_per_id() {
+        let store = InMemoryCheckpointStore::new();
+        store
+            .append("a", CheckpointRow::new(0, "A", "t0"))
+            .await
+            .unwrap();
+        store
+            .append("b", CheckpointRow::new(0, "B", "t0"))
+            .await
+            .unwrap();
+        store.clear("a").await.unwrap();
+        assert!(store.load_run("a").await.unwrap().is_empty());
+        assert_eq!(store.load_run("b").await.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_resources_with_store_inserts_memory_store() {
+        let resources = TestResources::new().with_store("store").build();
+        assert!(resources.get::<MemoryStore, _>("store").is_ok());
+    }
+
+    #[test]
+    fn test_resources_with_resource_inserts_custom() {
+        #[derive(Clone)]
+        struct Cfg {
+            limit: usize,
+        }
+        #[resource]
+        impl Resource for Cfg {}
+
+        let resources = TestResources::new()
+            .with_store("store")
+            .with_resource("cfg", Cfg { limit: 7 })
+            .build();
+        assert_eq!(resources.get::<Cfg, _>("cfg").unwrap().limit, 7);
+        assert!(resources.get::<MemoryStore, _>("store").is_ok());
+    }
+
+    #[tokio::test]
+    async fn panic_on_attempt_first_attempt_surfaces_as_error() {
+        // No retries: the first attempt panics. The engine converts a task panic into a
+        // CanoError whose message starts with "panic:" — assert that conversion here by
+        // driving the task's future through the same `catch_panic_to_error` wrapper.
+        let task = panic_on_attempt(1, S::Done);
+        let err = crate::workflow::catch_panic_to_error(
+            <PanicOnAttempt<S> as Task<S>>::run_bare(&task),
+            "Single task",
+        )
+        .await
+        .expect_err("expected the forced panic to surface as an error");
+        assert!(err.to_string().contains("panic"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn panic_on_attempt_fails_fast_even_with_retries_configured() {
+        // The engine wraps its catch-unwind around the *whole* retry loop, so a panicking
+        // task fails fast — panics are never retried (only returned `Err`s are). Even with a
+        // generous retry policy, the very first panic surfaces as a task failure with no
+        // retry recorded.
+        let observer = Arc::new(RecordingObserver::new());
+        let task = panic_on_attempt(2, S::Done)
+            .with_config(TaskConfig::new().with_fixed_retry(5, Duration::from_millis(1)));
+        let wf = Workflow::bare()
+            .register(S::Start, task)
+            .add_exit_state(S::Done)
+            .with_observer(observer.clone());
+        let err = wf.orchestrate(S::Start).await.unwrap_err();
+        assert!(err.to_string().contains("panic"), "{err}");
+        let retries = observer
+            .events()
+            .into_iter()
+            .filter(|e| matches!(e, RecordedEvent::Retry { .. }))
+            .count();
+        assert_eq!(retries, 0, "panics are not retried");
+        assert!(
+            observer
+                .events()
+                .iter()
+                .any(|e| matches!(e, RecordedEvent::TaskFailed { .. }))
+        );
+    }
+
+    #[tokio::test]
+    async fn panic_on_attempt_zero_panics_transitions_immediately() {
+        // `panics = 0` never panics: the success branch is reachable and the task
+        // transitions to its next state on the first attempt.
+        let wf = Workflow::bare()
+            .register(S::Start, panic_on_attempt(0, S::Done))
+            .add_exit_state(S::Done);
+        assert_eq!(wf.orchestrate(S::Start).await.unwrap(), S::Done);
+    }
+
+    #[test]
+    fn assert_compensation_ran_matches() {
+        let ran = vec!["charge".to_string(), "reserve".to_string()];
+        assert_compensation_ran(&ran, &["charge", "reserve"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "compensation order mismatch")]
+    fn assert_compensation_ran_mismatch_panics() {
+        let ran = vec!["reserve".to_string()];
+        assert_compensation_ran(&ran, &["charge", "reserve"]);
+    }
+}

--- a/cano/src/testing.rs
+++ b/cano/src/testing.rs
@@ -187,6 +187,63 @@ impl RecordingObserver {
         let actual_refs: Vec<&str> = actual.iter().map(String::as_str).collect();
         assert_eq!(actual_refs.as_slice(), expected);
     }
+
+    /// Assert that every state in `expected` was entered at least once during the
+    /// workflow run this observer recorded. Returns `Err` listing the missing
+    /// states (in the order they appear in `expected`, deduplicated) when one or
+    /// more were never entered; `Ok(())` when all were visited.
+    ///
+    /// Unlike [`assert_path`](Self::assert_path) this returns a `Result` instead of
+    /// panicking, so the caller can inspect the missing labels — `?`-propagate, or
+    /// `.expect(..)` / `.unwrap_err()` in a test.
+    ///
+    /// The comparison is string-based on the `Debug` rendering of each state,
+    /// matching what [`WorkflowObserver::on_state_enter`](crate::observer::WorkflowObserver::on_state_enter)
+    /// received from the engine. `TState` therefore only needs `Debug`.
+    pub fn assert_all_states_entered<TState: std::fmt::Debug>(
+        &self,
+        expected: &[TState],
+    ) -> Result<(), Vec<String>> {
+        let entered: std::collections::HashSet<String> =
+            self.states_entered().into_iter().collect();
+
+        let mut missing: Vec<String> = Vec::new();
+        let mut seen_in_input: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for state in expected {
+            let label = format!("{state:?}");
+            if seen_in_input.insert(label.clone()) && !entered.contains(&label) {
+                missing.push(label);
+            }
+        }
+
+        if missing.is_empty() {
+            Ok(())
+        } else {
+            Err(missing)
+        }
+    }
+
+    /// Assert that every state with a registered handler in `workflow` was
+    /// entered at least once during the run this observer recorded. Catches dead
+    /// states — handlers that exist in the registration map but are never routed
+    /// to.
+    ///
+    /// Exit states added via [`add_exit_state`](crate::workflow::Workflow::add_exit_state)
+    /// *without* a handler are not required (they are not part of
+    /// [`Workflow::registered_states`](crate::workflow::Workflow::registered_states)).
+    /// Returns `Err` with the missing state labels, like
+    /// [`assert_all_states_entered`](Self::assert_all_states_entered).
+    pub fn assert_registered_states_entered<TState, TResourceKey>(
+        &self,
+        workflow: &crate::workflow::Workflow<TState, TResourceKey>,
+    ) -> Result<(), Vec<String>>
+    where
+        TState: Clone + std::fmt::Debug + std::hash::Hash + Eq + Send + Sync + 'static,
+        TResourceKey: std::hash::Hash + Eq + Send + Sync + 'static,
+    {
+        let registered: Vec<TState> = workflow.registered_states().cloned().collect();
+        self.assert_all_states_entered(&registered)
+    }
 }
 
 impl WorkflowObserver for RecordingObserver {
@@ -459,6 +516,9 @@ mod tests {
     enum S {
         Start,
         Done,
+        A,
+        B,
+        C,
     }
 
     struct OkTask;
@@ -469,6 +529,16 @@ mod tests {
         }
         fn name(&self) -> Cow<'static, str> {
             "OkTask".into()
+        }
+    }
+
+    /// Transitions unconditionally to a supplied next state.
+    #[derive(Clone)]
+    struct Go(S);
+    #[task]
+    impl Task<S> for Go {
+        async fn run_bare(&self) -> Result<TaskResult<S>, CanoError> {
+            Ok(TaskResult::Single(self.0.clone()))
         }
     }
 
@@ -654,5 +724,74 @@ mod tests {
     fn assert_compensation_ran_mismatch_panics() {
         let ran = vec!["reserve".to_string()];
         assert_compensation_ran(&ran, &["charge", "reserve"]);
+    }
+
+    #[tokio::test]
+    async fn assert_all_states_entered_passes_when_all_visited() {
+        let observer = Arc::new(RecordingObserver::new());
+        let wf = Workflow::bare()
+            .register(S::A, Go(S::B))
+            .register(S::B, Go(S::Done))
+            .add_exit_state(S::Done)
+            .with_observer(observer.clone());
+        wf.orchestrate(S::A).await.unwrap();
+        observer
+            .assert_all_states_entered(&[S::A, S::B, S::Done])
+            .expect("all states visited");
+    }
+
+    #[tokio::test]
+    async fn assert_all_states_entered_returns_missing_in_input_order() {
+        let observer = Arc::new(RecordingObserver::new());
+        let wf = Workflow::bare()
+            .register(S::A, Go(S::Done))
+            .add_exit_state(S::Done)
+            .with_observer(observer.clone());
+        wf.orchestrate(S::A).await.unwrap();
+        let missing = observer
+            .assert_all_states_entered(&[S::A, S::B, S::C, S::Done])
+            .unwrap_err();
+        assert_eq!(missing, vec!["B".to_string(), "C".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn assert_all_states_entered_handles_duplicates_in_input() {
+        let observer = Arc::new(RecordingObserver::new());
+        let wf = Workflow::bare()
+            .register(S::A, Go(S::Done))
+            .add_exit_state(S::Done)
+            .with_observer(observer.clone());
+        wf.orchestrate(S::A).await.unwrap();
+        let missing = observer
+            .assert_all_states_entered(&[S::A, S::A, S::B])
+            .unwrap_err();
+        assert_eq!(missing, vec!["B".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn assert_registered_states_entered_passes_for_full_path() {
+        let observer = Arc::new(RecordingObserver::new());
+        let wf = Workflow::bare()
+            .register(S::A, Go(S::B))
+            .register(S::B, Go(S::Done))
+            .add_exit_state(S::Done)
+            .with_observer(observer.clone());
+        wf.orchestrate(S::A).await.unwrap();
+        observer
+            .assert_registered_states_entered(&wf)
+            .expect("all registered states visited");
+    }
+
+    #[tokio::test]
+    async fn assert_registered_states_entered_reports_dead_state() {
+        let observer = Arc::new(RecordingObserver::new());
+        let wf = Workflow::bare()
+            .register(S::A, Go(S::Done))
+            .register(S::C, Go(S::Done)) // never routed to
+            .add_exit_state(S::Done)
+            .with_observer(observer.clone());
+        wf.orchestrate(S::A).await.unwrap();
+        let missing = observer.assert_registered_states_entered(&wf).unwrap_err();
+        assert!(missing.contains(&"C".to_string()), "missing={missing:?}");
     }
 }

--- a/cano/src/workflow.rs
+++ b/cano/src/workflow.rs
@@ -578,6 +578,19 @@ where
         self
     }
 
+    /// Iterate over every state that has a registered handler — every key in the
+    /// internal state map populated by [`register`](Self::register),
+    /// [`register_router`](Self::register_router),
+    /// [`register_split`](Self::register_split),
+    /// [`register_with_compensation`](Self::register_with_compensation), and
+    /// [`register_stepped`](Self::register_stepped). **Exit-only states** added via
+    /// [`add_exit_state`](Self::add_exit_state) without a handler are *not* yielded.
+    ///
+    /// Iteration order is unspecified (backing storage is a `HashMap`).
+    pub fn registered_states(&self) -> impl Iterator<Item = &TState> {
+        self.states.keys()
+    }
+
     /// Register a [`WorkflowObserver`] to receive lifecycle and failure events.
     ///
     /// May be called more than once; every observer receives every event in
@@ -1573,6 +1586,39 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, TestState::Complete);
+    }
+
+    #[test]
+    fn registered_states_returns_all_registered_keys() {
+        use crate::task::{RouterTask, TaskConfig};
+
+        struct GoRoute;
+        #[task::router]
+        impl RouterTask<TestState> for GoRoute {
+            fn config(&self) -> TaskConfig {
+                TaskConfig::minimal()
+            }
+            async fn route(&self, _res: &Resources) -> Result<TaskResult<TestState>, CanoError> {
+                Ok(TaskResult::Single(TestState::Process))
+            }
+        }
+
+        let wf = Workflow::bare()
+            .register(TestState::Start, SimpleTask::new(TestState::Process))
+            .register_router(TestState::Process, GoRoute)
+            .register_split(
+                TestState::Split,
+                vec![SimpleTask::new(TestState::Join)],
+                JoinConfig::new(JoinStrategy::All, TestState::Join),
+            )
+            .add_exit_state(TestState::Complete);
+
+        let mut registered: Vec<TestState> = wf.registered_states().cloned().collect();
+        registered.sort_by_key(|s| format!("{s:?}"));
+        assert_eq!(
+            registered,
+            vec![TestState::Process, TestState::Split, TestState::Start]
+        );
     }
 
     #[test]

--- a/cano/src/workflow.rs
+++ b/cano/src/workflow.rs
@@ -92,7 +92,7 @@ mod compensation;
 mod execution;
 mod join;
 #[cfg(test)]
-mod test_support;
+pub(crate) mod test_support;
 
 pub use execution::StateEntry;
 pub use join::{JoinConfig, JoinStrategy, SplitResult, SplitTaskResult};

--- a/cano/src/workflow/compensation.rs
+++ b/cano/src/workflow/compensation.rs
@@ -678,7 +678,6 @@ where
 mod tests {
     use super::*;
     use crate::PollErrorPolicy;
-    use crate::observer::WorkflowObserver;
     use crate::resource::Resources;
     use crate::saga;
     use crate::saga::CompensatableTask;
@@ -696,27 +695,6 @@ mod tests {
 
     use crate::recovery::{CheckpointRow, CheckpointStore};
     use std::sync::Mutex;
-
-    /// Records `(event, workflow_id, sequence)` for `on_checkpoint` / `on_resume`.
-    /// Thin observer over a shared `Recorder<E>` (see `test_support`).
-    struct CkptObserver(Arc<Recorder<(&'static str, String, u64)>>);
-    impl WorkflowObserver for CkptObserver {
-        fn on_checkpoint(&self, workflow_id: &str, sequence: u64) {
-            self.0
-                .record(("checkpoint", workflow_id.to_string(), sequence));
-        }
-        fn on_resume(&self, workflow_id: &str, sequence: u64) {
-            self.0.record(("resume", workflow_id.to_string(), sequence));
-        }
-    }
-    impl CkptObserver {
-        /// Convenience: wraps a fresh `Recorder` and returns both halves.
-        #[allow(clippy::type_complexity)] // Vec event-shape is the whole point of Recorder
-        fn new() -> (Self, Arc<Recorder<(&'static str, String, u64)>>) {
-            let rec = Recorder::new();
-            (Self(rec.clone()), rec)
-        }
-    }
 
     #[tokio::test]
     async fn checkpoint_row_written_for_each_state_entered() {
@@ -786,7 +764,7 @@ mod tests {
 
         let start_task = SimpleTask::new(TestState::Process);
         let process_task = SimpleTask::new(TestState::Complete);
-        let (observer, rec) = CkptObserver::new();
+        let (observer, rec) = EventLog::new();
         let workflow = Workflow::bare()
             .register(TestState::Start, start_task.clone())
             .register(TestState::Process, process_task.clone())
@@ -819,13 +797,10 @@ mod tests {
                 (3, "Complete".to_string()),
             ]
         );
+        assert_eq!(rec.resumes(), vec![("run-2".to_string(), 1)]);
         assert_eq!(
-            rec.snapshot(),
-            vec![
-                ("resume", "run-2".to_string(), 1),
-                ("checkpoint", "run-2".to_string(), 2),
-                ("checkpoint", "run-2".to_string(), 3),
-            ]
+            rec.checkpoints(),
+            vec![("run-2".to_string(), 2), ("run-2".to_string(), 3)]
         );
     }
 
@@ -944,7 +919,6 @@ mod tests {
     async fn router_state_produces_no_checkpoint_row_and_sequences_are_dense() {
         // Note: inside the `cano` crate the inherent `#[task::router(state = S)]` form emits
         // `::cano::RouterTask<...>` paths that don't resolve. Use the trait-impl form instead.
-        use crate::observer::WorkflowObserver;
         use crate::task::{RouterTask, TaskConfig};
 
         struct RouteToWork;
@@ -959,18 +933,10 @@ mod tests {
             }
         }
 
-        // Observe on_state_enter and on_checkpoint to verify router fires the
-        // former but NOT the latter.
-        struct StateEnterObserver(Arc<Recorder<String>>);
-        impl WorkflowObserver for StateEnterObserver {
-            fn on_state_enter(&self, state: &str) {
-                self.0.record(state.to_string());
-            }
-        }
-
         let store = Arc::new(MemCheckpoints::default());
-        let state_rec = Recorder::<String>::new();
-        let (ckpt_obs, ckpt_rec) = CkptObserver::new();
+        // One `EventLog` observes both on_state_enter and on_checkpoint, to verify the
+        // router fires the former but NOT the latter.
+        let (obs, rec) = EventLog::new();
 
         // Route (router) → Process (single) → Complete (exit)
         let workflow = Workflow::bare()
@@ -979,8 +945,7 @@ mod tests {
             .add_exit_state(TestState::Complete)
             .with_checkpoint_store(store.clone())
             .with_workflow_id("router-run")
-            .with_observer(Arc::new(StateEnterObserver(state_rec.clone())))
-            .with_observer(Arc::new(ckpt_obs));
+            .with_observer(Arc::new(obs));
 
         assert_eq!(
             workflow.orchestrate(TestState::Start).await.unwrap(),
@@ -989,7 +954,7 @@ mod tests {
 
         // `on_state_enter` fires for ALL states (including the router).
         assert_eq!(
-            state_rec.snapshot(),
+            rec.state_enters(),
             vec!["Start", "Process", "Complete"],
             "on_state_enter fires for every state including the router"
         );
@@ -1003,11 +968,8 @@ mod tests {
 
         // `on_checkpoint` must not have fired for the Start/router state.
         assert_eq!(
-            ckpt_rec.snapshot(),
-            vec![
-                ("checkpoint", "router-run".to_string(), 0),
-                ("checkpoint", "router-run".to_string(), 1),
-            ],
+            rec.checkpoints(),
+            vec![("router-run".to_string(), 0), ("router-run".to_string(), 1)],
             "on_checkpoint fires only for non-router states"
         );
     }
@@ -2165,17 +2127,11 @@ mod tests {
             }
         }
 
-        struct Rec(Arc<Recorder<(Duration, Duration)>>);
-        impl WorkflowObserver for Rec {
-            fn on_workflow_timeout(&self, elapsed: Duration, limit: Duration) {
-                self.0.record((elapsed, limit));
-            }
-        }
-        let rec = Recorder::<(Duration, Duration)>::new();
+        let (obs, rec) = EventLog::new();
 
         let workflow = Workflow::bare()
             .with_total_timeout(Duration::from_millis(40))
-            .with_observer(Arc::new(Rec(rec.clone())))
+            .with_observer(Arc::new(obs))
             .register(TestState::Start, SimpleTask::new(TestState::Process))
             .register(TestState::Process, SlowProcess)
             .add_exit_state(TestState::Complete)
@@ -2195,7 +2151,7 @@ mod tests {
             "got: {err}"
         );
 
-        let events = rec.snapshot();
+        let events = rec.timeouts();
         assert_eq!(events.len(), 1, "on_workflow_timeout should fire once");
         let (elapsed_hook, limit_hook) = events[0];
         assert_eq!(limit_hook, Duration::from_millis(40));
@@ -3277,28 +3233,20 @@ mod tests {
             }
         }
 
-        struct ClearObserver(Arc<Recorder<(String, String)>>);
-        impl WorkflowObserver for ClearObserver {
-            fn on_checkpoint_clear_failed(&self, workflow_id: &str, error: &CanoError) {
-                self.0
-                    .record((workflow_id.to_string(), error.message().to_string()));
-            }
-        }
-
         let store = Arc::new(ClearFailsStore(MemCheckpoints::default()));
-        let rec = Recorder::<(String, String)>::new();
+        let (obs, rec) = EventLog::new();
 
         let workflow = Workflow::bare()
             .register(TestState::Start, SimpleTask::new(TestState::Complete))
             .add_exit_state(TestState::Complete)
             .with_checkpoint_store(store.clone())
             .with_workflow_id("clear-test")
-            .with_observer(Arc::new(ClearObserver(rec.clone())));
+            .with_observer(Arc::new(obs));
 
         // Successful run that triggers the clear-on-success path.
         workflow.orchestrate(TestState::Start).await.unwrap();
 
-        let calls = rec.snapshot();
+        let calls = rec.clear_failures();
         assert_eq!(calls.len(), 1, "expected one clear-failure event");
         assert_eq!(calls[0].0, "clear-test");
         assert!(
@@ -3732,13 +3680,7 @@ mod tests {
         );
 
         // Observer that records every on_resume call.
-        struct OnResumeRec(Arc<Recorder<u64>>);
-        impl WorkflowObserver for OnResumeRec {
-            fn on_resume(&self, _id: &str, sequence: u64) {
-                self.0.record(sequence);
-            }
-        }
-        let rec = Recorder::<u64>::new();
+        let (obs, rec) = EventLog::new();
 
         let workflow = Workflow::new(resources)
             .register_with_compensation(
@@ -3748,7 +3690,7 @@ mod tests {
             .register(TestState::Process, FailTask::new(true))
             .add_exit_state(TestState::Complete)
             .with_checkpoint_store(store.clone())
-            .with_observer(Arc::new(OnResumeRec(rec.clone())));
+            .with_observer(Arc::new(obs));
 
         let err = workflow.resume_from("f3").await.unwrap_err();
         // Setup ran and failed.
@@ -3764,7 +3706,7 @@ mod tests {
         );
         // on_resume must NOT have fired — the resume didn't actually start.
         assert!(
-            rec.is_empty(),
+            rec.resumes().is_empty(),
             "on_resume must not fire when setup_all fails"
         );
     }
@@ -3926,22 +3868,6 @@ mod tests {
         // rename without a `with_workflow_version` bump). Operators couldn't
         // see the gap. Now the engine fires `on_unknown_resume_state` per
         // unrecognized row so observers/metrics can surface the drift.
-        struct RecordObs(Arc<Recorder<(String, u64, String)>>);
-        impl WorkflowObserver for RecordObs {
-            fn on_unknown_resume_state(
-                &self,
-                workflow_id: &str,
-                sequence: u64,
-                unknown_state_label: &str,
-            ) {
-                self.0.record((
-                    workflow_id.to_string(),
-                    sequence,
-                    unknown_state_label.to_string(),
-                ));
-            }
-        }
-
         let store = Arc::new(MemCheckpoints::default());
         // Pre-populate the log with a StateEntry referencing a state ("Charge")
         // the current workflow no longer registers, plus a registered state
@@ -3971,17 +3897,17 @@ mod tests {
             .await
             .unwrap();
 
-        let rec = Recorder::<(String, u64, String)>::new();
+        let (obs, rec) = EventLog::new();
         let workflow = Workflow::bare()
             .register(TestState::Start, SimpleTask::new(TestState::Process))
             .register(TestState::Process, FailTask::new(true))
             .add_exit_state(TestState::Complete)
             .with_checkpoint_store(store.clone())
-            .with_observer(Arc::new(RecordObs(rec.clone())));
+            .with_observer(Arc::new(obs));
 
         // Resume succeeds (label dropped from path; gap surfaced via observer).
         let _ = workflow.resume_from("f-rename").await;
-        let recorded = rec.snapshot();
+        let recorded = rec.unknown_states();
         assert_eq!(
             recorded.len(),
             1,
@@ -4178,7 +4104,7 @@ mod rehydrated_run_tests {
     use super::*;
     use crate::observer::WorkflowObserver;
     use crate::recovery::CheckpointRow;
-    use crate::workflow::test_support::{Recorder, TestState};
+    use crate::workflow::test_support::{EventLog, TestState};
 
     /// Resolver that matches stored labels back to `TestState`. Returns None
     /// for any label not in this table — used to exercise the F11 fan-out.
@@ -4191,24 +4117,6 @@ mod rehydrated_run_tests {
             "Complete" => Some(TestState::Complete),
             "Error" => Some(TestState::Error),
             _ => None,
-        }
-    }
-
-    /// Captures `on_unknown_resume_state` events for assertion. Thin observer
-    /// over a shared `Recorder<E>` (see `test_support`).
-    struct UnknownStateRecorder(Arc<Recorder<(String, u64, String)>>);
-    impl WorkflowObserver for UnknownStateRecorder {
-        fn on_unknown_resume_state(
-            &self,
-            workflow_id: &str,
-            sequence: u64,
-            unknown_state_label: &str,
-        ) {
-            self.0.record((
-                workflow_id.to_string(),
-                sequence,
-                unknown_state_label.to_string(),
-            ));
         }
     }
 
@@ -4317,9 +4225,8 @@ mod rehydrated_run_tests {
             CheckpointRow::new(1, "Charge", "B").with_workflow_version(0),
             CheckpointRow::new(2, "Process", "C").with_workflow_version(0),
         ];
-        let recorder = Recorder::<(String, u64, String)>::new();
-        let observer_dyn: Arc<dyn WorkflowObserver> =
-            Arc::new(UnknownStateRecorder(recorder.clone()));
+        let (obs, recorder) = EventLog::new();
+        let observer_dyn: Arc<dyn WorkflowObserver> = Arc::new(obs);
         let observers = [observer_dyn];
         let rh = RehydratedRun::<TestState>::from_rows(
             &rows,
@@ -4333,7 +4240,7 @@ mod rehydrated_run_tests {
         assert_eq!(rh.resume_state_entry_cutoff, 2);
         // Only Start made it (Charge dropped, Process is the resume state).
         assert_eq!(rh.prior_transitions, vec![TestState::Start]);
-        let events = recorder.snapshot();
+        let events = recorder.unknown_states();
         assert_eq!(events.len(), 1, "Charge row must fire the hook once");
         assert_eq!(
             events[0],

--- a/cano/src/workflow/execution.rs
+++ b/cano/src/workflow/execution.rs
@@ -2490,18 +2490,10 @@ mod tests {
 
     #[tokio::test]
     async fn total_timeout_fires_on_workflow_timeout_observer_hook() {
-        use crate::observer::WorkflowObserver;
-
-        struct Rec(Arc<Recorder<(Duration, Duration)>>);
-        impl WorkflowObserver for Rec {
-            fn on_workflow_timeout(&self, elapsed: Duration, limit: Duration) {
-                self.0.record((elapsed, limit));
-            }
-        }
-        let rec = Recorder::<(Duration, Duration)>::new();
+        let (obs, rec) = EventLog::new();
         let workflow = Workflow::bare()
             .with_total_timeout(Duration::from_millis(20))
-            .with_observer(Arc::new(Rec(rec.clone())))
+            .with_observer(Arc::new(obs))
             .register(
                 TestState::Start,
                 SleepyTask {
@@ -2511,7 +2503,7 @@ mod tests {
             )
             .add_exit_state(TestState::Complete);
         let _ = workflow.orchestrate(TestState::Start).await;
-        let events = rec.snapshot();
+        let events = rec.timeouts();
         assert_eq!(events.len(), 1, "hook should fire exactly once");
         let (elapsed, limit) = events[0];
         assert_eq!(limit, Duration::from_millis(20));
@@ -2841,30 +2833,9 @@ mod wrap_and_drain_tests {
 mod dispatch_with_budget_tests {
     use super::*;
     use crate::observer::WorkflowObserver;
-    use crate::workflow::test_support::{Recorder, TestState};
+    use crate::workflow::test_support::{EventLog, TestState};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
-
-    /// Captures every observer event so tests can assert exact fan-out shape.
-    /// Thin observer over a shared `Recorder<String>` (see `test_support`).
-    struct CapturingObserver(Arc<Recorder<String>>);
-    impl WorkflowObserver for CapturingObserver {
-        fn on_task_failure(&self, task_id: &str, _err: &CanoError) {
-            self.0.record(format!("task_failure:{task_id}"));
-        }
-        fn on_workflow_timeout(&self, _elapsed: Duration, limit: Duration) {
-            self.0
-                .record(format!("workflow_timeout:{}ms", limit.as_millis()));
-        }
-    }
-    impl CapturingObserver {
-        /// Wraps a fresh `Recorder` and returns both halves: the observer for
-        /// `Workflow::with_observer`, and the recorder for snapshotting.
-        fn new() -> (Self, Arc<Recorder<String>>) {
-            let rec = Recorder::new();
-            (Self(rec.clone()), rec)
-        }
-    }
 
     fn budget_for(limit: Duration) -> Option<(std::time::Instant, Duration, tokio::time::Instant)> {
         let start = std::time::Instant::now();
@@ -2876,7 +2847,7 @@ mod dispatch_with_budget_tests {
     async fn no_budget_passes_future_result_through_unchanged() {
         // When `step_budget` is None we are on the zero-cost path; the helper
         // must NOT touch observers and must return the inner result verbatim.
-        let (observer, rec) = CapturingObserver::new();
+        let (observer, rec) = EventLog::new();
         let observer_dyn: Arc<dyn WorkflowObserver> = Arc::new(observer);
         let observers = [observer_dyn];
 
@@ -2905,7 +2876,7 @@ mod dispatch_with_budget_tests {
     async fn budget_with_timely_future_passes_through_without_observer_fanout() {
         // The deadline is comfortably in the future; the inner future returns
         // immediately. Helper returns the result; fan-out closure stays silent.
-        let (observer, rec) = CapturingObserver::new();
+        let (observer, rec) = EventLog::new();
         let observer_dyn: Arc<dyn WorkflowObserver> = Arc::new(observer);
         let observers = [observer_dyn];
 
@@ -2931,7 +2902,7 @@ mod dispatch_with_budget_tests {
         // A deadline already in the past trips the wrapper immediately. The
         // fan-out closure must run for each registered observer; the helper
         // must always fire `on_workflow_timeout`. Result is WorkflowTimeout.
-        let (observer, rec) = CapturingObserver::new();
+        let (observer, rec) = EventLog::new();
         let observer_dyn: Arc<dyn WorkflowObserver> = Arc::new(observer);
         let observers = [observer_dyn];
 
@@ -2966,7 +2937,7 @@ mod dispatch_with_budget_tests {
             "fan-out closure must fire exactly once (per registered observer)"
         );
         assert_eq!(
-            rec.snapshot(),
+            rec.labels(),
             vec![
                 "task_failure:synthetic".to_string(),
                 "workflow_timeout:50ms".to_string(),
@@ -3011,8 +2982,8 @@ mod dispatch_with_budget_tests {
     async fn budget_trip_fires_fan_out_once_per_observer() {
         // Two observers: the fan-out closure must run once per observer, and
         // each observer must see `on_workflow_timeout` exactly once.
-        let (a_obs, a_rec) = CapturingObserver::new();
-        let (b_obs, b_rec) = CapturingObserver::new();
+        let (a_obs, a_rec) = EventLog::new();
+        let (b_obs, b_rec) = EventLog::new();
         let observers: [Arc<dyn WorkflowObserver>; 2] = [Arc::new(a_obs), Arc::new(b_obs)];
         let call_count = Arc::new(AtomicUsize::new(0));
         let cc = Arc::clone(&call_count);
@@ -3045,8 +3016,8 @@ mod dispatch_with_budget_tests {
             "task_failure:multi".to_string(),
             "workflow_timeout:5ms".to_string(),
         ];
-        assert_eq!(a_rec.snapshot(), expected);
-        assert_eq!(b_rec.snapshot(), expected);
+        assert_eq!(a_rec.labels(), expected);
+        assert_eq!(b_rec.labels(), expected);
     }
 
     #[tokio::test]

--- a/cano/src/workflow/test_support.rs
+++ b/cano/src/workflow/test_support.rs
@@ -12,10 +12,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
 
 use cano_macros::task;
 
 use crate::error::CanoError;
+use crate::observer::WorkflowObserver;
 use crate::recovery::{CheckpointRow, CheckpointStore};
 use crate::resource::Resources;
 use crate::store::MemoryStore;
@@ -229,6 +231,242 @@ impl<E: Clone + Send + Sync + 'static> Recorder<E> {
     }
     pub(crate) fn is_empty(&self) -> bool {
         self.events.lock().unwrap().is_empty()
+    }
+}
+
+/// One captured [`WorkflowObserver`] event, one variant per hook. Recorded in
+/// arrival order by [`EventLog`] so tests can assert both *what* fired and the
+/// *order* it fired in. Replaces the per-test-module bespoke observers that each
+/// recorded a different bespoke tuple/string shape.
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TestEvent {
+    StateEnter(String),
+    TaskStart(String),
+    TaskSuccess(String),
+    TaskFailure {
+        task: String,
+        error: String,
+    },
+    Retry {
+        task: String,
+        attempt: u32,
+    },
+    CircuitOpen(String),
+    Checkpoint {
+        workflow_id: String,
+        sequence: u64,
+    },
+    Resume {
+        workflow_id: String,
+        sequence: u64,
+    },
+    WorkflowTimeout {
+        elapsed: Duration,
+        limit: Duration,
+    },
+    CheckpointClearFailed {
+        workflow_id: String,
+        error: String,
+    },
+    UnknownResumeState {
+        workflow_id: String,
+        sequence: u64,
+        label: String,
+    },
+}
+
+/// A [`WorkflowObserver`] that records *every* hook into a shared
+/// [`Recorder<TestEvent>`]. Construct with [`EventLog::new`], hand the `EventLog`
+/// to [`Workflow::with_observer`](crate::workflow::Workflow::with_observer), and
+/// snapshot/inspect via the returned `Recorder` handle (typed accessors like
+/// [`Recorder::<TestEvent>::checkpoints`] and the ordered [`Recorder::<TestEvent>::labels`]).
+pub(crate) struct EventLog(Arc<Recorder<TestEvent>>);
+
+#[allow(dead_code)]
+impl EventLog {
+    /// Wraps a fresh `Recorder` and returns both halves: the observer for
+    /// `Workflow::with_observer`, and the recorder for snapshotting — mirroring
+    /// the `*Observer::new()` convention the bespoke observers used.
+    pub(crate) fn new() -> (Self, Arc<Recorder<TestEvent>>) {
+        let rec = Recorder::new();
+        (Self(rec.clone()), rec)
+    }
+}
+
+impl WorkflowObserver for EventLog {
+    fn on_state_enter(&self, state: &str) {
+        self.0.record(TestEvent::StateEnter(state.to_string()));
+    }
+    fn on_task_start(&self, task_id: &str) {
+        self.0.record(TestEvent::TaskStart(task_id.to_string()));
+    }
+    fn on_task_success(&self, task_id: &str) {
+        self.0.record(TestEvent::TaskSuccess(task_id.to_string()));
+    }
+    fn on_task_failure(&self, task_id: &str, err: &CanoError) {
+        self.0.record(TestEvent::TaskFailure {
+            task: task_id.to_string(),
+            error: err.to_string(),
+        });
+    }
+    fn on_retry(&self, task_id: &str, attempt: u32) {
+        self.0.record(TestEvent::Retry {
+            task: task_id.to_string(),
+            attempt,
+        });
+    }
+    fn on_circuit_open(&self, task_id: &str) {
+        self.0.record(TestEvent::CircuitOpen(task_id.to_string()));
+    }
+    fn on_checkpoint(&self, workflow_id: &str, sequence: u64) {
+        self.0.record(TestEvent::Checkpoint {
+            workflow_id: workflow_id.to_string(),
+            sequence,
+        });
+    }
+    fn on_resume(&self, workflow_id: &str, sequence: u64) {
+        self.0.record(TestEvent::Resume {
+            workflow_id: workflow_id.to_string(),
+            sequence,
+        });
+    }
+    fn on_workflow_timeout(&self, elapsed: Duration, limit: Duration) {
+        self.0.record(TestEvent::WorkflowTimeout { elapsed, limit });
+    }
+    fn on_checkpoint_clear_failed(&self, workflow_id: &str, error: &CanoError) {
+        self.0.record(TestEvent::CheckpointClearFailed {
+            workflow_id: workflow_id.to_string(),
+            error: error.to_string(),
+        });
+    }
+    fn on_unknown_resume_state(&self, workflow_id: &str, sequence: u64, unknown_state_label: &str) {
+        self.0.record(TestEvent::UnknownResumeState {
+            workflow_id: workflow_id.to_string(),
+            sequence,
+            label: unknown_state_label.to_string(),
+        });
+    }
+}
+
+/// Typed projections over a recorded [`TestEvent`] stream. Each returns the
+/// fields the relevant tests assert on, in arrival order; tests that need a
+/// different shape can still `snapshot()` and match variants directly.
+#[allow(dead_code)]
+impl Recorder<TestEvent> {
+    /// Short `"kind:arg"` rendering of each event, in order — for cross-hook
+    /// ordering assertions (e.g. state-enter before task-start before success).
+    pub(crate) fn labels(&self) -> Vec<String> {
+        self.snapshot()
+            .into_iter()
+            .map(|e| match e {
+                TestEvent::StateEnter(s) => format!("state_enter:{s}"),
+                TestEvent::TaskStart(t) => format!("task_start:{t}"),
+                TestEvent::TaskSuccess(t) => format!("task_success:{t}"),
+                TestEvent::TaskFailure { task, .. } => format!("task_failure:{task}"),
+                TestEvent::Retry { task, attempt } => format!("retry:{task}:{attempt}"),
+                TestEvent::CircuitOpen(t) => format!("circuit_open:{t}"),
+                TestEvent::Checkpoint {
+                    workflow_id,
+                    sequence,
+                } => format!("checkpoint:{workflow_id}:{sequence}"),
+                TestEvent::Resume {
+                    workflow_id,
+                    sequence,
+                } => format!("resume:{workflow_id}:{sequence}"),
+                TestEvent::WorkflowTimeout { limit, .. } => {
+                    format!("workflow_timeout:{}ms", limit.as_millis())
+                }
+                TestEvent::CheckpointClearFailed { workflow_id, .. } => {
+                    format!("checkpoint_clear_failed:{workflow_id}")
+                }
+                TestEvent::UnknownResumeState { label, .. } => {
+                    format!("unknown_resume_state:{label}")
+                }
+            })
+            .collect()
+    }
+    /// State labels passed to `on_state_enter`, in order.
+    pub(crate) fn state_enters(&self) -> Vec<String> {
+        self.snapshot()
+            .into_iter()
+            .filter_map(|e| match e {
+                TestEvent::StateEnter(s) => Some(s),
+                _ => None,
+            })
+            .collect()
+    }
+    /// `(task, attempt)` for each `on_retry`, in order.
+    pub(crate) fn retries(&self) -> Vec<(String, u32)> {
+        self.snapshot()
+            .into_iter()
+            .filter_map(|e| match e {
+                TestEvent::Retry { task, attempt } => Some((task, attempt)),
+                _ => None,
+            })
+            .collect()
+    }
+    /// `(workflow_id, sequence)` for each `on_checkpoint`, in order.
+    pub(crate) fn checkpoints(&self) -> Vec<(String, u64)> {
+        self.snapshot()
+            .into_iter()
+            .filter_map(|e| match e {
+                TestEvent::Checkpoint {
+                    workflow_id,
+                    sequence,
+                } => Some((workflow_id, sequence)),
+                _ => None,
+            })
+            .collect()
+    }
+    /// `(workflow_id, sequence)` for each `on_resume`, in order.
+    pub(crate) fn resumes(&self) -> Vec<(String, u64)> {
+        self.snapshot()
+            .into_iter()
+            .filter_map(|e| match e {
+                TestEvent::Resume {
+                    workflow_id,
+                    sequence,
+                } => Some((workflow_id, sequence)),
+                _ => None,
+            })
+            .collect()
+    }
+    /// `(elapsed, limit)` for each `on_workflow_timeout`, in order.
+    pub(crate) fn timeouts(&self) -> Vec<(Duration, Duration)> {
+        self.snapshot()
+            .into_iter()
+            .filter_map(|e| match e {
+                TestEvent::WorkflowTimeout { elapsed, limit } => Some((elapsed, limit)),
+                _ => None,
+            })
+            .collect()
+    }
+    /// `(workflow_id, error)` for each `on_checkpoint_clear_failed`, in order.
+    pub(crate) fn clear_failures(&self) -> Vec<(String, String)> {
+        self.snapshot()
+            .into_iter()
+            .filter_map(|e| match e {
+                TestEvent::CheckpointClearFailed { workflow_id, error } => {
+                    Some((workflow_id, error))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+    /// `(workflow_id, sequence, label)` for each `on_unknown_resume_state`, in order.
+    pub(crate) fn unknown_states(&self) -> Vec<(String, u64, String)> {
+        self.snapshot()
+            .into_iter()
+            .filter_map(|e| match e {
+                TestEvent::UnknownResumeState {
+                    workflow_id,
+                    sequence,
+                    label,
+                } => Some((workflow_id, sequence, label)),
+                _ => None,
+            })
+            .collect()
     }
 }
 

--- a/cano/tests/testing_module_e2e.rs
+++ b/cano/tests/testing_module_e2e.rs
@@ -1,0 +1,206 @@
+//! Integration coverage for the `cano::testing` module.
+//!
+//! Drives real workflows through the public testing helpers — the `RecordingObserver`,
+//! the `InMemoryCheckpointStore` (including a full crash-and-resume cycle), the
+//! `panic_on_attempt` task factory, and the `assert_compensation_ran` saga assertion.
+//!
+//! Requires the `testing` feature.
+#![cfg(feature = "testing")]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use cano::prelude::*;
+use cano::testing::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum S {
+    Start,
+    Work,
+    Finish,
+    Done,
+}
+
+struct Go(S);
+#[task(state = S)]
+impl Go {
+    async fn run_bare(&self) -> Result<TaskResult<S>, CanoError> {
+        Ok(TaskResult::Single(self.0.clone()))
+    }
+}
+
+#[tokio::test]
+async fn recording_observer_captures_path_and_checkpoints() {
+    let observer = Arc::new(RecordingObserver::new());
+    let store = Arc::new(InMemoryCheckpointStore::new());
+    let wf = Workflow::bare()
+        .register(S::Start, Go(S::Work))
+        .register(S::Work, Go(S::Done))
+        .add_exit_state(S::Done)
+        .with_observer(observer.clone())
+        .with_checkpoint_store(store.clone())
+        .with_workflow_id("run-1");
+
+    assert_eq!(wf.orchestrate(S::Start).await.unwrap(), S::Done);
+    observer.assert_path(&["Start", "Work", "Done"]);
+    observer.assert_completed_with("Done");
+
+    // One checkpoint append per state entry (Start, Work, Done).
+    let checkpoints = observer
+        .events()
+        .into_iter()
+        .filter(|e| matches!(e, RecordedEvent::Checkpoint { .. }))
+        .count();
+    assert_eq!(checkpoints, 3);
+}
+
+/// A `Work` task that fails on its first run, then succeeds — used to simulate a crash
+/// before `Done`, so a later `resume_from` re-runs it and finishes.
+struct FlakyWork(Arc<AtomicUsize>);
+#[task(state = S)]
+impl FlakyWork {
+    fn config(&self) -> TaskConfig {
+        TaskConfig::minimal() // fail fast so the run stops and the log persists
+    }
+    async fn run_bare(&self) -> Result<TaskResult<S>, CanoError> {
+        if self.0.fetch_add(1, Ordering::SeqCst) == 0 {
+            Err(CanoError::task_execution("crash before Done"))
+        } else {
+            Ok(TaskResult::Single(S::Done))
+        }
+    }
+}
+
+#[tokio::test]
+async fn in_memory_store_supports_resume_after_failure() {
+    let store = Arc::new(InMemoryCheckpointStore::new());
+    let runs = Arc::new(AtomicUsize::new(0));
+    let wf_id = "resume-run";
+
+    let build = |runs: Arc<AtomicUsize>| {
+        Workflow::bare()
+            .register(S::Start, Go(S::Work))
+            .register(S::Work, FlakyWork(runs))
+            .add_exit_state(S::Done)
+            .with_checkpoint_store(store.clone())
+            .with_workflow_id(wf_id)
+    };
+
+    // Generation 1: crashes at Work. The log keeps Start + Work entries.
+    build(runs.clone())
+        .orchestrate(S::Start)
+        .await
+        .expect_err("generation 1 must fail at Work");
+    assert_eq!(store.load_run(wf_id).await.unwrap().len(), 2);
+
+    // Generation 2: resume re-enters at Work, re-runs it (now succeeds), reaches Done.
+    let observer = Arc::new(RecordingObserver::new());
+    let resumed = build(runs.clone()).with_observer(observer.clone());
+    assert_eq!(resumed.resume_from(wf_id).await.unwrap(), S::Done);
+    assert!(
+        observer
+            .events()
+            .iter()
+            .any(|e| matches!(e, RecordedEvent::Resume { .. })),
+        "resume must fire an on_resume event"
+    );
+    // Work ran twice total (gen 1 failure + gen 2 success); Start did not re-run.
+    assert_eq!(runs.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn panic_on_attempt_fails_fast_with_panic_error() {
+    let observer = Arc::new(RecordingObserver::new());
+    let wf = Workflow::bare()
+        .register(S::Start, panic_on_attempt(1, S::Done))
+        .add_exit_state(S::Done)
+        .with_observer(observer.clone());
+    let err = wf.orchestrate(S::Start).await.unwrap_err();
+    assert!(err.to_string().contains("panic"), "{err}");
+    // Panics are not retried — no retry event recorded.
+    assert!(
+        !observer
+            .events()
+            .iter()
+            .any(|e| matches!(e, RecordedEvent::Retry { .. }))
+    );
+}
+
+// ---- Saga: assert_compensation_ran -----------------------------------------------------
+
+#[derive(Default, Clone)]
+struct Log(Arc<Mutex<Vec<String>>>);
+#[resource]
+impl Resource for Log {}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct Unit;
+
+struct Step1;
+#[saga::task(state = S)]
+impl Step1 {
+    type Output = Unit;
+    async fn run(&self, _res: &Resources) -> Result<(TaskResult<S>, Unit), CanoError> {
+        Ok((TaskResult::Single(S::Work), Unit))
+    }
+    async fn compensate(&self, res: &Resources, _o: Unit) -> Result<(), CanoError> {
+        res.get::<Log, _>("log")?
+            .0
+            .lock()
+            .unwrap()
+            .push("step1".into());
+        Ok(())
+    }
+}
+
+struct Step2;
+#[saga::task(state = S)]
+impl Step2 {
+    type Output = Unit;
+    async fn run(&self, _res: &Resources) -> Result<(TaskResult<S>, Unit), CanoError> {
+        Ok((TaskResult::Single(S::Finish), Unit))
+    }
+    async fn compensate(&self, res: &Resources, _o: Unit) -> Result<(), CanoError> {
+        res.get::<Log, _>("log")?
+            .0
+            .lock()
+            .unwrap()
+            .push("step2".into());
+        Ok(())
+    }
+}
+
+struct Fail;
+#[task(state = S)]
+impl Fail {
+    fn config(&self) -> TaskConfig {
+        TaskConfig::minimal()
+    }
+    async fn run_bare(&self) -> Result<TaskResult<S>, CanoError> {
+        Err(CanoError::task_execution("boom"))
+    }
+}
+
+#[tokio::test]
+async fn assert_compensation_ran_matches_reverse_order() {
+    let log = Log::default();
+    let handle = log.clone();
+    let resources = Resources::new().insert("log", log);
+    let saga = Workflow::new(resources)
+        .register_with_compensation(S::Start, Step1)
+        .register_with_compensation(S::Work, Step2)
+        .register(S::Finish, Fail)
+        .add_exit_state(S::Done);
+    let _ = saga.orchestrate(S::Start).await; // fails, rolls back
+
+    let ran = handle.0.lock().unwrap().clone();
+    // Step2 completed last, so it compensates first; then Step1.
+    assert_compensation_ran(&ran, &["step2", "step1"]);
+}
+
+#[tokio::test]
+#[should_panic(expected = "compensation order mismatch")]
+async fn assert_compensation_ran_mismatch_panics() {
+    let ran = vec!["step1".to_string()];
+    assert_compensation_ran(&ran, &["step2", "step1"]);
+}

--- a/cano/tests/testing_state_coverage.rs
+++ b/cano/tests/testing_state_coverage.rs
@@ -1,0 +1,81 @@
+//! State-coverage assertions (`assert_all_states_entered` /
+//! `assert_registered_states_entered`) exercised across router hops, dead states, and
+//! explicit state lists.
+//!
+//! Requires the `testing` feature.
+#![cfg(feature = "testing")]
+
+use cano::prelude::*;
+use cano::testing::RecordingObserver;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum S {
+    Start,
+    Route,
+    Worker,
+    Orphan,
+    Done,
+}
+
+#[derive(Clone)]
+struct Go(S);
+#[task]
+impl Task<S> for Go {
+    async fn run_bare(&self) -> Result<TaskResult<S>, CanoError> {
+        Ok(TaskResult::Single(self.0.clone()))
+    }
+}
+
+struct RouteTo(S);
+#[task::router]
+impl RouterTask<S> for RouteTo {
+    fn config(&self) -> TaskConfig {
+        TaskConfig::minimal()
+    }
+    async fn route(&self, _res: &Resources) -> Result<TaskResult<S>, CanoError> {
+        Ok(TaskResult::Single(self.0.clone()))
+    }
+}
+
+#[tokio::test]
+async fn router_hop_is_counted() {
+    let observer = Arc::new(RecordingObserver::new());
+    let wf = Workflow::bare()
+        .register_router(S::Start, RouteTo(S::Route))
+        .register_router(S::Route, RouteTo(S::Worker))
+        .register(S::Worker, Go(S::Done))
+        .add_exit_state(S::Done)
+        .with_observer(observer.clone());
+    wf.orchestrate(S::Start).await.unwrap();
+    observer
+        .assert_registered_states_entered(&wf)
+        .expect("router hops counted");
+}
+
+#[tokio::test]
+async fn unregistered_routed_state_returns_err_does_not_panic() {
+    let observer = Arc::new(RecordingObserver::new());
+    let wf = Workflow::bare()
+        .register(S::Start, Go(S::Done))
+        .register(S::Orphan, Go(S::Done))
+        .add_exit_state(S::Done)
+        .with_observer(observer.clone());
+    wf.orchestrate(S::Start).await.unwrap();
+    let missing = observer.assert_registered_states_entered(&wf).unwrap_err();
+    assert!(missing.contains(&"Orphan".to_string()), "got: {missing:?}");
+}
+
+#[tokio::test]
+async fn multi_state_with_explicit_list() {
+    let observer = Arc::new(RecordingObserver::new());
+    let wf = Workflow::bare()
+        .register(S::Start, Go(S::Done))
+        .add_exit_state(S::Done)
+        .with_observer(observer.clone());
+    wf.orchestrate(S::Start).await.unwrap();
+    let missing = observer
+        .assert_all_states_entered(&[S::Start, S::Route, S::Worker])
+        .unwrap_err();
+    assert_eq!(missing, vec!["Route".to_string(), "Worker".to_string()]);
+}

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -132,13 +132,14 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 <p>
 Cano ships with <strong>no features enabled by default</strong>. <code>features = ["all"]</code> turns
-on all four optional features at once:
+on all five optional features at once:
 </p>
 <ul>
 <li><code>scheduler</code> — the <a href="scheduler/"><code>Scheduler</code></a> (cron + interval + manual triggers)</li>
 <li><code>tracing</code> — <a href="tracing/"><code>tracing</code>-crate spans</a> and the <code>TracingObserver</code></li>
 <li><code>recovery</code> — <a href="recovery/"><code>RedbCheckpointStore</code></a>, the embedded ACID checkpoint store (the <code>CheckpointStore</code> trait itself is always available)</li>
 <li><code>metrics</code> — <a href="metrics/"><code>metrics</code>-crate counters / histograms / gauges</a> and the <code>MetricsObserver</code></li>
+<li><code>testing</code> — <a href="testing/">batteries-included test fixtures</a> (recording observer, in-memory checkpoint store, resources builder); usually a <code>[dev-dependencies]</code> feature</li>
 </ul>
 <p>
 Pick only what you need — e.g. <code>features = ["recovery"]</code>, or omit <code>features</code>

--- a/docs/content/observers/_index.md
+++ b/docs/content/observers/_index.md
@@ -77,15 +77,19 @@ impl WorkflowObserver for TaskCounter {
     }
 }
 
-let counter = Arc::new(TaskCounter::default());
+#[tokio::main]
+async fn main() -> Result<(), CanoError> {
+    let counter = Arc::new(TaskCounter::default());
 
-let workflow = Workflow::bare()
-    .register(Step::Start, DoWork)
-    .add_exit_state(Step::Done)
-    .with_observer(counter.clone());
+    let workflow = Workflow::bare()
+        .register(Step::Start, DoWork)
+        .add_exit_state(Step::Done)
+        .with_observer(counter.clone());
 
-workflow.orchestrate(Step::Start).await?;
-assert_eq!(counter.0.load(Ordering::Relaxed), 1);
+    workflow.orchestrate(Step::Start).await?;
+    assert_eq!(counter.0.load(Ordering::Relaxed), 1);
+    Ok(())
+}
 ```
 <hr class="section-divider">
 
@@ -213,9 +217,12 @@ impl WorkflowObserver for ChannelObserver {
     }
 }
 
-let (tx, _rx) = channel();
-let observer: std::sync::Arc<dyn WorkflowObserver> =
-    std::sync::Arc::new(ChannelObserver { tx });
+fn main() {
+    let (tx, _rx) = channel();
+    let observer: std::sync::Arc<dyn WorkflowObserver> =
+        std::sync::Arc::new(ChannelObserver { tx });
+    let _ = observer;
+}
 ```
 <hr class="section-divider">
 
@@ -246,10 +253,16 @@ impl DoWork {
     }
 }
 
-Workflow::bare()
-    .register(Step::Start, DoWork)
-    .add_exit_state(Step::Done)
-    .with_observer(Arc::new(TracingObserver::new()))
+#[tokio::main]
+async fn main() -> Result<(), CanoError> {
+    let workflow = Workflow::bare()
+        .register(Step::Start, DoWork)
+        .add_exit_state(Step::Done)
+        .with_observer(Arc::new(TracingObserver::new()));
+
+    workflow.orchestrate(Step::Start).await?;
+    Ok(())
+}
 ```
 
 <p>It emits <strong>events, not spans</strong> — it does not reproduce the nested span tree the
@@ -322,17 +335,20 @@ checks sequentially.
 use cano::prelude::*;
 
 // PrimaryDb and ReadReplica are Resource impls (see ReadReplica above).
-let resources: Resources = Resources::new()
-    .insert("db", PrimaryDb)
-    .insert("replica", ReadReplica);
+#[tokio::main]
+async fn main() {
+    let resources: Resources = Resources::new()
+        .insert("db", PrimaryDb)
+        .insert("replica", ReadReplica);
 
-for (key, status) in resources.check_all_health().await {
-    println!("{key}: {status:?}");
-}
+    for (key, status) in resources.check_all_health().await {
+        println!("{key}: {status:?}");
+    }
 
-match resources.aggregate_health().await {
-    HealthStatus::Healthy => println!("all good"),
-    other => println!("attention needed: {other:?}"),
+    match resources.aggregate_health().await {
+        HealthStatus::Healthy => println!("all good"),
+        other => println!("attention needed: {other:?}"),
+    }
 }
 ```
 
@@ -395,14 +411,18 @@ impl FlakyLoad {
     }
 }
 
-let observer = Arc::new(PrintingObserver::default());
+#[tokio::main]
+async fn main() -> Result<(), CanoError> {
+    let observer = Arc::new(PrintingObserver::default());
 
-let workflow = Workflow::bare()
-    .register(Step::Load, FlakyLoad { remaining_failures: Arc::new(AtomicUsize::new(2)) })
-    .add_exit_state(Step::Done)
-    .with_observer(observer.clone());
+    let workflow = Workflow::bare()
+        .register(Step::Load, FlakyLoad { remaining_failures: Arc::new(AtomicUsize::new(2)) })
+        .add_exit_state(Step::Done)
+        .with_observer(observer.clone());
 
-workflow.orchestrate(Step::Load).await?;
-assert_eq!(observer.failures.load(Ordering::Relaxed), 0);
+    workflow.orchestrate(Step::Load).await?;
+    assert_eq!(observer.failures.load(Ordering::Relaxed), 0);
+    Ok(())
+}
 ```
 </div>

--- a/docs/content/recovery/_index.md
+++ b/docs/content/recovery/_index.md
@@ -74,16 +74,20 @@ impl WorkTask {
     }
 }
 
-let checkpoint_store = Arc::new(RedbCheckpointStore::new("workflow.redb")?);
+#[tokio::main]
+async fn main() -> Result<(), CanoError> {
+    let checkpoint_store = Arc::new(RedbCheckpointStore::new("workflow.redb")?);
 
-let workflow = Workflow::bare()
-    .register(Step::Start, StartTask)
-    .register(Step::Work, WorkTask)
-    .add_exit_state(Step::Done)
-    .with_checkpoint_store(checkpoint_store)
-    .with_workflow_id("run-42");
+    let workflow = Workflow::bare()
+        .register(Step::Start, StartTask)
+        .register(Step::Work, WorkTask)
+        .add_exit_state(Step::Done)
+        .with_checkpoint_store(checkpoint_store)
+        .with_workflow_id("run-42");
 
-workflow.orchestrate(Step::Start).await?;
+    workflow.orchestrate(Step::Start).await?;
+    Ok(())
+}
 ```
 <hr class="section-divider">
 
@@ -161,16 +165,20 @@ use cano::prelude::*;
 use cano::RedbCheckpointStore;
 use std::sync::Arc;
 
-let checkpoint_store = Arc::new(RedbCheckpointStore::new("workflow.redb")?);
-let workflow = Workflow::bare()
-    .register(Step::Start, StartTask)
-    .register(Step::Work, WorkTask)
-    .add_exit_state(Step::Done)
-    .with_checkpoint_store(checkpoint_store);
+#[tokio::main]
+async fn main() -> Result<(), CanoError> {
+    let checkpoint_store = Arc::new(RedbCheckpointStore::new("workflow.redb")?);
+    let workflow = Workflow::bare()
+        .register(Step::Start, StartTask)
+        .register(Step::Work, WorkTask)
+        .add_exit_state(Step::Done)
+        .with_checkpoint_store(checkpoint_store);
 
-// Some earlier process crashed mid-run; pick up where it left off.
-let final_state = workflow.resume_from("run-42").await?;
-assert_eq!(final_state, Step::Done);
+    // Some earlier process crashed mid-run; pick up where it left off.
+    let final_state = workflow.resume_from("run-42").await?;
+    assert_eq!(final_state, Step::Done);
+    Ok(())
+}
 ```
 
 <p>
@@ -414,27 +422,31 @@ impl FinalizeTask {
     }
 }
 
-let checkpoint_store = Arc::new(RedbCheckpointStore::new("recovery.redb")?);
-let resources = Resources::new().insert("crash", CrashOnce::default());
-let workflow = Workflow::new(resources)
-    .register(Step::Start, StartTask)
-    .register(Step::Process, ProcessTask)
-    .register(Step::Finalize, FinalizeTask)
-    .add_exit_state(Step::Done)
-    .with_checkpoint_store(checkpoint_store.clone())
-    .with_workflow_id("demo-run");
+#[tokio::main]
+async fn main() -> Result<(), CanoError> {
+    let checkpoint_store = Arc::new(RedbCheckpointStore::new("recovery.redb")?);
+    let resources = Resources::new().insert("crash", CrashOnce::default());
+    let workflow = Workflow::new(resources)
+        .register(Step::Start, StartTask)
+        .register(Step::Process, ProcessTask)
+        .register(Step::Finalize, FinalizeTask)
+        .add_exit_state(Step::Done)
+        .with_checkpoint_store(checkpoint_store.clone())
+        .with_workflow_id("demo-run");
 
-// Run 1: crashes inside ProcessTask. The Start and Process rows are already durable.
-let _ = workflow.orchestrate(Step::Start).await;
+    // Run 1: crashes inside ProcessTask. The Start and Process rows are already durable.
+    let _ = workflow.orchestrate(Step::Start).await;
 
-// Run 2: resume — re-runs ProcessTask (now it succeeds) and finishes at Done.
-let final_state = workflow.resume_from("demo-run").await?;
-assert_eq!(final_state, Step::Done);
+    // Run 2: resume — re-runs ProcessTask (now it succeeds) and finishes at Done.
+    let final_state = workflow.resume_from("demo-run").await?;
+    assert_eq!(final_state, Step::Done);
 
-// The append-only log: Start, Process (crash), Process (re-run), Finalize, Done —
-// all RowKind::StateEntry here, since this workflow has no compensatable or stepped states.
-for row in checkpoint_store.load_run("demo-run").await? {
-    println!("#{} {:?} {}  {}", row.sequence, row.kind, row.state, row.task_id);
+    // The append-only log: Start, Process (crash), Process (re-run), Finalize, Done —
+    // all RowKind::StateEntry here, since this workflow has no compensatable or stepped states.
+    for row in checkpoint_store.load_run("demo-run").await? {
+        println!("#{} {:?} {}  {}", row.sequence, row.kind, row.state, row.task_id);
+    }
+    Ok(())
 }
 ```
 </div>

--- a/docs/content/saga/_index.md
+++ b/docs/content/saga/_index.md
@@ -316,16 +316,19 @@ impl ShipOrder {
     }
 }
 
-let workflow = Workflow::bare()
-    .register_with_compensation(Step::Reserve, ReserveInventory)
-    .register(Step::Validate, ValidateOrder)              // plain — no compensation
-    .register_with_compensation(Step::Charge, ChargeCard)
-    .register(Step::Ship, ShipOrder)                      // plain — and it fails
-    .add_exit_state(Step::Done);
+#[tokio::main]
+async fn main() {
+    let workflow = Workflow::bare()
+        .register_with_compensation(Step::Reserve, ReserveInventory)
+        .register(Step::Validate, ValidateOrder)              // plain — no compensation
+        .register_with_compensation(Step::Charge, ChargeCard)
+        .register(Step::Ship, ShipOrder)                      // plain — and it fails
+        .add_exit_state(Step::Done);
 
-match workflow.orchestrate(Step::Reserve).await {
-    Ok(state) => println!("completed at {state:?}"),
-    Err(error) => println!("failed, rolled back: {error}"), // "courier unavailable" — the original error
+    match workflow.orchestrate(Step::Reserve).await {
+        Ok(state) => println!("completed at {state:?}"),
+        Err(error) => println!("failed, rolled back: {error}"), // "courier unavailable" — the original error
+    }
 }
 ```
 </div>

--- a/docs/content/testing/_index.md
+++ b/docs/content/testing/_index.md
@@ -78,21 +78,21 @@ impl Task<S> for OkTask {
     }
 }
 
-# #[tokio::main]
-# async fn main() {
-let observer = Arc::new(RecordingObserver::new());
-let wf = Workflow::bare()
-    .register(S::Start, OkTask)
-    .add_exit_state(S::Done)
-    .with_observer(observer.clone());
+#[tokio::test]
+async fn recording_observer_captures_the_path() {
+    let observer = Arc::new(RecordingObserver::new());
+    let wf = Workflow::bare()
+        .register(S::Start, OkTask)
+        .add_exit_state(S::Done)
+        .with_observer(observer.clone());
 
-assert_eq!(wf.orchestrate(S::Start).await.unwrap(), S::Done);
+    assert_eq!(wf.orchestrate(S::Start).await.unwrap(), S::Done);
 
-// Assert the whole path, or inspect events directly.
-observer.assert_path(&["Start", "Done"]);
-observer.assert_completed_with("Done");
-assert!(observer.events().iter().any(|e| matches!(e, RecordedEvent::TaskSucceeded { .. })));
-# }
+    // Assert the whole path, or inspect events directly.
+    observer.assert_path(&["Start", "Done"]);
+    observer.assert_completed_with("Done");
+    assert!(observer.events().iter().any(|e| matches!(e, RecordedEvent::TaskSucceeded { .. })));
+}
 ```
 
 <p>
@@ -101,6 +101,58 @@ assert!(observer.events().iter().any(|e| matches!(e, RecordedEvent::TaskSucceede
 <code>CircuitOpen</code>, <code>Checkpoint</code>, <code>Resume</code>). It is
 <code>#[non_exhaustive]</code> — match with a wildcard arm.
 </p>
+
+<h3 id="state-coverage">State-coverage assertions</h3>
+
+<p>
+Two helpers turn the recorded <code>on_state_enter</code> events into CI guardrails that catch
+<strong>dead states</strong> (a state you registered but nothing ever routes to) and routing
+regressions. Both return <code>Result&lt;(), Vec&lt;String&gt;&gt;</code> — <code>Ok(())</code>
+when every expected state was entered, or <code>Err</code> with the missing state labels (in
+input order, deduplicated). Unlike <code>assert_path</code>, they return rather than panic, so
+you can inspect the gap (<code>?</code>-propagate, <code>.expect(..)</code>, or
+<code>.unwrap_err()</code>).
+</p>
+
+<ul>
+<li><code>assert_all_states_entered(&amp;[..])</code> — check an explicit list of states (compared by their <code>Debug</code> rendering).</li>
+<li><code>assert_registered_states_entered(&amp;workflow)</code> — check <em>every state the workflow registered a handler for</em> (via <a href="../workflows/"><code>Workflow::registered_states</code></a>). Exit-only states added with <code>add_exit_state</code> and no handler are not required.</li>
+</ul>
+
+```rust
+use cano::prelude::*;
+use cano::testing::RecordingObserver;
+use std::sync::Arc;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum S { Start, Worker, Done }
+
+#[derive(Clone)]
+struct Go(S);
+#[task]
+impl Task<S> for Go {
+    async fn run_bare(&self) -> Result<TaskResult<S>, CanoError> {
+        Ok(TaskResult::Single(self.0.clone()))
+    }
+}
+
+#[tokio::test]
+async fn every_registered_state_is_reached() {
+    let observer = Arc::new(RecordingObserver::new());
+    let wf = Workflow::bare()
+        .register(S::Start, Go(S::Worker))
+        .register(S::Worker, Go(S::Done))
+        .add_exit_state(S::Done)
+        .with_observer(observer.clone());
+    wf.orchestrate(S::Start).await.unwrap();
+
+    // Every registered handler was actually reached — no dead states.
+    observer.assert_registered_states_entered(&wf).expect("no dead states");
+
+    // Or assert an explicit set; Err lists what was never entered.
+    observer.assert_all_states_entered(&[S::Start, S::Worker, S::Done]).unwrap();
+}
+```
 
 <h2 id="in-memory-store">InMemoryCheckpointStore</h2>
 
@@ -118,18 +170,27 @@ use cano::prelude::*;
 use cano::testing::*;
 use std::sync::Arc;
 
-# #[derive(Clone, Debug, PartialEq, Eq, Hash)] enum S { Start, Done }
-# struct Go; #[task] impl Task<S> for Go { async fn run_bare(&self) -> Result<TaskResult<S>, CanoError> { Ok(TaskResult::Single(S::Done)) } }
-# #[tokio::main]
-# async fn main() {
-let store = Arc::new(InMemoryCheckpointStore::new());
-let wf = Workflow::bare()
-    .register(S::Start, Go)
-    .add_exit_state(S::Done)
-    .with_checkpoint_store(store.clone())
-    .with_workflow_id("run-1");
-assert_eq!(wf.orchestrate(S::Start).await.unwrap(), S::Done);
-# }
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum S { Start, Done }
+
+struct Go;
+#[task]
+impl Task<S> for Go {
+    async fn run_bare(&self) -> Result<TaskResult<S>, CanoError> {
+        Ok(TaskResult::Single(S::Done))
+    }
+}
+
+#[tokio::test]
+async fn checkpoints_run_in_memory() {
+    let store = Arc::new(InMemoryCheckpointStore::new());
+    let wf = Workflow::bare()
+        .register(S::Start, Go)
+        .add_exit_state(S::Done)
+        .with_checkpoint_store(store.clone())
+        .with_workflow_id("run-1");
+    assert_eq!(wf.orchestrate(S::Start).await.unwrap(), S::Done);
+}
 ```
 
 <h2 id="test-resources">TestResources</h2>
@@ -170,16 +231,18 @@ only with <code>panics == 0</code>.
 use cano::prelude::*;
 use cano::testing::panic_on_attempt;
 
-# #[derive(Clone, Debug, PartialEq, Eq, Hash)] enum S { Start, Done }
-# #[tokio::main]
-# async fn main() {
-let wf = Workflow::bare()
-    .register(S::Start, panic_on_attempt(1, S::Done))
-    .add_exit_state(S::Done);
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum S { Start, Done }
 
-let err = wf.orchestrate(S::Start).await.unwrap_err();
-assert!(err.to_string().contains("panic"));
-# }
+#[tokio::test]
+async fn panicking_task_fails_fast() {
+    let wf = Workflow::bare()
+        .register(S::Start, panic_on_attempt(1, S::Done))
+        .add_exit_state(S::Done);
+
+    let err = wf.orchestrate(S::Start).await.unwrap_err();
+    assert!(err.to_string().contains("panic"));
+}
 ```
 
 <h2 id="assert-compensation">assert_compensation_ran</h2>

--- a/docs/content/testing/_index.md
+++ b/docs/content/testing/_index.md
@@ -1,0 +1,210 @@
++++
+title = "Testing"
+description = "Batteries-included fixtures for testing Cano workflows — a recording observer, an in-memory checkpoint store, a resources builder, a panic task factory, and a saga assertion."
+template = "section.html"
++++
+
+<div class="content-wrapper">
+<h1>Testing</h1>
+<p class="subtitle">Drop a pile of bespoke test fixtures for a one-line <code>use cano::testing::*;</code>.</p>
+<p class="feature-tag">Everything on this page is behind the <code>testing</code> feature gate (<code>features = ["testing"]</code>) — typically enabled under <code>[dev-dependencies]</code>.</p>
+
+<p>
+The <code>cano::testing</code> module wraps existing public surface
+(<a href="../observers/"><code>WorkflowObserver</code></a>,
+<a href="../recovery/"><code>CheckpointStore</code></a>,
+<a href="../resources/"><code>Resources</code></a>,
+<a href="../store/"><code>MemoryStore</code></a>,
+<a href="../task/"><code>Task</code></a>) into ready-made fixtures. It adds <strong>no</strong> new
+traits and changes <strong>no</strong> existing public items — it just saves you from
+re-writing the same recording observer and in-memory store in every test crate.
+</p>
+
+<p>
+It is deliberately <strong>not</strong> in the <a href="../"><code>prelude</code></a>: import it
+explicitly with <code>use cano::testing::*;</code> so production code never picks it up by
+accident.
+</p>
+
+<nav class="page-toc" aria-label="Table of contents">
+<div class="page-toc-title">On this page</div>
+<ol>
+<li><a href="#enabling">Enabling the feature</a></li>
+<li><a href="#recording-observer">RecordingObserver</a></li>
+<li><a href="#in-memory-store">InMemoryCheckpointStore</a></li>
+<li><a href="#test-resources">TestResources</a></li>
+<li><a href="#panic-on-attempt">panic_on_attempt</a></li>
+<li><a href="#assert-compensation">assert_compensation_ran</a></li>
+</ol>
+</nav>
+<hr class="section-divider">
+
+<h2 id="enabling">Enabling the feature</h2>
+
+<p>
+Add <code>cano</code> with the <code>testing</code> feature to your <code>[dev-dependencies]</code>
+so the helpers compile only for tests and never ship in your release build:
+</p>
+
+```toml
+[dev-dependencies]
+cano = { version = "0.14", features = ["testing"] }
+```
+
+<p>The <code>testing</code> feature pulls in no extra dependencies and is zero-cost when off.</p>
+
+<h2 id="recording-observer">RecordingObserver</h2>
+
+<p>
+A <a href="../observers/"><code>WorkflowObserver</code></a> that records every lifecycle event
+into an inspectable <code>Vec&lt;RecordedEvent&gt;</code>. Attach it, drive the workflow, then
+assert against the recorded path — or use the <code>assert_path</code> /
+<code>assert_completed_with</code> convenience checks.
+</p>
+
+```rust
+use cano::prelude::*;
+use cano::testing::*;
+use std::sync::Arc;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum S { Start, Done }
+
+struct OkTask;
+#[task]
+impl Task<S> for OkTask {
+    async fn run_bare(&self) -> Result<TaskResult<S>, CanoError> {
+        Ok(TaskResult::Single(S::Done))
+    }
+}
+
+# #[tokio::main]
+# async fn main() {
+let observer = Arc::new(RecordingObserver::new());
+let wf = Workflow::bare()
+    .register(S::Start, OkTask)
+    .add_exit_state(S::Done)
+    .with_observer(observer.clone());
+
+assert_eq!(wf.orchestrate(S::Start).await.unwrap(), S::Done);
+
+// Assert the whole path, or inspect events directly.
+observer.assert_path(&["Start", "Done"]);
+observer.assert_completed_with("Done");
+assert!(observer.events().iter().any(|e| matches!(e, RecordedEvent::TaskSucceeded { .. })));
+# }
+```
+
+<p>
+<code>RecordedEvent</code> mirrors the observer hooks (<code>StateEntered</code>,
+<code>TaskStarted</code>, <code>TaskSucceeded</code>, <code>TaskFailed</code>, <code>Retry</code>,
+<code>CircuitOpen</code>, <code>Checkpoint</code>, <code>Resume</code>). It is
+<code>#[non_exhaustive]</code> — match with a wildcard arm.
+</p>
+
+<h2 id="in-memory-store">InMemoryCheckpointStore</h2>
+
+<p>
+A process-local <a href="../recovery/"><code>CheckpointStore</code></a> for resume / recovery
+tests — no <code>recovery</code> feature and no on-disk file needed. Share one
+<code>Arc&lt;InMemoryCheckpointStore&gt;</code> across an <code>orchestrate</code> run and a later
+<code>resume_from</code> to exercise the crash-recovery path entirely in memory. It honors the
+full trait contract: duplicate <code>(workflow_id, sequence)</code> is rejected,
+<code>load_run</code> returns rows sorted by sequence, and <code>clear</code> is per-id.
+</p>
+
+```rust
+use cano::prelude::*;
+use cano::testing::*;
+use std::sync::Arc;
+
+# #[derive(Clone, Debug, PartialEq, Eq, Hash)] enum S { Start, Done }
+# struct Go; #[task] impl Task<S> for Go { async fn run_bare(&self) -> Result<TaskResult<S>, CanoError> { Ok(TaskResult::Single(S::Done)) } }
+# #[tokio::main]
+# async fn main() {
+let store = Arc::new(InMemoryCheckpointStore::new());
+let wf = Workflow::bare()
+    .register(S::Start, Go)
+    .add_exit_state(S::Done)
+    .with_checkpoint_store(store.clone())
+    .with_workflow_id("run-1");
+assert_eq!(wf.orchestrate(S::Start).await.unwrap(), S::Done);
+# }
+```
+
+<h2 id="test-resources">TestResources</h2>
+
+<p>
+A small builder for the <a href="../resources/"><code>Resources</code></a> a workflow needs.
+<code>with_store</code> drops in a fresh <a href="../store/"><code>MemoryStore</code></a> at a key;
+<code>with_resource</code> takes any <a href="../resources/"><code>Resource</code></a>.
+</p>
+
+```rust
+use cano::prelude::*;
+use cano::testing::TestResources;
+
+let resources = TestResources::new()
+    .with_store("store")
+    .build();
+assert!(resources.get::<MemoryStore, _>("store").is_ok());
+```
+
+<h2 id="panic-on-attempt">panic_on_attempt</h2>
+
+<p>
+A <a href="../task/"><code>Task</code></a> that panics on its first <em>N</em> attempts, for
+exercising <a href="../resilience/">panic safety</a>: the engine converts a panicking task into a
+<code>CanoError</code> (message starting <code>"panic: "</code>) instead of unwinding the
+workflow loop.
+</p>
+
+<p class="feature-tag">
+Note: the engine wraps its catch-unwind around the <em>whole</em> retry loop, so a panic
+<strong>fails fast — panics are never retried</strong> (only a returned <code>Err</code> is).
+With <code>panics &gt;= 1</code> the run fails on the first attempt; the success branch is reached
+only with <code>panics == 0</code>.
+</p>
+
+```rust
+use cano::prelude::*;
+use cano::testing::panic_on_attempt;
+
+# #[derive(Clone, Debug, PartialEq, Eq, Hash)] enum S { Start, Done }
+# #[tokio::main]
+# async fn main() {
+let wf = Workflow::bare()
+    .register(S::Start, panic_on_attempt(1, S::Done))
+    .add_exit_state(S::Done);
+
+let err = wf.orchestrate(S::Start).await.unwrap_err();
+assert!(err.to_string().contains("panic"));
+# }
+```
+
+<h2 id="assert-compensation">assert_compensation_ran</h2>
+
+<p>
+A <a href="../saga/">saga</a> assertion that compares the recorded compensation order against
+an expected sequence. Have each <code>compensate</code> push its identifier into a shared
+<code>Vec</code> (typically held in a <a href="../resources/">resource</a>), then pass that slice
+as <code>actual</code>. Compensations drain in reverse of completion order, so list
+<code>expected</code> in the order you expect them to <em>undo</em>.
+</p>
+
+```rust
+use cano::testing::assert_compensation_ran;
+
+// Charge ran last, so it compensates first; then Reserve.
+let ran = vec!["charge".to_string(), "reserve".to_string()];
+assert_compensation_ran(&ran, &["charge", "reserve"]);
+```
+
+<hr class="section-divider">
+
+<p>
+Runnable end-to-end demo of every helper:
+<code>cargo run --example testing_helpers --features testing</code>.
+</p>
+
+</div>

--- a/docs/static/styles.css
+++ b/docs/static/styles.css
@@ -440,7 +440,6 @@ p {
     color: var(--text-muted);
     line-height: 1.6;
     margin-bottom: var(--space-8);
-    max-width: 56ch;
 }
 
 strong {

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -104,6 +104,12 @@
                 <li><a href="{{ get_url(path='@/observers/_index.md') }}">Observers</a></li>
             </ul>
         </details>
+        <details class="nav-section" id="nav-testing">
+            <summary class="nav-section-label">Testing</summary>
+            <ul class="nav-links">
+                <li><a href="{{ get_url(path='@/testing/_index.md') }}">Testing</a></li>
+            </ul>
+        </details>
         <div class="sidebar-footer">
             <span class="version-badge">v{{ config.extra.version }}</span>
             <div class="sidebar-links">


### PR DESCRIPTION
# Add a public `testing` module with batteries-included test fixtures

## Summary

Introduces a new opt-in `testing` feature that ships a small set of reusable test fixtures for workflow tests, plus state-coverage assertions that let a test prove every registered state was actually exercised. Also consolidates the codebase's own ad-hoc test observers onto a single shared fixture and refreshes the docs examples to use a runnable `#[tokio::main]` shape.

No new traits and no changes to existing public items — every fixture wraps existing public surface (`WorkflowObserver`, `CheckpointStore`, `Resources`, `MemoryStore`, `Task`).

## Motivation

Workflow tests previously needed a pile of bespoke fixtures — a hand-rolled recording observer, a custom in-memory checkpoint store, manual `Resources` wiring. The same recording-observer pattern was duplicated across ~10 internal test modules. This PR turns that boilerplate into a handful of importable lines and gives the same tooling to downstream users.

## What's new

### `cano::testing` (feature `testing`)

Import wholesale with `use cano::testing::*;`. Deliberately **not** in the `prelude` so production code never picks it up by accident.

| Helper | What it gives you |
|---|---|
| `RecordingObserver` | a `WorkflowObserver` that captures every lifecycle event into an inspectable `Vec<RecordedEvent>`, with `assert_path` / `assert_completed_with` / `assert_all_states_entered` / `assert_registered_states_entered` |
| `InMemoryCheckpointStore` | a process-local `CheckpointStore` for resume/recovery tests — no `recovery` feature or on-disk file needed |
| `TestResources` | a tiny builder for the `Resources` dictionary a workflow needs |
| `panic_on_attempt` | a `Task` that panics on its first *N* attempts — exercises the panic-safety path |
| `assert_compensation_ran` | a saga assertion that compares recorded compensation order against an expected sequence |

### State-coverage assertions

New `Workflow::registered_states()` iterates every state that has a registered handler (exit-only states added via `add_exit_state` are excluded). Combined with `RecordingObserver::assert_registered_states_entered(&workflow)`, a test can assert that a run touched every registered state — catching dead branches and unreachable routes.

## Internal cleanup

- Consolidated the ~10 duplicated internal recording observers onto a single shared `EventLog` fixture in `workflow/test_support.rs` (`compensation.rs` −116, `execution.rs` −36, `observer.rs` test module trimmed).
- `test_support` promoted to `pub(crate)` so sibling modules share the fixture.

## Docs

- New **Testing** page (`docs/content/testing/_index.md`) + sidebar nav entry.
- Observers / recovery / saga examples updated to a runnable `#[tokio::main] async fn main` shape.
- Landing page updated: "all" now turns on **five** optional features.

## Feature flag

```toml
testing = []
all = ["scheduler", "tracing", "recovery", "metrics", "testing"]
```
Zero-cost when off; intended as a [dev-dependencies] feature. The new testing_helpers example is gated on it.

## Tests
cano/tests/testing_module_e2e.rs — end-to-end coverage of the fixtures (+206)
cano/tests/testing_state_coverage.rs — state-coverage assertions (+81)
cano/examples/testing_helpers.rs — runnable usage example (+161)
Unit test for registered_states()