### PR TITLE
TimerTask + ergonomic split/exit-state registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The engine is built on three core concepts: **Tasks** for logic, **Workflows** f
 ## Features
 
 - **Type-Safe State Machines**: Enum-driven transitions with compile-time guarantees.
-- **Multiple Processing Models**: `Task` for general-purpose work, plus `RouterTask`, `PollTask`, `BatchTask`, and `SteppedTask` for specialized shapes — mixed freely in one workflow.
+- **Multiple Processing Models**: `Task` for general-purpose work, plus `RouterTask`, `PollTask`, `TimerTask`, `BatchTask`, and `SteppedTask` for specialized shapes — mixed freely in one workflow.
 - **Resource Dependency Injection**: Typed, lifecycle-managed `Resources` dictionary with `setup`/`teardown`/`health` hooks, looked up by key and type, plus `#[derive(FromResources)]` for ergonomic wiring.
 - **Parallel Execution (Split/Join)**: Run tasks concurrently and join results with strategies like `All`, `Any`, `Quorum`, or `PartialResults`, with an optional bulkhead to cap concurrency.
 - **Robust Retry Logic**: Configurable strategies including exponential backoff with jitter and per-attempt timeouts.

--- a/cano-macros/Cargo.toml
+++ b/cano-macros/Cargo.toml
@@ -21,4 +21,4 @@ syn = { version = "2", features = ["full", "visit-mut"] }
 [dev-dependencies]
 cano = { path = "../cano" }
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "test-util"] }

--- a/cano-macros/src/lib.rs
+++ b/cano-macros/src/lib.rs
@@ -14,6 +14,7 @@
 //! - `#[cano::task]` — for `impl Task` (and the `Task` trait definition itself)
 //! - `#[cano::task::router]` — for `impl RouterTask` and the `RouterTask` trait
 //! - `#[cano::task::poll]` — for `impl PollTask` and the `PollTask` trait
+//! - `#[cano::task::timer]` — for `impl TimerTask` and the `TimerTask` trait
 //! - `#[cano::task::batch]` — for `impl BatchTask` and the `BatchTask` trait
 //! - `#[cano::task::stepped]` — for `impl SteppedTask` and the `SteppedTask` trait
 //! - `#[cano::saga::task]` — for `impl CompensatableTask`
@@ -38,6 +39,7 @@ mod resource_derive;
 mod router_task_impl;
 mod stepped_task_impl;
 mod task_impl;
+mod timer_task_impl;
 
 /// Derive a `from_resources(&Resources<_>) -> CanoResult<Self>` constructor that
 /// pulls each field out of a `cano::Resources` map.
@@ -278,6 +280,44 @@ pub fn batch_task(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn poll_task(attr: TokenStream, item: TokenStream) -> TokenStream {
     poll_task_impl::expand(attr.into(), item.into())
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+/// Apply to the `TimerTask` trait definition, an
+/// `impl TimerTask<S [, K]> for T` block, or — for less boilerplate — an
+/// inherent `impl T { ... }` block.
+///
+/// Use as `#[cano::task::timer]`.
+///
+/// Two surface forms on impl blocks:
+///
+/// 1. **Trait-impl form:** `#[task::timer] impl TimerTask<S> for T { async fn wait(..) { ... } async fn after_wait(..) { ... } }` —
+///    user writes the trait header. The macro async-rewrites the `TimerTask` impl AND emits a
+///    companion `impl Task<S> for T` whose `Task::run` sleeps for the returned `TimerOutcome`
+///    (via the `run_timer` helper) then calls `after_wait`.
+/// 2. **Inherent-impl form:** `#[task::timer(state = S [, key = K])] impl T { async fn wait(..) { ... } async fn after_wait(..) { ... } }` —
+///    the macro builds the `impl TimerTask<S [, K]> for T` header from the attribute args, enforces
+///    that both `wait` and `after_wait` are present (`config` / `name` may be overridden), and emits
+///    the same companion `impl Task<S [, K]> for T`.
+///
+/// On a trait definition (`#[task::timer] pub trait TimerTask ...`) the macro just performs the
+/// async-fn-in-trait rewrite.
+///
+/// Because a blanket `impl<T: TimerTask<..>> Task<..> for T` would conflict (E0119) with the
+/// analogous blanket impls for the other specialized task traits — a type can implement more than
+/// one — the companion `Task` impl is generated per-use-site rather than as a blanket.
+///
+/// The default `config()` injected by the inherent form is [`TaskConfig::minimal()`]
+/// (no retries) — a single scheduled sleep needs no outer retry wrapping.
+///
+/// The **inherent form** routes `Task::run` through `::cano::task::timer::run_timer`, so the user
+/// crate needs no direct `tokio` dependency. The **trait-impl form** inlines the sleep, so a crate
+/// using `#[task::timer] impl TimerTask<S> for T` must depend on `tokio` (feature `time`),
+/// reachable as `::tokio` — the same requirement the sibling `#[task::poll]` macro has.
+#[proc_macro_attribute]
+pub fn timer_task(attr: TokenStream, item: TokenStream) -> TokenStream {
+    timer_task_impl::expand(attr.into(), item.into())
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }

--- a/cano-macros/src/timer_task_impl.rs
+++ b/cano-macros/src/timer_task_impl.rs
@@ -1,0 +1,403 @@
+//! Boilerplate-filling pass for `#[cano::task::timer]` on `impl TimerTask<S [, K]> for T`
+//! blocks and on inherent `impl T { ... }` blocks.
+//!
+//! ## Why a sibling `impl Task` is emitted
+//!
+//! A blanket `impl<T: TimerTask<..>> Task<..> for T` would conflict (E0119) with the
+//! analogous blanket impls for the other specialized task traits (a type can implement
+//! more than one). Instead, each use of `#[timer_task]` on an **impl** block synthesises a
+//! concrete `impl Task<S [, K]> for T` alongside the `TimerTask` impl, with `Task::run`
+//! delegating to `::cano::task::timer::run_timer(self, res).await`. This gives the same
+//! ergonomics ("register a `TimerTask` directly with `Workflow::register`") without
+//! touching coherence.
+//!
+//! ## Path handling
+//!
+//! Same strategy as `poll_task_impl.rs`:
+//! - Trait-impl form: derive type paths from the same prefix as the user's `TimerTask` path.
+//! - Inherent form: use `::cano::` paths (valid for external callers).
+//!
+//! ## Surface forms
+//!
+//! 1. **Trait-definition form:** `#[timer_task] pub trait TimerTask<...> { ... }` —
+//!    the macro only async-rewrites the trait.
+//!
+//! 2. **Trait-impl form:** `#[timer_task] impl TimerTask<S> for T { async fn wait(...);
+//!    async fn after_wait(...) }` — the macro async-rewrites the `TimerTask` impl AND emits a
+//!    companion `impl Task<S> for T` using the same path prefix as the `TimerTask` path.
+//!
+//! 3. **Inherent-impl form:** `#[timer_task(state = S [, key = K])] impl T { async fn wait(...);
+//!    async fn after_wait(...) }` — the macro builds the `impl ::cano::TimerTask<S [, K]> for T`
+//!    header, async-rewrites it, and emits the companion `impl ::cano::Task<S [, K]> for T`.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    AngleBracketedGenericArguments, ImplItem, ImplItemFn, ItemImpl, ItemTrait, Path, PathArguments,
+    PathSegment, Type, parse2, spanned::Spanned,
+};
+
+use crate::async_rewrite;
+use crate::attr_args::{AttrArgs, combine_errors};
+use crate::path_prefix::{ModulePrefix, derive_module_prefix};
+
+/// Entry point — dispatches based on what `item` parses to.
+pub(crate) fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> {
+    if let Ok(trait_def) = parse2::<ItemTrait>(item.clone()) {
+        if !attr.is_empty() {
+            return Err(syn::Error::new(
+                trait_def.span(),
+                "#[cano::task::timer]: no attribute args are accepted on a trait definition",
+            ));
+        }
+        let rewritten = async_rewrite::rewrite_trait_def(trait_def);
+        return Ok(quote! { #rewritten });
+    }
+
+    if let Ok(item_impl) = parse2::<ItemImpl>(item.clone()) {
+        let args = AttrArgs::parse(attr)?;
+
+        if item_impl.trait_.is_none() {
+            // Inherent-impl form: need `state = S`.
+            let state_ty = args.state.ok_or_else(|| {
+                syn::Error::new(
+                    item_impl.span(),
+                    "#[cano::task::timer] on an inherent `impl T { ... }` block requires \
+                     `state = T` (e.g. `#[task::timer(state = MyState)]`)",
+                )
+            })?;
+            return expand_inherent_impl(item_impl, state_ty, args.key);
+        } else {
+            if args.state.is_some() || args.key.is_some() {
+                return Err(syn::Error::new(
+                    item_impl.span(),
+                    "#[cano::task::timer]: `state` / `key` args only apply to inherent \
+                     `impl T { ... }` blocks; when writing `impl TimerTask<...> for T` the \
+                     trait header already specifies them",
+                ));
+            }
+            return expand_trait_impl(item_impl);
+        }
+    }
+
+    Err(syn::Error::new(
+        proc_macro2::Span::call_site(),
+        "#[cano::task::timer]: expected a trait definition or impl block",
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Trait-impl form: `#[timer_task] impl TimerTask<S [, K]> for T { ... }`
+// ---------------------------------------------------------------------------
+
+fn expand_trait_impl(item_impl: ItemImpl) -> syn::Result<TokenStream> {
+    let (state_ty, key_ty, task_trait_path, module_prefix) =
+        extract_state_key_task_path_and_prefix(&item_impl)?;
+
+    let timer_impl = async_rewrite::rewrite_impl_block(item_impl.clone());
+
+    let task_impl = synthesise_task_impl(
+        &item_impl,
+        &state_ty,
+        key_ty.as_ref(),
+        task_trait_path,
+        &module_prefix,
+    )?;
+
+    Ok(quote! {
+        #timer_impl
+        #task_impl
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Inherent-impl form: `#[timer_task(state = S [, key = K])] impl T { ... }`
+// ---------------------------------------------------------------------------
+
+fn expand_inherent_impl(
+    item_impl: ItemImpl,
+    state_ty: Type,
+    key_ty: Option<Type>,
+) -> syn::Result<TokenStream> {
+    let mut wait_fn: Option<&ImplItemFn> = None;
+    let mut after_wait_fn: Option<&ImplItemFn> = None;
+    let mut errors: Vec<syn::Error> = Vec::new();
+    let mut has_config = false;
+    let mut has_name = false;
+
+    for it in &item_impl.items {
+        match it {
+            ImplItem::Fn(f) => match f.sig.ident.to_string().as_str() {
+                "wait" => wait_fn = Some(f),
+                "after_wait" => after_wait_fn = Some(f),
+                "config" => has_config = true,
+                "name" => has_name = true,
+                other => {
+                    errors.push(syn::Error::new_spanned(
+                        &f.sig.ident,
+                        format!(
+                            "#[cano::task::timer]: unexpected method `{other}` in inherent impl; \
+                             only `wait`, `after_wait`, `config`, and `name` are allowed"
+                        ),
+                    ));
+                }
+            },
+            ImplItem::Type(t) => {
+                errors.push(syn::Error::new_spanned(
+                    &t.ident,
+                    format!(
+                        "#[cano::task::timer]: unexpected associated type `{}`; \
+                         `TimerTask` has no associated types",
+                        t.ident
+                    ),
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    if wait_fn.is_none() {
+        errors.push(syn::Error::new(
+            item_impl.span(),
+            "#[cano::task::timer] requires an `async fn wait(&self, res: &Resources<_>) \
+             -> Result<TimerOutcome, CanoError>` method",
+        ));
+    }
+    if after_wait_fn.is_none() {
+        errors.push(syn::Error::new(
+            item_impl.span(),
+            "#[cano::task::timer] requires an `async fn after_wait(&self, res: &Resources<_>) \
+             -> Result<TaskResult<_>, CanoError>` method",
+        ));
+    }
+
+    if !errors.is_empty() {
+        return Err(combine_errors(errors));
+    }
+
+    let timer_trait_ref: syn::Path = match &key_ty {
+        Some(k) => syn::parse_quote!(::cano::TimerTask<#state_ty, #k>),
+        None => syn::parse_quote!(::cano::TimerTask<#state_ty>),
+    };
+
+    let task_trait_path: syn::Path = match &key_ty {
+        Some(k) => syn::parse_quote!(::cano::Task<#state_ty, #k>),
+        None => syn::parse_quote!(::cano::Task<#state_ty>),
+    };
+
+    let attrs = &item_impl.attrs;
+    let unsafety = &item_impl.unsafety;
+    let generics = &item_impl.generics;
+    let where_clause = &item_impl.generics.where_clause;
+    let self_ty = &item_impl.self_ty;
+    let user_items = &item_impl.items;
+
+    // TimerTask defaults to TaskConfig::minimal() (no retries).
+    let config_default = if !has_config {
+        Some(quote! {
+            fn config(&self) -> ::cano::TaskConfig {
+                ::cano::TaskConfig::minimal()
+            }
+        })
+    } else {
+        None
+    };
+
+    let name_default = if !has_name {
+        Some(quote! {
+            fn name(&self) -> ::std::borrow::Cow<'static, str> {
+                ::std::borrow::Cow::Borrowed(::std::any::type_name::<Self>())
+            }
+        })
+    } else {
+        None
+    };
+
+    let synth = quote! {
+        #(#attrs)*
+        #unsafety impl #generics #timer_trait_ref for #self_ty #where_clause {
+            #config_default
+            #name_default
+            #(#user_items)*
+        }
+    };
+
+    let synth_impl: ItemImpl = parse2(synth)?;
+    let timer_impl = async_rewrite::rewrite_impl_block(synth_impl.clone());
+
+    let module_prefix = ModulePrefix::Cano;
+    let task_impl = synthesise_task_impl(
+        &synth_impl,
+        &state_ty,
+        key_ty.as_ref(),
+        task_trait_path,
+        &module_prefix,
+    )?;
+
+    Ok(quote! {
+        #timer_impl
+        #task_impl
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn extract_state_key_task_path_and_prefix(
+    item_impl: &ItemImpl,
+) -> syn::Result<(Type, Option<Type>, Path, ModulePrefix)> {
+    let (_, trait_path, _) = item_impl
+        .trait_
+        .as_ref()
+        .ok_or_else(|| syn::Error::new(item_impl.span(), "expected a trait impl block"))?;
+
+    let last_seg = trait_path
+        .segments
+        .last()
+        .ok_or_else(|| syn::Error::new(item_impl.span(), "cannot read trait path segments"))?;
+
+    let args = match &last_seg.arguments {
+        syn::PathArguments::AngleBracketed(a) => a,
+        _ => {
+            return Err(syn::Error::new(
+                item_impl.span(),
+                "TimerTask impl must have angle-bracketed type arguments (e.g. `TimerTask<MyState>`)",
+            ));
+        }
+    };
+
+    let type_args: Vec<&Type> = args
+        .args
+        .iter()
+        .filter_map(|a| {
+            if let syn::GenericArgument::Type(t) = a {
+                Some(t)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if type_args.is_empty() {
+        return Err(syn::Error::new(
+            item_impl.span(),
+            "TimerTask impl requires at least one type argument (the state type)",
+        ));
+    }
+
+    let state_ty = type_args[0].clone();
+    let key_ty = type_args.get(1).map(|t| (*t).clone());
+
+    let module_prefix = derive_module_prefix(trait_path);
+    let task_path = derive_task_path_from_timer_path(trait_path, &state_ty, key_ty.as_ref())?;
+
+    Ok((state_ty, key_ty, task_path, module_prefix))
+}
+
+fn derive_task_path_from_timer_path(
+    timer_path: &Path,
+    state_ty: &Type,
+    key_ty: Option<&Type>,
+) -> syn::Result<Path> {
+    let mut task_path = timer_path.clone();
+
+    let angle_args: AngleBracketedGenericArguments = match key_ty {
+        Some(k) => syn::parse_quote!(<#state_ty, #k>),
+        None => syn::parse_quote!(<#state_ty>),
+    };
+    let task_args = PathArguments::AngleBracketed(angle_args);
+
+    if let Some(last) = task_path.segments.last_mut() {
+        *last = PathSegment {
+            ident: syn::Ident::new("Task", last.ident.span()),
+            arguments: task_args,
+        };
+    }
+
+    Ok(task_path)
+}
+
+/// Synthesise `impl Task<S [, K]> for T` whose `Task::run` waits then transitions,
+/// forwarding `config`/`name` to `TimerTask::config`/`TimerTask::name` via UFCS.
+///
+/// For the inherent form (and other cases where `::cano::` is valid), `Task::run`
+/// delegates to `::cano::task::timer::run_timer(self, res).await`. For the
+/// trait-impl form used inside the `cano` crate itself (where `::cano` doesn't
+/// exist), the wait/after_wait sequence is inlined directly so no external crate
+/// reference is needed.
+fn synthesise_task_impl(
+    timer_impl: &ItemImpl,
+    state_ty: &Type,
+    key_ty: Option<&Type>,
+    task_trait_path: Path,
+    module_prefix: &ModulePrefix,
+) -> syn::Result<TokenStream> {
+    let attrs = &timer_impl.attrs;
+    let generics = &timer_impl.generics;
+    let where_clause = &timer_impl.generics.where_clause;
+    let self_ty = &timer_impl.self_ty;
+
+    let (_, timer_trait_path, _) = timer_impl.trait_.as_ref().ok_or_else(|| {
+        syn::Error::new(timer_impl.span(), "expected a TimerTask trait impl block")
+    })?;
+
+    let task_config_ty = module_prefix.qualify("TaskConfig");
+    let resources_ty = module_prefix.qualify("Resources");
+    let task_result_ty = module_prefix.qualify("TaskResult");
+    let cano_error_ty = module_prefix.qualify("CanoError");
+    let timer_outcome_ty = module_prefix.qualify("TimerOutcome");
+
+    let key_ty_tok: TokenStream = match key_ty {
+        Some(k) => quote! { #k },
+        None => quote! { ::std::borrow::Cow<'static, str> },
+    };
+
+    // For the inherent form (ModulePrefix::Cano), delegate to the free helper function
+    // in cano::task::timer so that the sleep body lives in one place.
+    //
+    // For the trait-impl form (Bare / Prefixed), inline the body so it compiles both
+    // inside the `cano` crate (where `::cano` does not resolve) and in external crates.
+    let run_body = match module_prefix {
+        ModulePrefix::Cano => quote! {
+            ::cano::task::timer::run_timer(self, res).await
+        },
+        _ => quote! {
+            {
+                match <Self as #timer_trait_path>::wait(self, res).await? {
+                    #timer_outcome_ty::Duration(__d) => {
+                        ::tokio::time::sleep(__d).await;
+                    }
+                    // `sleep_until` resolves immediately for a past deadline.
+                    #timer_outcome_ty::Until(__i) => {
+                        ::tokio::time::sleep_until(
+                            ::tokio::time::Instant::from_std(__i)
+                        ).await;
+                    }
+                }
+                <Self as #timer_trait_path>::after_wait(self, res).await
+            }
+        },
+    };
+
+    let synth = quote! {
+        #(#attrs)*
+        impl #generics #task_trait_path for #self_ty #where_clause {
+            fn config(&self) -> #task_config_ty {
+                <Self as #timer_trait_path>::config(self)
+            }
+            fn name(&self) -> ::std::borrow::Cow<'static, str> {
+                <Self as #timer_trait_path>::name(self)
+            }
+            async fn run(
+                &self,
+                res: &#resources_ty<#key_ty_tok>,
+            ) -> ::std::result::Result<#task_result_ty<#state_ty>, #cano_error_ty> {
+                #run_body
+            }
+        }
+    };
+
+    let synth_impl: ItemImpl = parse2(synth)?;
+    Ok(async_rewrite::rewrite_impl_block(synth_impl))
+}

--- a/cano-macros/tests/timer_task_impl.rs
+++ b/cano-macros/tests/timer_task_impl.rs
@@ -1,0 +1,259 @@
+//! Integration tests for `#[cano::task::timer]` — both the inherent form (which emits
+//! `::cano::` paths) and the trait-impl form. These run outside the `cano` crate so
+//! `::cano::` paths resolve correctly.
+
+use cano::prelude::*;
+use std::borrow::Cow;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Step {
+    Wait,
+    Next,
+    Done,
+}
+
+// ---------------------------------------------------------------------------
+// Inherent form: `#[task::timer(state = S)] impl T { wait + after_wait }`
+// ---------------------------------------------------------------------------
+
+struct InherentTimer;
+
+#[task::timer(state = Step)]
+impl InherentTimer {
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        Ok(TimerOutcome::Duration(Duration::from_millis(30)))
+    }
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        Ok(TaskResult::Single(Step::Done))
+    }
+}
+
+#[test]
+fn inherent_timer_has_default_minimal_config() {
+    assert_eq!(
+        TimerTask::<Step>::config(&InherentTimer)
+            .retry_mode
+            .max_attempts(),
+        1,
+        "TimerTask default config must be minimal (no retries)"
+    );
+}
+
+#[test]
+fn inherent_timer_has_default_name() {
+    assert!(
+        TimerTask::<Step>::name(&InherentTimer).contains("InherentTimer"),
+        "default name should contain the type name"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn inherent_timer_duration_waits_then_transitions() {
+    // Under the paused clock, the runtime auto-advances virtual time to the next
+    // timer, so the 30ms sleep completes without real waiting — and virtual elapsed
+    // time reflects the requested duration.
+    let start = tokio::time::Instant::now();
+    let res = Resources::new();
+    let result = Task::run(&InherentTimer, &res).await.unwrap();
+    let elapsed = start.elapsed();
+
+    assert_eq!(result, TaskResult::Single(Step::Done));
+    assert!(
+        elapsed >= Duration::from_millis(30),
+        "timer should sleep at least the requested duration, virtual elapsed = {elapsed:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Inherent form: Until a past instant completes immediately
+// ---------------------------------------------------------------------------
+
+struct PastInstantTimer;
+
+#[task::timer(state = Step)]
+impl PastInstantTimer {
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        Ok(TimerOutcome::Until(
+            Instant::now() - Duration::from_secs(60),
+        ))
+    }
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        Ok(TaskResult::Single(Step::Done))
+    }
+}
+
+#[tokio::test]
+async fn inherent_timer_until_past_instant_completes_immediately() {
+    let res = Resources::new();
+    let start = Instant::now();
+    let result = Task::run(&PastInstantTimer, &res).await.unwrap();
+    assert_eq!(result, TaskResult::Single(Step::Done));
+    assert!(
+        start.elapsed() < Duration::from_millis(500),
+        "a past Until instant must not sleep"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// after_wait can return Split
+// ---------------------------------------------------------------------------
+
+struct SplitTimer;
+
+#[task::timer(state = Step)]
+impl SplitTimer {
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        Ok(TimerOutcome::Duration(Duration::ZERO))
+    }
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        Ok(TaskResult::Split(vec![Step::Wait, Step::Next]))
+    }
+}
+
+#[tokio::test]
+async fn inherent_timer_after_wait_transition() {
+    let res = Resources::new();
+    let result = Task::run(&SplitTimer, &res).await.unwrap();
+    assert_eq!(result, TaskResult::Split(vec![Step::Wait, Step::Next]));
+}
+
+// ---------------------------------------------------------------------------
+// Inherent form with config/name overrides
+// ---------------------------------------------------------------------------
+
+struct InherentCustomTimer;
+
+#[task::timer(state = Step)]
+impl InherentCustomTimer {
+    fn config(&self) -> TaskConfig {
+        TaskConfig::minimal().with_attempt_timeout(Duration::from_secs(5))
+    }
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("my-inherent-timer")
+    }
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        Ok(TimerOutcome::Duration(Duration::ZERO))
+    }
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        Ok(TaskResult::Single(Step::Done))
+    }
+}
+
+#[test]
+fn inherent_custom_config_override() {
+    let cfg = TimerTask::<Step>::config(&InherentCustomTimer);
+    assert_eq!(cfg.retry_mode.max_attempts(), 1);
+    assert_eq!(cfg.attempt_timeout, Some(Duration::from_secs(5)));
+}
+
+#[test]
+fn inherent_custom_name_override() {
+    assert_eq!(
+        TimerTask::<Step>::name(&InherentCustomTimer),
+        "my-inherent-timer"
+    );
+}
+
+#[test]
+fn inherent_companion_task_forwards_config() {
+    let cfg = Task::config(&InherentCustomTimer);
+    assert_eq!(cfg.attempt_timeout, Some(Duration::from_secs(5)));
+}
+
+#[test]
+fn inherent_companion_task_forwards_name() {
+    assert_eq!(Task::name(&InherentCustomTimer), "my-inherent-timer");
+}
+
+// ---------------------------------------------------------------------------
+// Trait-impl form: `#[task::timer] impl TimerTask<S> for T { ... }`
+// ---------------------------------------------------------------------------
+
+struct TraitTimer;
+
+#[task::timer]
+impl TimerTask<Step> for TraitTimer {
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        Ok(TimerOutcome::Duration(Duration::ZERO))
+    }
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        Ok(TaskResult::Single(Step::Done))
+    }
+}
+
+#[tokio::test]
+async fn trait_form_timer_works() {
+    let res = Resources::new();
+    let result = Task::run(&TraitTimer, &res).await.unwrap();
+    assert_eq!(result, TaskResult::Single(Step::Done));
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic dispatch: cast to Arc<dyn Task<Step>>
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn inherent_timer_as_dyn_task() {
+    let timer: Arc<dyn Task<Step>> = Arc::new(SplitTimer);
+    let res = Resources::new();
+    let result = Task::run(timer.as_ref(), &res).await.unwrap();
+    assert_eq!(result, TaskResult::Split(vec![Step::Wait, Step::Next]));
+}
+
+// ---------------------------------------------------------------------------
+// Workflow integration via register
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn inherent_timer_integrates_with_workflow() {
+    let workflow = Workflow::bare()
+        .register(Step::Wait, TraitTimer)
+        .add_exit_state(Step::Done);
+
+    let result = workflow.orchestrate(Step::Wait).await.unwrap();
+    assert_eq!(result, Step::Done);
+}
+
+// ---------------------------------------------------------------------------
+// Error propagation from wait() / after_wait()
+// ---------------------------------------------------------------------------
+
+struct WaitErrorTimer;
+
+#[task::timer(state = Step)]
+impl WaitErrorTimer {
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        Err(CanoError::task_execution("wait failed deliberately"))
+    }
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        Ok(TaskResult::Single(Step::Done))
+    }
+}
+
+#[tokio::test]
+async fn wait_error_propagates_from_task_run() {
+    let res = Resources::new();
+    let err = Task::run(&WaitErrorTimer, &res).await.unwrap_err();
+    assert!(matches!(err, CanoError::TaskExecution(_)));
+}
+
+struct AfterWaitErrorTimer;
+
+#[task::timer(state = Step)]
+impl AfterWaitErrorTimer {
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        Ok(TimerOutcome::Duration(Duration::ZERO))
+    }
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        Err(CanoError::task_execution("after_wait failed deliberately"))
+    }
+}
+
+#[tokio::test]
+async fn after_wait_error_propagates_from_task_run() {
+    let res = Resources::new();
+    let err = Task::run(&AfterWaitErrorTimer, &res).await.unwrap_err();
+    assert!(matches!(err, CanoError::TaskExecution(_)));
+}

--- a/cano/Cargo.toml
+++ b/cano/Cargo.toml
@@ -47,7 +47,7 @@ tempfile = "3"
 wide = "1.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 chrono = { version = "0.4", features = ["serde"] }
-tokio = { version = "1.52.1", features = ["macros", "sync", "time", "rt-multi-thread", "signal"] }
+tokio = { version = "1.52.1", features = ["macros", "sync", "time", "rt-multi-thread", "signal", "test-util"] }
 metrics-util = { version = "0.20.3", features = ["debugging"] }
 metrics-tracing-context = "0.18.1"
 
@@ -208,6 +208,10 @@ path = "examples/router_task.rs"
 [[example]]
 name = "poll_task"
 path = "examples/poll_task.rs"
+
+[[example]]
+name = "timer_task"
+path = "examples/timer_task.rs"
 
 [[example]]
 name = "batch_task"

--- a/cano/benches/workflow_performance.rs
+++ b/cano/benches/workflow_performance.rs
@@ -611,7 +611,7 @@ fn bench_large_split_collect(c: &mut Criterion) {
             let workflow = Workflow::<S>::bare()
                 .register_split(
                     S::Start,
-                    (0..n).map(|_| Noop).collect::<Vec<_>>(),
+                    (0..n).map(|_| Noop),
                     JoinConfig::new(JoinStrategy::All, S::Done),
                 )
                 .add_exit_state(S::Done);

--- a/cano/examples/scheduler_mapreduce_books.rs
+++ b/cano/examples/scheduler_mapreduce_books.rs
@@ -391,24 +391,18 @@ fn create_batch_workflow(
         // Split: Download all books in parallel
         .register_split(
             BookAnalysisState::DownloadBatch,
-            books
-                .iter()
-                .map(|(id, title)| DownloadTask {
-                    book_id: *id,
-                    title: title.clone(),
-                    batch_name: batch_name.clone(),
-                })
-                .collect::<Vec<_>>(),
+            books.iter().map(|(id, title)| DownloadTask {
+                book_id: *id,
+                title: title.clone(),
+                batch_name: batch_name.clone(),
+            }),
             JoinConfig::new(JoinStrategy::All, BookAnalysisState::AnalyzeBatch)
                 .with_timeout(Duration::from_secs(120)),
         )
         // Split: Analyze all books in parallel
         .register_split(
             BookAnalysisState::AnalyzeBatch,
-            books
-                .iter()
-                .map(|(id, _)| AnalyzeTask { book_id: *id })
-                .collect::<Vec<_>>(),
+            books.iter().map(|(id, _)| AnalyzeTask { book_id: *id }),
             JoinConfig::new(
                 JoinStrategy::Percentage(0.75), // Proceed if 75% complete
                 BookAnalysisState::SummarizeBatch,

--- a/cano/examples/split_bulkhead.rs
+++ b/cano/examples/split_bulkhead.rs
@@ -157,7 +157,8 @@ async fn main() -> Result<(), CanoError> {
 
     // Eight workers, each taking ~50ms. With bulkhead=2 only 2 run at once,
     // so total time will be roughly 4 × 50ms = 200ms instead of 50ms flat.
-    let workers: Vec<Worker> = (0..8).map(|id| Worker { id }).collect();
+    // `register_split` takes any iterator, so the mapped range goes straight in.
+    let workers = (0..8).map(|id| Worker { id });
 
     let join_config = JoinConfig::new(JoinStrategy::All, Step::Summarize).with_bulkhead(2);
 

--- a/cano/examples/timer_task.rs
+++ b/cano/examples/timer_task.rs
@@ -1,0 +1,108 @@
+//! # TimerTask — Wait-Then-Transition Processing Model
+//!
+//! Run with: `cargo run --example timer_task`
+//!
+//! Demonstrates [`TimerTask`] as a "pause, then continue" processing unit. The `CoolDown`
+//! timer sleeps for a fixed [`Duration`] (the engine schedules a *single* `tokio::time::sleep`,
+//! not a polling loop), then transitions to the processing step.
+//!
+//! Workflow shape:
+//!
+//! ```text
+//!   CoolDown ──(sleep 50ms)──► Process ──► Done
+//! ```
+//!
+//! Contrast with [`PollTask`](cano::PollTask): a poll task re-evaluates a condition on every
+//! wake-up, whereas a timer wakes exactly once. Reach for a `TimerTask` when you just need a
+//! deliberate delay — a cool-down between phases, a debounce, or resuming after a known delay via
+//! a monotonic [`Instant`](std::time::Instant) and [`TimerOutcome::Until`].
+//!
+//! To cap the wait, `config()` can return `TaskConfig::minimal().with_attempt_timeout(dur)`; the
+//! engine enforces it and produces `CanoError::Timeout` if the timer hasn't fired in time.
+//!
+//! Note: a `TimerTask` is checkpointed like any single-task state, so a resumed run re-runs
+//! `wait()` and the delay restarts from scratch after a crash.
+
+use std::time::Duration;
+
+use cano::prelude::*;
+
+// ---------------------------------------------------------------------------
+// State enum
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Step {
+    /// Timer state: pauses for a fixed cool-down before continuing.
+    CoolDown,
+    /// Processing state: runs after the cool-down elapses.
+    Process,
+    /// Terminal exit state.
+    Done,
+}
+
+// ---------------------------------------------------------------------------
+// Timer task — waits a fixed cool-down, then transitions
+// ---------------------------------------------------------------------------
+
+/// Waits a fixed duration before letting the workflow continue.
+struct CoolDown {
+    delay: Duration,
+}
+
+#[task::timer(state = Step)]
+impl CoolDown {
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        println!(
+            "cool down  : sleeping for {:?} (single scheduled wake-up)",
+            self.delay
+        );
+        Ok(TimerOutcome::Duration(self.delay))
+    }
+
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        // `wait` can also return `TimerOutcome::Until(instant)`; see the module docs.
+        println!("cool down  : elapsed — continuing");
+        Ok(TaskResult::Single(Step::Process))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Processing task — runs after the cool-down
+// ---------------------------------------------------------------------------
+
+/// Simple post-cool-down processor that transitions to the exit state.
+struct Process;
+
+#[task(state = Step)]
+impl Process {
+    async fn run_bare(&self) -> Result<TaskResult<Step>, CanoError> {
+        println!("process    : handling work after the cool-down");
+        Ok(TaskResult::Single(Step::Done))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> CanoResult<()> {
+    println!("=== timer_task example ===\n");
+
+    let workflow = Workflow::bare()
+        .register(
+            Step::CoolDown,
+            CoolDown {
+                delay: Duration::from_millis(50),
+            },
+        )
+        .register(Step::Process, Process)
+        .add_exit_state(Step::Done);
+
+    let result = workflow.orchestrate(Step::CoolDown).await?;
+    assert_eq!(result, Step::Done);
+    println!("\ncompleted at {result:?}");
+
+    Ok(())
+}

--- a/cano/src/lib.rs
+++ b/cano/src/lib.rs
@@ -119,12 +119,16 @@
 //!   [`PollOutcome::Pending { delay_ms }`](PollOutcome::Pending) on each call. Defaults to
 //!   [`TaskConfig::minimal()`](task::TaskConfig::minimal) (no retries). Registered with
 //!   [`Workflow::register`] — the engine applies `attempt_timeout` if set via `config()`.
+//! - [`TimerTask`] trait: wait-then-transition; `wait()` returns a [`TimerOutcome`] (a
+//!   [`Duration`](std::time::Duration) or monotonic [`Instant`](std::time::Instant)) and the
+//!   engine sleeps **once** before `after_wait()` routes. Registered with
+//!   [`Workflow::register`]. A resumed run re-runs `wait()`, so the delay restarts after a crash.
 //! - [`BatchTask`] trait: fan-out over data items via `load`/`process_item`/`finish`.
 //! - [`SteppedTask`] trait: resumable iterative work via `step()` with a serializable cursor.
 //!
-//! Every [`RouterTask`], [`PollTask`], [`BatchTask`], and [`SteppedTask`] automatically
-//! implements [`Task`] via companion impls emitted by the `#[task::router]`,
-//! `#[task::poll]`, `#[task::batch]`, and `#[task::stepped]` macros respectively.
+//! Every [`RouterTask`], [`PollTask`], [`TimerTask`], [`BatchTask`], and [`SteppedTask`]
+//! automatically implements [`Task`] via companion impls emitted by the `#[task::router]`,
+//! `#[task::poll]`, `#[task::timer]`, `#[task::batch]`, and `#[task::stepped]` macros respectively.
 //!
 //! ### Parallel Execution (Split/Join)
 //!
@@ -188,6 +192,11 @@
 //! to `TaskConfig::minimal()` (no retries). Use `config().with_attempt_timeout(dur)` to cap
 //! total wall-clock time; registered with [`Workflow::register`] like any other task.
 //!
+//! **TimerTask**: `wait()` returns a [`TimerOutcome`] and `after_wait()` returns the next state —
+//! the engine schedules a single sleep between them (no polling loop). Defaults to
+//! `TaskConfig::minimal()`; an `attempt_timeout` caps the wait. Registered with
+//! [`Workflow::register`] like any other task.
+//!
 //! ### Timeouts
 //!
 //! Three layered budgets bound a run. [`TaskConfig::with_attempt_timeout`](task::TaskConfig::with_attempt_timeout)
@@ -203,6 +212,7 @@
 //! - [`mod@task`]: The [`Task`] trait — single `run()` / `run_bare()` method
 //! - [`task::router`]: The [`RouterTask`] trait — side-effect-free branching via `route()`; registered with [`Workflow::register_router`]
 //! - [`task::poll`]: The [`PollTask`] trait — wait-until loop via `poll()`; registered with [`Workflow::register`]
+//! - [`task::timer`]: The [`TimerTask`] trait — wait-then-transition via `wait()`/`after_wait()`; registered with [`Workflow::register`]
 //! - [`task::batch`]: The [`BatchTask`] trait — fan-out over data items via `load`/`process_item`/`finish`; registered with [`Workflow::register`]
 //! - [`task::stepped`]: The [`SteppedTask`] trait — resumable iterative work via `step()` with a serializable cursor; registered with [`Workflow::register_stepped`] (persists the cursor when a checkpoint store is attached)
 //! - [`workflow`]: [`Workflow`] — FSM orchestration with Split/Join support
@@ -271,6 +281,7 @@ pub use task::router::{DynRouterTask, RouterTask, RouterTaskObject};
 pub use task::stepped::{
     DefaultStepCursor, DynSteppedTask, StepOutcome, SteppedTask, SteppedTaskObject, run_stepped,
 };
+pub use task::timer::{DynTimerTask, TimerOutcome, TimerTask, TimerTaskObject, run_timer};
 
 #[cfg(feature = "recovery")]
 pub use recovery::RedbCheckpointStore;
@@ -297,6 +308,7 @@ pub use scheduler::{BackoffPolicy, FlowInfo, RunningScheduler, Schedule, Schedul
 /// Processing-model macros are namespaced under `cano::task::` and `cano::saga::`:
 /// - `#[cano::task::router]` — for `impl RouterTask` blocks
 /// - `#[cano::task::poll]` — for `impl PollTask` blocks
+/// - `#[cano::task::timer]` — for `impl TimerTask` blocks
 /// - `#[cano::task::batch]` — for `impl BatchTask` blocks
 /// - `#[cano::task::stepped]` — for `impl SteppedTask` blocks
 /// - `#[cano::saga::task]` — for `impl CompensatableTask` blocks
@@ -347,8 +359,8 @@ pub mod prelude {
         PollErrorPolicy, PollOutcome, PollTask, RateLimiter, RateLimiterPermit, RateLimiterPolicy,
         Reservation, Resource, Resources, RetryMode, RouterTask, RowKind, SplitResult,
         SplitTaskResult, StateEntry, StepOutcome, SteppedTask, Task, TaskConfig, TaskObject,
-        TaskResult, Tier, WindowPermit, WindowPolicy, WindowedRateLimiter, Workflow,
-        WorkflowObserver, run_stepped,
+        TaskResult, Tier, TimerOutcome, TimerTask, WindowPermit, WindowPolicy, WindowedRateLimiter,
+        Workflow, WorkflowObserver, run_stepped,
     };
 
     #[cfg(feature = "scheduler")]

--- a/cano/src/task.rs
+++ b/cano/src/task.rs
@@ -88,6 +88,7 @@ pub mod poll;
 mod retry;
 pub mod router;
 pub mod stepped;
+pub mod timer;
 
 pub use batch::{
     BatchTask, BatchTaskObject, DefaultBatchItem, DefaultBatchItemOutput, DynBatchTask, run_batch,
@@ -100,16 +101,18 @@ pub use router::{DynRouterTask, RouterTask, RouterTaskObject};
 pub use stepped::{
     DefaultStepCursor, DynSteppedTask, StepOutcome, SteppedTask, SteppedTaskObject, run_stepped,
 };
+pub use timer::{DynTimerTask, TimerOutcome, TimerTask, TimerTaskObject, run_timer};
 
 // Attribute macros namespaced under `cano::task::` so that
-// `#[task::router]`, `#[task::poll]`, `#[task::batch]`, and `#[task::stepped]`
-// all resolve as path-qualified attribute macros.
+// `#[task::router]`, `#[task::poll]`, `#[task::timer]`, `#[task::batch]`, and
+// `#[task::stepped]` all resolve as path-qualified attribute macros.
 // (Modules and macros occupy different namespaces, so these coexist with the
-// `router`, `poll`, `batch`, and `stepped` submodules above.)
+// `router`, `poll`, `timer`, `batch`, and `stepped` submodules above.)
 pub use cano_macros::batch_task as batch;
 pub use cano_macros::poll_task as poll;
 pub use cano_macros::router_task as router;
 pub use cano_macros::stepped_task as stepped;
+pub use cano_macros::timer_task as timer;
 
 /// Result type for task execution that supports both single and split transitions
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/cano/src/task/timer.rs
+++ b/cano/src/task/timer.rs
@@ -1,0 +1,487 @@
+//! # TimerTask — Wait-Then-Transition Processing Model
+//!
+//! A [`TimerTask`] sleeps for a [`Duration`](std::time::Duration) (or until a monotonic
+//! [`Instant`](std::time::Instant) is reached) and then transitions to the next state. It
+//! replaces the manual `PollTask + sleep + check` boilerplate users write when all they actually
+//! need is "pause here, then continue": a [`PollTask`](crate::task::PollTask) re-evaluates a
+//! condition on every wake-up, whereas a `TimerTask` schedules **a single** `tokio::time::sleep`
+//! and wakes exactly once.
+//!
+//! ## When to use `TimerTask`
+//!
+//! - **Cool-down / debounce**: wait a fixed delay before the next step (rate-pacing, backoff
+//!   between externally-triggered phases).
+//! - **Deferred hand-off**: resume after a known delay via [`TimerOutcome::Until`].
+//! - **Deliberate pauses** in a workflow that don't depend on polling an external condition.
+//!
+//! If you need to *re-check a condition* while waiting, use a
+//! [`PollTask`](crate::task::PollTask) instead.
+//!
+//! Every [`TimerTask`] automatically implements [`Task`](crate::task::Task) via a per-impl-site
+//! companion `impl Task<S> for T` emitted by the `#[task::timer]` macro, so you register one with
+//! [`Workflow::register`](crate::workflow::Workflow::register) exactly like any other task.
+//!
+//! ## Recovery: a timer re-waits from scratch on resume
+//!
+//! A `TimerTask` is an ordinary checkpointed single-task state: the engine writes its
+//! [`CheckpointRow`](crate::recovery::CheckpointRow) **before** running it, so a
+//! [resumed](crate::workflow::Workflow::resume_from) run **re-runs `wait()` from the start**. A
+//! `Duration(30 min)` timer that crashes at minute 29 sleeps the full 30 minutes again after
+//! resume, and an [`Until`](TimerOutcome::Until) deadline built from
+//! [`Instant::now()`](std::time::Instant::now) is recomputed relative to the *new* now — so it
+//! shifts forward by the downtime rather than firing at the originally-intended moment. Note also
+//! that [`Instant`] is a **monotonic, process-relative** clock reading, not a wall-clock/calendar
+//! time, and is not comparable across process restarts. If you need a delay that survives a crash,
+//! derive it inside `wait()` from a timestamp you persist in [`Resources`] (or a checkpoint),
+//! not from `Instant::now()`.
+//!
+//! ## Quick Start
+//!
+//! ```rust
+//! use cano::prelude::*;
+//! use std::time::Duration;
+//!
+//! #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+//! enum Step { Wait, Done }
+//!
+//! struct CoolDown;
+//!
+//! #[task::timer(state = Step)]
+//! impl CoolDown {
+//!     async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+//!         Ok(TimerOutcome::Duration(Duration::from_millis(50)))
+//!     }
+//!
+//!     async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+//!         Ok(TaskResult::Single(Step::Done))
+//!     }
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), CanoError> {
+//! let workflow = Workflow::bare()
+//!     .register(Step::Wait, CoolDown)
+//!     .add_exit_state(Step::Done);
+//!
+//! let result = workflow.orchestrate(Step::Wait).await?;
+//! assert_eq!(result, Step::Done);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Bounding the wait
+//!
+//! A `TimerTask` runs as a single dispatch attempt, so an `attempt_timeout` from
+//! [`TimerTask::config`] caps the whole wait. If the timer hasn't fired by then, the workflow
+//! receives [`CanoError::Timeout`]:
+//!
+//! ```rust
+//! use cano::prelude::*;
+//! use std::time::Duration;
+//!
+//! #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+//! enum Step { Wait, Done }
+//!
+//! struct BoundedTimer;
+//!
+//! #[task::timer(state = Step)]
+//! impl BoundedTimer {
+//!     fn config(&self) -> TaskConfig {
+//!         TaskConfig::minimal().with_attempt_timeout(Duration::from_secs(5))
+//!     }
+//!
+//!     async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+//!         Ok(TimerOutcome::Duration(Duration::from_millis(10)))
+//!     }
+//!
+//!     async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+//!         Ok(TaskResult::Single(Step::Done))
+//!     }
+//! }
+//! ```
+//!
+//! ## The trait-impl form
+//!
+//! You can also write the full `impl TimerTask<S> for T` header explicitly:
+//!
+//! ```rust
+//! use cano::prelude::*;
+//! use std::time::Duration;
+//!
+//! #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+//! enum Step { Wait, Done }
+//!
+//! struct TraitTimer;
+//!
+//! #[task::timer]
+//! impl TimerTask<Step> for TraitTimer {
+//!     async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+//!         Ok(TimerOutcome::Duration(Duration::from_millis(10)))
+//!     }
+//!     async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+//!         Ok(TaskResult::Single(Step::Done))
+//!     }
+//! }
+//! ```
+
+use crate::error::CanoError;
+use crate::resource::Resources;
+use crate::task::{TaskConfig, TaskResult};
+use std::borrow::Cow;
+use std::fmt;
+use std::hash::Hash;
+use std::time::{Duration, Instant};
+
+// ---------------------------------------------------------------------------
+// TimerOutcome — how long to wait before transitioning
+// ---------------------------------------------------------------------------
+
+/// The outcome returned by [`TimerTask::wait`]: how long the engine should sleep before
+/// calling [`after_wait`](TimerTask::after_wait).
+///
+/// - [`TimerOutcome::Duration`] — sleep for a relative duration from now.
+/// - [`TimerOutcome::Until`] — sleep until a monotonic [`Instant`]. An instant in the past fires
+///   immediately (no sleep).
+///
+/// Note that [`Instant`] is a **monotonic, process-relative** clock reading — not a
+/// wall-clock/calendar time, and not meaningful across a process restart. See the
+/// [module-level recovery note](self#recovery-a-timer-re-waits-from-scratch-on-resume).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TimerOutcome {
+    /// Sleep for this duration, then transition. `Duration::ZERO` transitions immediately.
+    Duration(Duration),
+    /// Sleep until this monotonic [`Instant`], then transition. A past instant fires immediately.
+    Until(Instant),
+}
+
+// ---------------------------------------------------------------------------
+// TimerTask trait
+// ---------------------------------------------------------------------------
+
+/// A "wait-then-transition" processing model that sleeps once for the
+/// [`TimerOutcome`] returned by [`wait`](TimerTask::wait), then routes via
+/// [`after_wait`](TimerTask::after_wait).
+///
+/// # Generic Types
+///
+/// - **`TState`**: The state enum used by the workflow (`Clone + Debug + Send + Sync`).
+/// - **`TResourceKey`**: The key type used to look up resources (defaults to
+///   [`Cow<'static, str>`]).
+///
+/// # Default config
+///
+/// Like [`PollTask`](crate::task::PollTask), `TimerTask` defaults to
+/// [`TaskConfig::minimal()`] (no retries). A single scheduled sleep does not benefit from outer
+/// retry wrapping; to bound the wait, attach an `attempt_timeout` instead.
+///
+/// # Implementing TimerTask
+///
+/// Prefer the inherent `#[task::timer(state = S)]` form:
+///
+/// ```rust
+/// use cano::prelude::*;
+/// use std::time::Duration;
+///
+/// #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// enum Step { Wait, Done }
+///
+/// struct MyTimer;
+///
+/// #[task::timer(state = Step)]
+/// impl MyTimer {
+///     async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+///         Ok(TimerOutcome::Duration(Duration::from_millis(10)))
+///     }
+///     async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+///         Ok(TaskResult::Single(Step::Done))
+///     }
+/// }
+/// ```
+#[crate::task::timer]
+pub trait TimerTask<TState, TResourceKey = Cow<'static, str>>: Send + Sync
+where
+    TState: Clone + fmt::Debug + Send + Sync + 'static,
+    TResourceKey: Hash + Eq + Send + Sync + 'static,
+{
+    /// Get the task configuration that controls execution behaviour.
+    ///
+    /// Defaults to [`TaskConfig::minimal()`] (no retries, no timeout). Override to attach a
+    /// per-attempt timeout that bounds the wait.
+    fn config(&self) -> TaskConfig {
+        TaskConfig::minimal()
+    }
+
+    /// Human-readable identifier for this timer, reported to [`WorkflowObserver`] hooks.
+    ///
+    /// Defaults to [`std::any::type_name`] of the implementing type. Override for a stable,
+    /// friendly name.
+    ///
+    /// [`WorkflowObserver`]: crate::observer::WorkflowObserver
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed(std::any::type_name::<Self>())
+    }
+
+    /// Decide how long to wait. Called once, before the engine sleeps.
+    ///
+    /// Return [`TimerOutcome::Duration`] for a relative delay or [`TimerOutcome::Until`] for a
+    /// monotonic [`Instant`](std::time::Instant) deadline.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CanoError`] to abort before sleeping (no [`after_wait`](Self::after_wait) call).
+    async fn wait(&self, res: &Resources<TResourceKey>) -> Result<TimerOutcome, CanoError>;
+
+    /// Decide the next state. Called once, after the sleep has elapsed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CanoError`] propagated from the task logic.
+    async fn after_wait(
+        &self,
+        res: &Resources<TResourceKey>,
+    ) -> Result<TaskResult<TState>, CanoError>;
+}
+
+// ---------------------------------------------------------------------------
+// run_timer — the body called by the macro-synthesised Task::run
+// ---------------------------------------------------------------------------
+
+/// Run the [`TimerTask`] wait-then-transition sequence for `t`.
+///
+/// The synthesised `Task::run` method emitted by `#[task::timer]` delegates here so that the
+/// sleep body (which needs `tokio::time`) lives in a single place. It calls `t.wait(res)`, sleeps
+/// for the returned [`TimerOutcome`] (a `Duration::ZERO` or a past `Until` instant resolves
+/// immediately), then returns `t.after_wait(res)`.
+///
+/// To cap the whole wait, return `TaskConfig::minimal().with_attempt_timeout(dur)` from
+/// [`TimerTask::config`] and dispatch the task via
+/// [`Workflow::orchestrate`](crate::workflow::Workflow::orchestrate).
+pub async fn run_timer<T, S, K>(t: &T, res: &Resources<K>) -> Result<TaskResult<S>, CanoError>
+where
+    T: TimerTask<S, K> + ?Sized,
+    S: Clone + fmt::Debug + Send + Sync + 'static,
+    K: Hash + Eq + Send + Sync + 'static,
+{
+    match t.wait(res).await? {
+        TimerOutcome::Duration(d) => tokio::time::sleep(d).await,
+        // `sleep_until` resolves immediately for a deadline already in the past.
+        TimerOutcome::Until(i) => tokio::time::sleep_until(tokio::time::Instant::from_std(i)).await,
+    }
+    t.after_wait(res).await
+}
+
+// ---------------------------------------------------------------------------
+// Type aliases
+// ---------------------------------------------------------------------------
+
+/// Type alias for a dynamic [`TimerTask`] trait object.
+pub type DynTimerTask<TState, TResourceKey = Cow<'static, str>> =
+    dyn TimerTask<TState, TResourceKey> + Send + Sync;
+
+/// Type alias for an `Arc`-wrapped dynamic [`TimerTask`] trait object.
+pub type TimerTaskObject<TState, TResourceKey = Cow<'static, str>> =
+    std::sync::Arc<DynTimerTask<TState, TResourceKey>>;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resource::Resources;
+    use crate::task;
+    use crate::task::Task;
+    use std::sync::Arc;
+
+    // Note: like `poll.rs`, all `#[task::timer]` usages inside the `cano` crate use the
+    // trait-impl form (`impl TimerTask<S> for T`), because the inherent form emits
+    // `::cano::TimerTask<...>` paths that don't resolve inside this crate. The inherent
+    // form is tested in `cano-macros/tests/timer_task_impl.rs` where `::cano` resolves.
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    enum Step {
+        Wait,
+        Done,
+        Next,
+    }
+
+    // (a) Duration timer drives the wait-then-transition sequence.
+    struct DurationTimer;
+
+    #[task::timer]
+    impl TimerTask<Step> for DurationTimer {
+        async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+            Ok(TimerOutcome::Duration(Duration::ZERO))
+        }
+        async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+            Ok(TaskResult::Single(Step::Done))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_timer_task_duration_via_run_timer() {
+        let timer = DurationTimer;
+        let res = Resources::new();
+        let result = run_timer(&timer, &res).await.unwrap();
+        assert_eq!(result, TaskResult::Single(Step::Done));
+    }
+
+    #[tokio::test]
+    async fn test_timer_task_duration_via_task_run() {
+        let timer = DurationTimer;
+        let res = Resources::new();
+        let result = Task::run(&timer, &res).await.unwrap();
+        assert_eq!(result, TaskResult::Single(Step::Done));
+    }
+
+    // (b) Until a past instant — fires immediately (no sleep).
+    struct PastInstantTimer;
+
+    #[task::timer]
+    impl TimerTask<Step> for PastInstantTimer {
+        async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+            let past = Instant::now() - Duration::from_secs(60);
+            Ok(TimerOutcome::Until(past))
+        }
+        async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+            Ok(TaskResult::Single(Step::Done))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_timer_task_until_past_instant_fires_immediately() {
+        let timer = PastInstantTimer;
+        let res = Resources::new();
+        let start = Instant::now();
+        let result = run_timer(&timer, &res).await.unwrap();
+        assert_eq!(result, TaskResult::Single(Step::Done));
+        assert!(
+            start.elapsed() < Duration::from_millis(500),
+            "past Until should not sleep"
+        );
+    }
+
+    // (c) after_wait may return Split.
+    struct SplitTimer;
+
+    #[task::timer]
+    impl TimerTask<Step> for SplitTimer {
+        async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+            Ok(TimerOutcome::Duration(Duration::ZERO))
+        }
+        async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+            Ok(TaskResult::Split(vec![Step::Wait, Step::Next]))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_timer_task_split() {
+        let timer = SplitTimer;
+        let res = Resources::new();
+        let result = Task::run(&timer, &res).await.unwrap();
+        assert_eq!(result, TaskResult::Split(vec![Step::Wait, Step::Next]));
+    }
+
+    // (d) Config + name defaults / overrides.
+    struct CustomTimer;
+
+    #[task::timer]
+    impl TimerTask<Step> for CustomTimer {
+        fn name(&self) -> Cow<'static, str> {
+            Cow::Borrowed("my-custom-timer")
+        }
+        async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+            Ok(TimerOutcome::Duration(Duration::ZERO))
+        }
+        async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+            Ok(TaskResult::Single(Step::Done))
+        }
+    }
+
+    #[test]
+    fn test_timer_task_default_config_is_minimal() {
+        let timer = DurationTimer;
+        assert_eq!(
+            TimerTask::<Step>::config(&timer).retry_mode.max_attempts(),
+            1,
+            "TimerTask default config must be minimal (no retries)"
+        );
+    }
+
+    #[test]
+    fn test_timer_task_default_name_contains_type_name() {
+        let timer = DurationTimer;
+        let name = TimerTask::<Step>::name(&timer);
+        assert!(
+            name.contains("DurationTimer"),
+            "default name should contain the type name, got: {name}",
+        );
+    }
+
+    #[test]
+    fn test_timer_task_name_override_forwarded_to_task() {
+        let timer = CustomTimer;
+        assert_eq!(TimerTask::<Step>::name(&timer), "my-custom-timer");
+        assert_eq!(Task::name(&timer), "my-custom-timer");
+    }
+
+    // (e) Dynamic dispatch: Arc<dyn Task<S>>.
+    #[tokio::test]
+    async fn test_timer_task_as_dyn_task() {
+        let timer: Arc<dyn Task<Step>> = Arc::new(DurationTimer);
+        let res = Resources::new();
+        let result = Task::run(timer.as_ref(), &res).await.unwrap();
+        assert_eq!(result, TaskResult::Single(Step::Done));
+    }
+
+    // (f) Errors from wait / after_wait propagate.
+    struct WaitErrorTimer;
+
+    #[task::timer]
+    impl TimerTask<Step> for WaitErrorTimer {
+        async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+            Err(CanoError::task_execution("wait failed"))
+        }
+        async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+            Ok(TaskResult::Single(Step::Done))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_wait_error_propagates() {
+        let timer = WaitErrorTimer;
+        let res = Resources::new();
+        let err = Task::run(&timer, &res).await.unwrap_err();
+        assert!(matches!(err, CanoError::TaskExecution(_)));
+    }
+
+    struct AfterWaitErrorTimer;
+
+    #[task::timer]
+    impl TimerTask<Step> for AfterWaitErrorTimer {
+        async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+            Ok(TimerOutcome::Duration(Duration::ZERO))
+        }
+        async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+            Err(CanoError::task_execution("after_wait failed"))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_after_wait_error_propagates() {
+        let timer = AfterWaitErrorTimer;
+        let res = Resources::new();
+        let err = Task::run(&timer, &res).await.unwrap_err();
+        assert!(matches!(err, CanoError::TaskExecution(_)));
+    }
+
+    // (g) run_timer with a dyn TimerTask (?Sized).
+    #[tokio::test]
+    async fn test_run_timer_dyn_dispatch() {
+        let timer: &dyn TimerTask<Step> = &DurationTimer;
+        let res = Resources::new();
+        let result = run_timer(timer, &res).await.unwrap();
+        assert_eq!(result, TaskResult::Single(Step::Done));
+    }
+}

--- a/cano/src/workflow.rs
+++ b/cano/src/workflow.rs
@@ -449,21 +449,26 @@ where
         self
     }
 
-    /// Register multiple tasks that will execute in parallel with a join configuration
+    /// Register multiple tasks that execute in parallel with a join configuration.
+    ///
+    /// `tasks` accepts any [`IntoIterator`] (a `Vec`, an array, a `(0..n).map(…)` chain,
+    /// etc.); the tasks are collected eagerly at registration time.
     pub fn register_split<T>(
         mut self,
         state: TState,
-        tasks: Vec<T>,
+        tasks: impl IntoIterator<Item = T>,
         join_config: JoinConfig<TState>,
     ) -> Self
     where
         T: Task<TState, TResourceKey> + Send + Sync + 'static,
     {
         self.forget_compensator_for(&state);
-        let configs: Vec<Arc<crate::task::TaskConfig>> =
-            tasks.iter().map(|t| Arc::new(t.config())).collect();
-        let arc_tasks: Vec<Arc<dyn Task<TState, TResourceKey> + Send + Sync>> =
-            tasks.into_iter().map(|t| Arc::new(t) as Arc<_>).collect();
+        let mut configs: Vec<Arc<crate::task::TaskConfig>> = Vec::new();
+        let mut arc_tasks: Vec<Arc<dyn Task<TState, TResourceKey> + Send + Sync>> = Vec::new();
+        for t in tasks {
+            configs.push(Arc::new(t.config()));
+            arc_tasks.push(Arc::new(t) as Arc<_>);
+        }
 
         self.states.insert(
             state,
@@ -568,8 +573,11 @@ where
         self
     }
 
-    /// Add multiple exit states
-    pub fn add_exit_states(mut self, states: Vec<TState>) -> Self {
+    /// Add multiple exit states.
+    ///
+    /// `states` accepts any [`IntoIterator`] (a `Vec`, an array, a `.map(…)` chain, etc.);
+    /// duplicates already present are skipped.
+    pub fn add_exit_states(mut self, states: impl IntoIterator<Item = TState>) -> Self {
         for state in states {
             if !self.exit_states.contains(&state) {
                 self.exit_states.push(state);
@@ -1445,6 +1453,61 @@ mod tests {
             )
             .add_exit_state(TestState::Complete);
         assert!(workflow.validate().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_register_split_accepts_array_input() {
+        // An array literal is `IntoIterator<Item = T>` but not a `Vec`; it must
+        // register and run through split/join just like a `Vec` does.
+        let workflow = Workflow::bare()
+            .register_split(
+                TestState::Start,
+                [
+                    SimpleTask::new(TestState::Complete),
+                    SimpleTask::new(TestState::Complete),
+                ],
+                JoinConfig::new(JoinStrategy::All, TestState::Complete),
+            )
+            .add_exit_state(TestState::Complete);
+
+        let result = workflow.orchestrate(TestState::Start).await.unwrap();
+        assert_eq!(result, TestState::Complete);
+    }
+
+    #[tokio::test]
+    async fn test_register_split_accepts_lazy_iterator_input() {
+        // A `Range::map` adapter is a lazy iterator with no `Vec` backing — it must
+        // be consumed and materialized by `register_split` without a `.collect()`.
+        let workflow = Workflow::bare()
+            .register_split(
+                TestState::Start,
+                (0..3).map(|_| SimpleTask::new(TestState::Complete)),
+                JoinConfig::new(JoinStrategy::All, TestState::Complete),
+            )
+            .add_exit_state(TestState::Complete);
+
+        let result = workflow.orchestrate(TestState::Start).await.unwrap();
+        assert_eq!(result, TestState::Complete);
+    }
+
+    #[tokio::test]
+    async fn test_add_exit_states_accepts_array_input() {
+        // An array literal is `IntoIterator` but not a `Vec`.
+        let workflow = Workflow::bare()
+            .register(TestState::Start, SimpleTask::new(TestState::Complete))
+            .add_exit_states([TestState::Complete, TestState::Error]);
+        let result = workflow.orchestrate(TestState::Start).await.unwrap();
+        assert_eq!(result, TestState::Complete);
+    }
+
+    #[tokio::test]
+    async fn test_add_exit_states_accepts_lazy_iterator_and_dedups() {
+        // A lazy iterator (no Vec) carrying a duplicate — dedup must still hold.
+        let workflow = Workflow::bare()
+            .register(TestState::Start, SimpleTask::new(TestState::Complete))
+            .add_exit_states([TestState::Complete, TestState::Complete].into_iter());
+        let result = workflow.orchestrate(TestState::Start).await.unwrap();
+        assert_eq!(result, TestState::Complete);
     }
 
     #[test]

--- a/cano/tests/timer_task_e2e.rs
+++ b/cano/tests/timer_task_e2e.rs
@@ -1,0 +1,144 @@
+//! End-to-end workflow integration tests for `TimerTask`.
+//!
+//! Duration-based timers run under a paused clock (`#[tokio::test(start_paused = true)]`),
+//! so virtual time auto-advances to the scheduled wake-up and the tests assert no real wall
+//! time is spent. `Until`-based timers use tiny *real* instants without pausing the clock —
+//! mixing a frozen tokio clock with the real `std::Instant` that `TimerOutcome::Until` carries
+//! is fragile, so those tests stay on the real clock with short (tens-of-ms) deadlines.
+
+use cano::prelude::*;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Step {
+    Wait,
+    Process,
+    Done,
+}
+
+// A plain follow-on task so timers route into a real subsequent state.
+struct Process;
+
+#[task(state = Step)]
+impl Process {
+    async fn run_bare(&self) -> Result<TaskResult<Step>, CanoError> {
+        Ok(TaskResult::Single(Step::Done))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Duration timer fires after the expected (virtual) delay
+// ---------------------------------------------------------------------------
+
+struct ThirtySecondTimer;
+
+#[task::timer(state = Step)]
+impl ThirtySecondTimer {
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        Ok(TimerOutcome::Duration(Duration::from_secs(30)))
+    }
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        Ok(TaskResult::Single(Step::Process))
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn duration_timer_fires_after_expected_delay() {
+    let start = tokio::time::Instant::now();
+
+    let workflow = Workflow::bare()
+        .register(Step::Wait, ThirtySecondTimer)
+        .register(Step::Process, Process)
+        .add_exit_state(Step::Done);
+
+    let result = workflow.orchestrate(Step::Wait).await.unwrap();
+    let elapsed = start.elapsed();
+
+    assert_eq!(result, Step::Done);
+    // The engine schedules a single 30s sleep; virtual time advances exactly once.
+    assert!(
+        elapsed >= Duration::from_secs(30),
+        "timer should wait the full duration, virtual elapsed = {elapsed:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(31),
+        "timer should wake exactly once, not loop, virtual elapsed = {elapsed:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Instant timer fires at (around) the requested wall-clock instant
+// ---------------------------------------------------------------------------
+
+struct NearFutureInstantTimer;
+
+#[task::timer(state = Step)]
+impl NearFutureInstantTimer {
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        Ok(TimerOutcome::Until(
+            Instant::now() + Duration::from_millis(40),
+        ))
+    }
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        Ok(TaskResult::Single(Step::Process))
+    }
+}
+
+#[tokio::test]
+async fn instant_timer_fires_at_correct_instant() {
+    let start = Instant::now();
+
+    let result = Workflow::bare()
+        .register(Step::Wait, NearFutureInstantTimer)
+        .register(Step::Process, Process)
+        .add_exit_state(Step::Done)
+        .orchestrate(Step::Wait)
+        .await
+        .unwrap();
+
+    let elapsed = start.elapsed();
+    assert_eq!(result, Step::Done);
+    // `sleep_until` never fires early, so we waited at least (most of) the deadline.
+    assert!(
+        elapsed >= Duration::from_millis(30),
+        "Until timer fired too early: {elapsed:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// attempt_timeout cancels a long timer
+// ---------------------------------------------------------------------------
+
+struct OneHourTimer;
+
+#[task::timer(state = Step)]
+impl OneHourTimer {
+    fn config(&self) -> TaskConfig {
+        TaskConfig::minimal().with_attempt_timeout(Duration::from_millis(50))
+    }
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        Ok(TimerOutcome::Duration(Duration::from_secs(3600)))
+    }
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        Ok(TaskResult::Single(Step::Process))
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn attempt_timeout_cancels_long_timer() {
+    // The 50ms attempt timeout fires before the 1h sleep; auto-advance jumps to the
+    // earliest deadline (the timeout), producing CanoError::Timeout.
+    let err = Workflow::bare()
+        .register(Step::Wait, OneHourTimer)
+        .register(Step::Process, Process)
+        .add_exit_state(Step::Done)
+        .orchestrate(Step::Wait)
+        .await
+        .unwrap_err();
+
+    // The FSM wraps the failure with state context; `.inner()` peels one layer.
+    assert!(
+        matches!(err.inner(), CanoError::Timeout(_)),
+        "expected CanoError::Timeout, got: {err:?}"
+    );
+}

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -45,7 +45,7 @@ It excels at managing complex lifecycles where state transitions matter:
 <div class="feature-card animate-in">
 <div class="feature-icon" aria-hidden="true">&#9881;</div>
 <h3>Processing Models</h3>
-<p>A whole <a href="task/#task-family"><code>Task</code> family</a>: plain <code>Task</code>, side-effect-free <code>RouterTask</code>, wait-until <code>PollTask</code>, fan-out <code>BatchTask</code>, resumable <code>SteppedTask</code> — mixed freely in one workflow.</p>
+<p>A whole <a href="task/#task-family"><code>Task</code> family</a>: plain <code>Task</code>, side-effect-free <code>RouterTask</code>, wait-until <code>PollTask</code>, wait-then-go <code>TimerTask</code>, fan-out <code>BatchTask</code>, resumable <code>SteppedTask</code> — mixed freely in one workflow.</p>
 </div>
 <div class="feature-card animate-in">
 <div class="feature-icon secondary" aria-hidden="true">&#9670;</div>
@@ -218,7 +218,7 @@ async fn main() -> Result<(), CanoError> {
 <ol>
 <li><a href="workflows/">Workflows</a> — defining states, the builder, validation, and how a run executes.</li>
 <li><a href="resources/">Resources</a> — typed, lifecycle-managed dependency injection (every task receives a <code>&amp;Resources</code>).</li>
-<li><a href="task/">Task</a> — the default processing unit, then the rest of the <a href="task/#task-family">Task family</a> (<a href="router-task/">RouterTask</a>, <a href="poll-task/">PollTask</a>, <a href="batch-task/">BatchTask</a>, <a href="stepped-task/">SteppedTask</a>) as you hit a shape that fits.</li>
+<li><a href="task/">Task</a> — the default processing unit, then the rest of the <a href="task/#task-family">Task family</a> (<a href="router-task/">RouterTask</a>, <a href="poll-task/">PollTask</a>, <a href="timer-task/">TimerTask</a>, <a href="batch-task/">BatchTask</a>, <a href="stepped-task/">SteppedTask</a>) as you hit a shape that fits.</li>
 <li><a href="split-join/">Split &amp; Join</a> and <a href="scheduler/">Scheduler</a> — parallelism within a workflow, and time-driven execution of workflows.</li>
 <li>Resilience &amp; recovery: <a href="resilience/">Resilience</a>, <a href="recovery/">Recovery</a>, <a href="saga/">Saga</a>.</li>
 <li>Observability: <a href="tracing/">Tracing</a>, <a href="metrics/">Metrics</a>, <a href="observers/">Observers</a>.</li>

--- a/docs/content/batch-task/_index.md
+++ b/docs/content/batch-task/_index.md
@@ -14,7 +14,8 @@ concurrency (each item independently retryable), collects the per-item results <
 order</strong>, and decides the next state from the aggregate — all within one workflow state. It is
 one of the <a href="../task/">Task</a> family of processing models, alongside
 <a href="../router-task/">RouterTask</a>,
-<a href="../poll-task/">PollTask</a>, and <a href="../stepped-task/">SteppedTask</a>, and it reads
+<a href="../poll-task/">PollTask</a>, <a href="../timer-task/">TimerTask</a>, and
+<a href="../stepped-task/">SteppedTask</a>, and it reads
 typed dependencies from <a href="../resources/">Resources</a> like the rest. New to Cano? Read
 <a href="../workflows/">Workflows</a> and <a href="../resources/">Resources</a> first.
 </p>

--- a/docs/content/poll-task/_index.md
+++ b/docs/content/poll-task/_index.md
@@ -13,8 +13,9 @@ A <code>PollTask</code> repeatedly calls its <code>poll</code> method until the 
 is ready. Each call returns either "ready, here's the next state" or "not yet, try again in
 <em>n</em> milliseconds" — an async sleep, not a blocked thread. It is one of the
 <a href="../task/">Task</a> family of processing models, alongside
-<a href="../router-task/">RouterTask</a>, <a href="../batch-task/">BatchTask</a>, and
-<a href="../stepped-task/">SteppedTask</a>. A <code>PollTask</code> reads typed dependencies from
+<a href="../router-task/">RouterTask</a>, <a href="../timer-task/">TimerTask</a>,
+<a href="../batch-task/">BatchTask</a>, and <a href="../stepped-task/">SteppedTask</a>. A
+<code>PollTask</code> reads typed dependencies from
 <a href="../resources/">Resources</a> the same way every other model does. New to Cano? Read
 <a href="../workflows/">Workflows</a> and <a href="../resources/">Resources</a> first.
 </p>

--- a/docs/content/router-task/_index.md
+++ b/docs/content/router-task/_index.md
@@ -15,8 +15,8 @@ and nothing else. No store mutations, no external I/O, no side effects. Because 
 is free, the workflow engine records <strong>no checkpoint row</strong> for it — see
 <a href="../recovery/">Crash Recovery</a> for what that means. It is one of the
 <a href="../task/">Task</a> family of processing models, alongside
-<a href="../poll-task/">PollTask</a>, <a href="../batch-task/">BatchTask</a>, and
-<a href="../stepped-task/">SteppedTask</a>.
+<a href="../poll-task/">PollTask</a>, <a href="../timer-task/">TimerTask</a>,
+<a href="../batch-task/">BatchTask</a>, and <a href="../stepped-task/">SteppedTask</a>.
 </p>
 
 <div class="callout callout-info">

--- a/docs/content/stepped-task/_index.md
+++ b/docs/content/stepped-task/_index.md
@@ -14,8 +14,9 @@ returns either "more work, here's the new cursor" or "done, here's the next stat
 <a href="../recovery/">checkpoint store</a> is attached, the engine persists that cursor after every
 step — so a crash mid-loop resumes from where it left off, not from step zero. It is one of the
 <a href="../task/">Task</a> family of processing models, alongside
-<a href="../router-task/">RouterTask</a>, <a href="../poll-task/">PollTask</a>, and
-<a href="../batch-task/">BatchTask</a>, and it reads typed dependencies from
+<a href="../router-task/">RouterTask</a>, <a href="../poll-task/">PollTask</a>,
+<a href="../timer-task/">TimerTask</a>, and <a href="../batch-task/">BatchTask</a>, and it reads
+typed dependencies from
 <a href="../resources/">Resources</a> like the rest. New to Cano? Read
 <a href="../workflows/">Workflows</a> and <a href="../resources/">Resources</a> first; for the
 cursor-persistence half, <a href="../recovery/">Recovery</a>.

--- a/docs/content/task/_index.md
+++ b/docs/content/task/_index.md
@@ -11,9 +11,10 @@ template = "section.html"
 <p>
 A <code>Task</code> is the fundamental building block of a Cano workflow: a single <code>run</code>
 method that decides the next state. <strong>Start here</strong> — <code>Task</code> is the default
-choice for every processing unit. The other four processing models
+choice for every processing unit. The other five processing models
 (<a href="../router-task/">RouterTask</a>,
-<a href="../poll-task/">PollTask</a>, <a href="../batch-task/">BatchTask</a>,
+<a href="../poll-task/">PollTask</a>, <a href="../timer-task/">TimerTask</a>,
+<a href="../batch-task/">BatchTask</a>,
 <a href="../stepped-task/">SteppedTask</a>) are specialisations you reach for only when a task
 has a shape that one of them fits better — see <a href="#task-family">The Task Family</a> below for
 the decision matrix. Tasks receive a <code>&amp;Resources</code> reference at dispatch time — see
@@ -349,6 +350,12 @@ nothing. Registered with <code>register_router</code>; leaves no checkpoint row.
 <p><strong>Reach for it when:</strong> waiting on an external job, queue, or flag flip.</p>
 </div>
 <div class="card">
+<h3><a href="../timer-task/">TimerTask</a></h3>
+<p>Wait-then-transition: <code>wait</code> returns a <code>Duration</code> or monotonic
+<code>Instant</code>, the engine sleeps <em>once</em>, then <code>after_wait</code> routes.</p>
+<p><strong>Reach for it when:</strong> a fixed cool-down/debounce, or resuming at a set instant.</p>
+</div>
+<div class="card">
 <h3><a href="../batch-task/">BatchTask</a></h3>
 <p>Fan out over data: <code>load → process_item (×N, bounded concurrency, per-item retry) → finish</code>,
 re-joined in one state.</p>
@@ -366,7 +373,7 @@ step, so a crash resumes mid-loop. Registered with <code>register_stepped</code>
 <hr class="section-divider">
 <h2 id="choosing"><a href="#choosing" class="anchor-link" aria-hidden="true">#</a>Choosing a Processing Model</h2>
 <p>
-All five models dispatch as a <code>Task</code>, so you can mix them in one workflow. Start from
+All six models dispatch as a <code>Task</code>, so you can mix them in one workflow. Start from
 <code>Task</code> and move to a specialised model only when your work has its shape:
 </p>
 
@@ -392,6 +399,11 @@ All five models dispatch as a <code>Task</code>, so you can mix them in one work
 <tr>
 <td><a href="../poll-task/"><strong><code>PollTask</code></strong></a></td>
 <td>You need to <em>wait until</em> something is ready — an external job, a queue, a flag flip — without blocking a thread.</td>
+<td><code>register</code></td>
+</tr>
+<tr>
+<td><a href="../timer-task/"><strong><code>TimerTask</code></strong></a></td>
+<td>You just need to <em>pause then continue</em> — a fixed cool-down/debounce, or sleeping until a monotonic instant — with a single scheduled wake-up, not a poll loop.</td>
 <td><code>register</code></td>
 </tr>
 <tr>

--- a/docs/content/timer-task/_index.md
+++ b/docs/content/timer-task/_index.md
@@ -1,0 +1,295 @@
++++
+title = "TimerTask"
+description = "TimerTask in Cano - wait-then-transition with a single scheduled sleep for a relative duration or a monotonic instant."
+template = "section.html"
++++
+
+<div class="content-wrapper">
+<h1>TimerTask</h1>
+<p class="subtitle">Wait once, then transition — a single scheduled sleep, not a poll loop.</p>
+
+<p>
+A <code>TimerTask</code> decides <em>how long to wait</em>, the engine sleeps exactly once, and then
+the task decides <em>where to go next</em>. There is no loop and no condition re-check: a 30-minute
+timer schedules one <code>tokio::time::sleep</code> and wakes a single time. It is one of the
+<a href="../task/">Task</a> family of processing models, alongside
+<a href="../router-task/">RouterTask</a>, <a href="../poll-task/">PollTask</a>,
+<a href="../batch-task/">BatchTask</a>, and <a href="../stepped-task/">SteppedTask</a>. A
+<code>TimerTask</code> reads typed dependencies from <a href="../resources/">Resources</a> the same
+way every other model does. New to Cano? Read <a href="../workflows/">Workflows</a> and
+<a href="../resources/">Resources</a> first.
+</p>
+
+<div class="code-block">
+<span class="code-block-label">At a glance — <code>wait</code> returns a <code>TimerOutcome</code>, then <code>after_wait</code> routes</span>
+
+```rust
+use cano::prelude::*;
+use std::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Stage { CoolDown, Done }
+
+struct CoolDown;
+
+#[task::timer(state = Stage)]
+impl CoolDown {
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        Ok(TimerOutcome::Duration(Duration::from_secs(30))) // one scheduled wake-up
+    }
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Stage>, CanoError> {
+        Ok(TaskResult::Single(Stage::Done))
+    }
+}
+```
+</div>
+
+<div class="callout callout-info">
+<div class="callout-label">TimerTask vs PollTask</div>
+<p>
+Reach for a <code>TimerTask</code> when you just need to <strong>pause, then continue</strong> — a
+cool-down, a debounce, or waking after a known delay. Reach for a
+<a href="../poll-task/">PollTask</a> when you need to <strong>re-check a condition</strong> while
+waiting. A timer wakes once; a poller loops.
+</p>
+</div>
+
+<!-- Table of Contents -->
+<nav class="page-toc" aria-label="Table of contents">
+<div class="page-toc-title">On this page</div>
+<ol>
+<li><a href="#how-it-works">How the Timer Works</a></li>
+<li><a href="#quick-start">Quick Start with <code>#[task::timer]</code></a></li>
+<li><a href="#registering">Registering a Timer Task</a></li>
+<li><a href="#outcomes">Duration vs Until</a></li>
+<li><a href="#caps">Bounding the Wait</a></li>
+<li><a href="#explicit">Explicit Trait-Impl Form</a></li>
+<li><a href="#object-safe">Type-Erased Aliases</a></li>
+<li><a href="#when-to-use">When to Use TimerTask</a></li>
+</ol>
+</nav>
+
+<!-- Section: how it works -->
+<hr class="section-divider">
+<h2 id="how-it-works"><a href="#how-it-works" class="anchor-link" aria-hidden="true">#</a>How the Timer Works</h2>
+
+<div class="diagram-frame">
+<p class="diagram-label">wait &rarr; sleep once &rarr; after_wait</p>
+<div class="mermaid">
+graph LR
+A[wait] -->|"TimerOutcome"| B[sleep once]
+B --> C[after_wait]
+C --> D[Next State]
+</div>
+</div>
+
+<p>
+A timer implements two required methods. <code>async fn wait(&amp;self, res: &amp;Resources) -&gt; Result&lt;TimerOutcome, CanoError&gt;</code>
+runs first and decides the delay; the engine then sleeps for that <code>TimerOutcome</code>; finally
+<code>async fn after_wait(&amp;self, res: &amp;Resources) -&gt; Result&lt;TaskResult&lt;TState&gt;, CanoError&gt;</code>
+runs and returns the next state.
+</p>
+<table class="styled-table">
+<thead>
+<tr>
+<th><code>TimerOutcome</code> variant</th>
+<th>Effect</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>Duration(d)</code></td>
+<td>sleep for the relative duration <code>d</code>, then call <code>after_wait</code> (<code>Duration::ZERO</code> transitions immediately)</td>
+</tr>
+<tr>
+<td><code>Until(instant)</code></td>
+<td>sleep until the monotonic <code>instant</code>, then call <code>after_wait</code> (a past instant fires immediately)</td>
+</tr>
+</tbody>
+</table>
+
+<!-- Section: Quick Start -->
+<hr class="section-divider">
+<h2 id="quick-start"><a href="#quick-start" class="anchor-link" aria-hidden="true">#</a>Quick Start with <code>#[task::timer]</code></h2>
+<p>
+Attach <code>#[task::timer(state = MyState)]</code> to an inherent <code>impl</code> block. You write
+<code>wait</code> and <code>after_wait</code>; the macro injects default bodies for <code>config</code>
+and <code>name</code> if you don't, synthesises the
+<code>impl TimerTask&lt;MyState&gt; for MyTimer</code> header, and emits a companion
+<code>impl Task&lt;MyState&gt; for MyTimer</code> whose <code>run</code> schedules the sleep (via
+<code>cano::task::timer::run_timer</code>) — so a timer is just an ordinary single-task state whose
+<code>run</code> happens to sleep first. No engine changes.
+</p>
+
+<div class="code-block">
+<span class="code-block-label"><span class="label-icon">&#9889;</span> Inference form — <code>#[task::timer(state = ...)]</code> on an inherent impl</span>
+
+```rust
+use cano::prelude::*;
+use std::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Step { CoolDown, Process, Done }
+
+struct CoolDown { delay: Duration }
+
+#[task::timer(state = Step)]
+impl CoolDown {
+    fn config(&self) -> TaskConfig {
+        // cap the whole wait at 5s
+        TaskConfig::minimal().with_attempt_timeout(Duration::from_secs(5))
+    }
+
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        Ok(TimerOutcome::Duration(self.delay))
+    }
+
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        Ok(TaskResult::Single(Step::Process))
+    }
+}
+```
+</div>
+
+<!-- Section: registering -->
+<hr class="section-divider">
+<h2 id="registering"><a href="#registering" class="anchor-link" aria-hidden="true">#</a>Registering a Timer Task</h2>
+<p>
+Register a timer with plain <code>Workflow::register</code> — to the FSM a timer is an ordinary
+<code>Single</code> state, so there is no special builder method (the companion <code>impl Task</code>
+the macro generated does the wait internally).
+</p>
+
+<div class="code-block">
+<span class="code-block-label"><span class="label-icon">&#9998;</span> Wiring a timer into a workflow</span>
+
+```rust
+use cano::prelude::*;
+
+let workflow = Workflow::bare()
+    .register(Step::CoolDown, CoolDown { delay: Duration::from_millis(50) })
+    .register(Step::Process, ProcessResults)
+    .add_exit_state(Step::Done);
+```
+</div>
+
+<!-- Section: outcomes -->
+<hr class="section-divider">
+<h2 id="outcomes"><a href="#outcomes" class="anchor-link" aria-hidden="true">#</a>Duration vs Until</h2>
+<div class="card-stack">
+<div class="card">
+<h3><code>TimerOutcome::Duration(d)</code></h3>
+<p>Wait a <strong>relative</strong> delay measured from now. Best for cool-downs, debounces, and
+fixed pacing between phases. <code>Duration::ZERO</code> skips the sleep entirely.</p>
+</div>
+<div class="card">
+<h3><code>TimerOutcome::Until(instant)</code></h3>
+<p>Wait until a monotonic <code>std::time::Instant</code> (a process-relative reading, <em>not</em>
+a wall-clock/calendar time). Best for "wake after a known delay" hand-offs. An instant already in
+the past fires immediately.</p>
+</div>
+</div>
+
+<!-- Section: caps -->
+<hr class="section-divider">
+<h2 id="caps"><a href="#caps" class="anchor-link" aria-hidden="true">#</a>Bounding the Wait</h2>
+<p>
+A timer runs as a single dispatch attempt, so an <code>attempt_timeout</code> from
+<code>config()</code> caps the <em>whole wait</em>. If the timer hasn't fired by the deadline, the
+workflow engine cancels it and produces <code>CanoError::Timeout</code>.
+</p>
+
+<div class="callout callout-tip">
+<p>The default <code>config()</code> is <code>TaskConfig::minimal()</code> — <strong>no retries</strong>.
+A single scheduled sleep doesn't benefit from outer retry wrapping; attach an
+<code>attempt_timeout</code> instead if you need a bound.</p>
+</div>
+
+<!-- Section: explicit -->
+<hr class="section-divider">
+<h2 id="explicit"><a href="#explicit" class="anchor-link" aria-hidden="true">#</a>Explicit Trait-Impl Form</h2>
+<p>
+Prefer writing the trait header yourself? Put a bare <code>#[task::timer]</code> on an
+<code>impl TimerTask&lt;...&gt; for ...</code> block. The companion <code>impl Task</code> is still
+emitted; explicit method definitions always win.
+</p>
+
+<div class="code-block">
+<span class="code-block-label"><span class="label-icon">&#9998;</span> Explicit form — <code>#[task::timer]</code> on a trait impl</span>
+
+```rust
+use cano::prelude::*;
+use std::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Step { CoolDown, Process, Done }
+
+struct CoolDown;
+
+#[task::timer]
+impl TimerTask<Step> for CoolDown {
+    async fn wait(&self, _res: &Resources) -> Result<TimerOutcome, CanoError> {
+        Ok(TimerOutcome::Duration(Duration::from_secs(30)))
+    }
+    async fn after_wait(&self, _res: &Resources) -> Result<TaskResult<Step>, CanoError> {
+        Ok(TaskResult::Single(Step::Process))
+    }
+}
+```
+</div>
+
+<!-- Section: object-safe aliases -->
+<hr class="section-divider">
+<h2 id="object-safe"><a href="#object-safe" class="anchor-link" aria-hidden="true">#</a>Type-Erased Aliases</h2>
+<table class="styled-table">
+<thead>
+<tr>
+<th>Alias</th>
+<th>Expands to</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>DynTimerTask&lt;TState, TResourceKey&gt;</code></td>
+<td><code>dyn TimerTask&lt;TState, TResourceKey&gt;</code></td>
+</tr>
+<tr>
+<td><code>TimerTaskObject&lt;TState, TResourceKey&gt;</code></td>
+<td><code>Arc&lt;dyn TimerTask&lt;TState, TResourceKey&gt;&gt;</code></td>
+</tr>
+</tbody>
+</table>
+
+<!-- Section: When to use -->
+<hr class="section-divider">
+<h2 id="when-to-use"><a href="#when-to-use" class="anchor-link" aria-hidden="true">#</a>When to Use TimerTask</h2>
+<p>Reach for a <code>TimerTask</code> when:</p>
+<ul>
+<li>you need a <strong>fixed cool-down or debounce</strong> between workflow phases;</li>
+<li>you want to <strong>wake after a known delay</strong> via <code>TimerOutcome::Until</code> with a
+monotonic instant;</li>
+<li>you want a <strong>deliberate pause</strong> that doesn't depend on polling an external
+condition — if it does, use a <a href="../poll-task/">PollTask</a> instead.</li>
+</ul>
+
+<div class="callout callout-warning">
+<span class="callout-label">Recovery</span>
+<p>
+A <code>TimerTask</code> is a checkpointed single-task state: a
+<a href="../recovery/">resumed</a> run re-runs <code>wait()</code> from the start. A
+<code>Duration(30 min)</code> timer that crashes at minute 29 sleeps the full 30 minutes again, and
+an <code>Until</code> deadline built from <code>Instant::now()</code> is recomputed relative to the
+new "now" — so it shifts forward by the downtime. <code>std::time::Instant</code> is monotonic and
+process-relative, not a calendar time. If you need a delay that survives a crash, derive it inside
+<code>wait()</code> from a timestamp you persist in <a href="../resources/">Resources</a> or a
+checkpoint, not from <code>Instant::now()</code>.
+</p>
+</div>
+
+<div class="callout callout-tip">
+<div class="callout-label">Runnable example</div>
+<p>
+The crate ships a complete example — run it with <code>cargo run --example timer_task</code>.
+</p>
+</div>
+</div>

--- a/docs/content/workflows/_index.md
+++ b/docs/content/workflows/_index.md
@@ -159,7 +159,7 @@ will warn you if you discard the return value. If you forget to capture it, the 
 <tr>
 <td><code>register(state, task)</code></td>
 <td><code>Single</code></td>
-<td>One <a href="../task/">Task</a> (or <a href="../poll-task/">PollTask</a>, <a href="../batch-task/">BatchTask</a> — all dispatch as <code>Task</code>).</td>
+<td>One <a href="../task/">Task</a> (or <a href="../poll-task/">PollTask</a>, <a href="../timer-task/">TimerTask</a>, <a href="../batch-task/">BatchTask</a> — all dispatch as <code>Task</code>).</td>
 </tr>
 <tr>
 <td><code>register_split(state, tasks, join_config)</code></td>

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -71,6 +71,7 @@
             <ul class="nav-links">
                 <li><a href="{{ get_url(path='@/router-task/_index.md') }}">RouterTask</a></li>
                 <li><a href="{{ get_url(path='@/poll-task/_index.md') }}">PollTask</a></li>
+                <li><a href="{{ get_url(path='@/timer-task/_index.md') }}">TimerTask</a></li>
                 <li><a href="{{ get_url(path='@/batch-task/_index.md') }}">BatchTask</a></li>
                 <li><a href="{{ get_url(path='@/stepped-task/_index.md') }}">SteppedTask</a></li>
             </ul>


### PR DESCRIPTION
This branch adds a new **`TimerTask`** processing model and loosens two `Workflow` registration APIs to accept any iterator.

### `TimerTask` — wait-then-transition

A new task specialization for the common "pause here, then continue" pattern, replacing the manual `PollTask + sleep + check` boilerplate. A `TimerTask` schedules a single `tokio::time::sleep` and wakes exactly once, rather than re-evaluating a condition on every wake-up like a `PollTask`.

- New `task/timer.rs` trait with `wait()` returning a `TimerOutcome` (`Duration` or `Until` an `Instant`) and `after_wait()` for the transition.
- New `#[task::timer]` attribute macro (`cano-macros/src/timer_task_impl.rs`) that emits the companion `impl Task`, so timers register with the ordinary `Workflow::register`.
- Registered as a normal checkpointed single-task state: on resume the engine re-runs `wait()` from scratch (a 30-min timer that crashed at minute 29 sleeps the full 30 min again), and `attempt_timeout` caps the whole wait via `CanoError::Timeout`. Docs call out that `Instant` is monotonic/process-relative and not crash-durable.
- Public exports in `lib.rs` + prelude, plus an example, unit/macro tests, an e2e test, and a docs page.

### `IntoIterator` for `register_split` / `add_exit_states`

`Workflow::register_split` and `add_exit_states` now take `impl IntoIterator<Item = T>` instead of `Vec<T>`, so array literals and lazy `.map(…)` adapters work without an explicit `.collect()`. Behavior is unchanged (tasks collected eagerly, exit-state dedup preserved); covered by four new regression tests.

### Housekeeping

Docs cross-links across the task-model pages, a `base.html` template tweak, and an unrelated fix swapping the Gutenberg network download in `scheduler_mapreduce_books.rs` for an offline corpus.
