### PR TITLE
 Release 0.15.0 — StreamTask simplification, reliability suites, and a hand-built docs diagram system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cano"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "axum",
  "cano-macros",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "cano-e2e"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "cano",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "cano-macros"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cano",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["cano", "cano-macros", "cano-e2e"]
 default-members = ["cano", "cano-macros"]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.89.0"
 license = "MIT OR Apache-2.0"

--- a/cano-macros/src/stream_task_impl.rs
+++ b/cano-macros/src/stream_task_impl.rs
@@ -171,34 +171,31 @@ fn expand_inherent_impl(
         }
     }
 
-    if !has_open {
-        errors.push(syn::Error::new(
-            item_impl.span(),
-            "#[cano::task::stream] requires an `async fn open(&self, res: &Resources<_>, \
-             cursor: Option<_>) -> Result<Pin<Box<dyn Stream<Item = _> + Send>>, CanoError>` method",
-        ));
-    }
-    if process_item_fn.is_none() {
-        errors.push(syn::Error::new(
-            item_impl.span(),
-            "#[cano::task::stream] requires an `async fn process_item(&self, res: &Resources<_>, \
-             item: T) -> Result<(Output, Cursor), CanoError>` method",
-        ));
-    }
-    if !has_flush_window {
-        errors.push(syn::Error::new(
-            item_impl.span(),
-            "#[cano::task::stream] requires an `async fn flush_window(&self, res: &Resources<_>, \
-             outputs: Vec<_>) -> Result<WindowSignal<_>, CanoError>` method",
-        ));
-    }
-    if !has_on_close {
-        errors.push(syn::Error::new(
-            item_impl.span(),
-            "#[cano::task::stream] requires an `async fn on_close(&self, res: &Resources<_>, \
-             reason: CloseReason) -> Result<TaskResult<_>, CanoError>` method",
-        ));
-    }
+    let mut require = |present: bool, message: &str| {
+        if !present {
+            errors.push(syn::Error::new(item_impl.span(), message));
+        }
+    };
+    require(
+        has_open,
+        "#[cano::task::stream] requires an `async fn open(&self, res: &Resources<_>, \
+         cursor: Option<_>) -> Result<Pin<Box<dyn Stream<Item = _> + Send>>, CanoError>` method",
+    );
+    require(
+        process_item_fn.is_some(),
+        "#[cano::task::stream] requires an `async fn process_item(&self, res: &Resources<_>, \
+         item: T) -> Result<(Output, Cursor), CanoError>` method",
+    );
+    require(
+        has_flush_window,
+        "#[cano::task::stream] requires an `async fn flush_window(&self, res: &Resources<_>, \
+         outputs: Vec<_>) -> Result<WindowSignal<_>, CanoError>` method",
+    );
+    require(
+        has_on_close,
+        "#[cano::task::stream] requires an `async fn on_close(&self, res: &Resources<_>, \
+         reason: CloseReason) -> Result<TaskResult<_>, CanoError>` method",
+    );
 
     if !errors.is_empty() {
         return Err(combine_errors(errors));
@@ -217,17 +214,10 @@ fn expand_inherent_impl(
         (None, None)
     } else {
         let (out_ty, cur_ty) = peel_result_tuple_return(process_item, "process_item")?;
-        let out = if has_output_ty {
-            None
-        } else {
-            Some(quote!(type Output = #out_ty;))
-        };
-        let cur = if has_cursor_ty {
-            None
-        } else {
-            Some(quote!(type Cursor = #cur_ty;))
-        };
-        (out, cur)
+        (
+            (!has_output_ty).then(|| quote!(type Output = #out_ty;)),
+            (!has_cursor_ty).then(|| quote!(type Cursor = #cur_ty;)),
+        )
     };
 
     let stream_trait_ref: syn::Path = match &key_ty {
@@ -471,26 +461,26 @@ fn peel_owned_param(f: &ImplItemFn, fn_name: &str) -> syn::Result<Type> {
         )
     })?;
 
-    match third {
-        FnArg::Typed(pt) => {
-            if matches!(&*pt.ty, Type::Reference(_)) {
-                return Err(syn::Error::new_spanned(
-                    &pt.ty,
-                    format!(
-                        "#[cano::task::stream]: `{fn_name}`'s `item` parameter must be an owned \
-                         type (stream items are moved into the task); found a reference"
-                    ),
-                ));
-            }
-            Ok((*pt.ty).clone())
-        }
-        FnArg::Receiver(_) => Err(syn::Error::new_spanned(
+    let FnArg::Typed(pt) = third else {
+        return Err(syn::Error::new_spanned(
             third,
             format!(
                 "#[cano::task::stream]: `{fn_name}` third parameter must be a typed argument, not `self`"
             ),
-        )),
+        ));
+    };
+
+    if matches!(&*pt.ty, Type::Reference(_)) {
+        return Err(syn::Error::new_spanned(
+            &pt.ty,
+            format!(
+                "#[cano::task::stream]: `{fn_name}`'s `item` parameter must be an owned \
+                 type (stream items are moved into the task); found a reference"
+            ),
+        ));
     }
+
+    Ok((*pt.ty).clone())
 }
 
 /// Extract `(Output, Cursor)` from the `Ok` 2-tuple of `process_item`'s
@@ -510,19 +500,17 @@ fn peel_result_tuple_return(f: &ImplItemFn, fn_name: &str) -> syn::Result<(Type,
         }
     };
 
+    let bad_return = || tuple_return_error(fn_name, ret_ty);
+
     let Type::Path(tp) = ret_ty else {
-        return Err(tuple_return_error(fn_name, ret_ty));
+        return Err(bad_return());
     };
-    let last = tp
-        .path
-        .segments
-        .last()
-        .ok_or_else(|| tuple_return_error(fn_name, ret_ty))?;
+    let last = tp.path.segments.last().ok_or_else(bad_return)?;
     if last.ident != "Result" && last.ident != "CanoResult" {
-        return Err(tuple_return_error(fn_name, ret_ty));
+        return Err(bad_return());
     }
     let PathArguments::AngleBracketed(args) = &last.arguments else {
-        return Err(tuple_return_error(fn_name, ret_ty));
+        return Err(bad_return());
     };
     let ok_ty = args
         .args
@@ -531,13 +519,13 @@ fn peel_result_tuple_return(f: &ImplItemFn, fn_name: &str) -> syn::Result<(Type,
             GenericArgument::Type(t) => Some(t),
             _ => None,
         })
-        .ok_or_else(|| tuple_return_error(fn_name, ret_ty))?;
+        .ok_or_else(bad_return)?;
 
     let Type::Tuple(tuple) = ok_ty else {
-        return Err(tuple_return_error(fn_name, ret_ty));
+        return Err(bad_return());
     };
     if tuple.elems.len() != 2 {
-        return Err(tuple_return_error(fn_name, ret_ty));
+        return Err(bad_return());
     }
     let mut it = tuple.elems.iter();
     let output_ty = it.next().unwrap().clone();

--- a/cano/Cargo.toml
+++ b/cano/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["framework", "async", "workflow", "data-processing", "ai"]
 categories = ["development-tools", "concurrency", "asynchronous"]
 
 [dependencies]
-cano-macros = { version = "0.14", path = "../cano-macros" }
+cano-macros = { version = "0.15", path = "../cano-macros" }
 tokio = { version = "1.52.1", features = ["macros", "sync", "time", "rt-multi-thread"] }
 rand = "0.10"
 chrono = { version = "0.4", features = ["serde"], optional = true }

--- a/cano/Cargo.toml
+++ b/cano/Cargo.toml
@@ -38,6 +38,8 @@ all = ["scheduler", "tracing", "recovery", "metrics", "testing"]
 [dev-dependencies]
 axum = "0.8.9"
 criterion = { version = "0.8", features = ["html_reports", "async_tokio"] }
+futures-util = "0.3"
+parking_lot = "0.12"
 redb = "4.1"
 reqwest = { version = "0.13", features = ["json"] }
 rig-core = "0.36.0"

--- a/cano/examples/scheduler_graceful_shutdown.rs
+++ b/cano/examples/scheduler_graceful_shutdown.rs
@@ -163,7 +163,10 @@ async fn main() -> CanoResult<()> {
             .expect("Failed to send SIGINT");
 
         #[cfg(not(unix))]
-        println!("Automatic SIGINT not supported on this platform, please press Ctrl+C manually");
+        println!(
+            "Automatic SIGINT not supported on this platform, please press Ctrl+C manually \
+             (or terminate pid {pid})"
+        );
     });
 
     // Block on the scheduler until shutdown completes.

--- a/cano/examples/split_bulkhead.rs
+++ b/cano/examples/split_bulkhead.rs
@@ -127,14 +127,16 @@ impl Summarize {
         // concurrently at any single instant. We use a sweep-line over all
         // start/finish events — at each start time we count how many
         // intervals contain that point (start <= t < finish).
-        let mut max_concurrent = 0usize;
-        for &(_, s, _) in &entries {
-            let concurrent = entries
-                .iter()
-                .filter(|&&(_, s2, f2)| s2 <= s && s < f2)
-                .count();
-            max_concurrent = max_concurrent.max(concurrent);
-        }
+        let max_concurrent = entries
+            .iter()
+            .map(|&(_, s, _)| {
+                entries
+                    .iter()
+                    .filter(|&&(_, s2, f2)| s2 <= s && s < f2)
+                    .count()
+            })
+            .max()
+            .unwrap_or(0);
         println!("\n  max concurrent tasks observed: {max_concurrent}");
         assert!(
             max_concurrent <= 2,

--- a/cano/examples/stream_task.rs
+++ b/cano/examples/stream_task.rs
@@ -31,7 +31,7 @@ use cano::prelude::*;
 use futures_util::{Stream, stream};
 use std::collections::VecDeque;
 use std::pin::Pin;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 /// Flip to `Alert` when a calm window contains a reading at or above this.
 const HIGH: i32 = 80;
@@ -62,7 +62,7 @@ impl Resource for Source {}
 
 /// Build a lazy stream that pops one reading at a time from the shared `Source`.
 /// Dropping this stream (when the FSM flips modes) leaves the rest in the queue.
-fn open_source(source: std::sync::Arc<Source>) -> Pin<Box<dyn Stream<Item = Reading> + Send>> {
+fn open_source(source: Arc<Source>) -> Pin<Box<dyn Stream<Item = Reading> + Send>> {
     Box::pin(stream::unfold(source, |source| async move {
         let next = source.queue.lock().unwrap().pop_front();
         next.map(|reading| (reading, source))
@@ -175,9 +175,9 @@ async fn main() -> CanoResult<()> {
     // A synthetic temperature stream that heats up and cools off twice.
     let temps = [70, 71, 73, 85, 88, 76, 71, 90, 68, 73, 74, 95, 88, 60];
     let readings: VecDeque<Reading> = temps
-        .iter()
+        .into_iter()
         .enumerate()
-        .map(|(i, &temp)| Reading {
+        .map(|(i, temp)| Reading {
             seq: i as u64,
             temp,
         })

--- a/cano/src/recovery/redb.rs
+++ b/cano/src/recovery/redb.rs
@@ -27,12 +27,6 @@ use cano_macros::checkpoint_store;
 /// `(workflow_id, sequence) -> postcard(StoredRow)`.
 const CHECKPOINTS: TableDefinition<(&str, u64), &[u8]> = TableDefinition::new("cano_checkpoints");
 
-/// Upper bound of the sequence key range — the largest valid `sequence` value.
-const SEQUENCE_MAX: u64 = u64::MAX;
-
-/// Lower bound of the sequence key range — the smallest valid `sequence` value.
-const SEQUENCE_MIN: u64 = u64::MIN;
-
 /// The payload half of a [`CheckpointRow`]: everything except `sequence`, which
 /// is carried by the redb key. Kept private — callers only ever see `CheckpointRow`.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -56,7 +50,7 @@ struct StoredRowV0 {
 
 /// The key range covering every row for `workflow_id`, in ascending `sequence` order.
 fn workflow_range(workflow_id: &str) -> RangeInclusive<(&str, u64)> {
-    (workflow_id, SEQUENCE_MIN)..=(workflow_id, SEQUENCE_MAX)
+    (workflow_id, u64::MIN)..=(workflow_id, u64::MAX)
 }
 
 /// Wrap any `redb` error (they all implement [`Display`](std::fmt::Display)) as a

--- a/cano/src/scheduler.rs
+++ b/cano/src/scheduler.rs
@@ -23,7 +23,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! cano = { version = "0.14", features = ["scheduler"] }
+//! cano = { version = "0.15", features = ["scheduler"] }
 //! ```
 
 mod backoff;

--- a/cano/src/scheduler/running.rs
+++ b/cano/src/scheduler/running.rs
@@ -829,6 +829,30 @@ mod tests {
             .add_exit_state(TestState::Error)
     }
 
+    /// Poll `running.status(id)` until `pred(&snapshot)` holds or `budget` elapses,
+    /// returning the last observed snapshot either way.
+    ///
+    /// Fixed `sleep`-then-assert races the scheduler's dispatch loop: a duration that's
+    /// "surely long enough" on an idle machine can be too short once hundreds of other
+    /// tests share the runtime's thread pool. Polling waits for the real condition and
+    /// still fails loudly — the caller's outer `tokio::time::timeout` bounds the total
+    /// test runtime regardless of what `budget` is passed here.
+    async fn wait_for_status(
+        running: &RunningScheduler<TestState>,
+        id: &str,
+        budget: Duration,
+        mut pred: impl FnMut(&FlowInfo) -> bool,
+    ) -> FlowInfo {
+        let deadline = tokio::time::Instant::now() + budget;
+        loop {
+            let snap = running.status(id).await.unwrap();
+            if pred(&snap) || tokio::time::Instant::now() >= deadline {
+                return snap;
+            }
+            sleep(Duration::from_millis(5)).await;
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_backoff_progression_extends_interval() {
         // Base interval (50ms) is small; backoff should grow above it. With
@@ -936,7 +960,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_reset_flow_clears_trip_and_resumes() {
-        let timeout = Duration::from_secs(5);
+        let timeout = Duration::from_secs(10);
         let result = tokio::time::timeout(timeout, async {
             let mut scheduler: Scheduler<TestState> = Scheduler::<TestState>::new();
             // Succeeds on attempt 5, after 4 failures. With streak_limit=2 it
@@ -969,8 +993,10 @@ mod tests {
             let running = scheduler.start().await.unwrap();
 
             // Wait for trip.
-            sleep(Duration::from_millis(300)).await;
-            let snap = running.status("reset_me").await.unwrap();
+            let snap = wait_for_status(&running, "reset_me", Duration::from_secs(3), |s| {
+                matches!(s.status, Status::Tripped { .. })
+            })
+            .await;
             assert!(
                 matches!(snap.status, Status::Tripped { .. }),
                 "expected trip, got: {:?}",
@@ -986,12 +1012,17 @@ mod tests {
             assert!(snap_after_reset.next_eligible.is_none());
 
             // Loop trips again (failures 3,4 → trip). Reset once more.
-            sleep(Duration::from_millis(200)).await;
+            wait_for_status(&running, "reset_me", Duration::from_secs(3), |s| {
+                matches!(s.status, Status::Tripped { .. })
+            })
+            .await;
             running.reset_flow("reset_me").await.unwrap();
 
             // Attempt 5 succeeds → status Completed, streak 0.
-            sleep(Duration::from_millis(200)).await;
-            let snap_done = running.status("reset_me").await.unwrap();
+            let snap_done = wait_for_status(&running, "reset_me", Duration::from_secs(3), |s| {
+                s.status == Status::Completed
+            })
+            .await;
             assert_eq!(snap_done.status, Status::Completed);
             assert_eq!(snap_done.failure_streak, 0);
             assert!(snap_done.next_eligible.is_none());
@@ -1034,8 +1065,10 @@ mod tests {
 
             let running = scheduler.start().await.unwrap();
 
-            sleep(Duration::from_millis(400)).await;
-            let snap = running.status("recover").await.unwrap();
+            let snap = wait_for_status(&running, "recover", Duration::from_secs(4), |s| {
+                s.status == Status::Completed
+            })
+            .await;
             assert_eq!(
                 snap.failure_streak, 0,
                 "streak must reset on success, got {snap:?}"

--- a/cano/src/task.rs
+++ b/cano/src/task.rs
@@ -149,7 +149,7 @@ pub enum TaskResult<TState> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust
 /// use cano::prelude::*;
 ///
 /// struct DataProcessor {

--- a/cano/src/task/retry.rs
+++ b/cano/src/task/retry.rs
@@ -991,13 +991,29 @@ mod tests {
         }
     }
 
+    /// Same thresholds as [`cb_policy`], but with a `reset_timeout` long enough that a
+    /// tripped breaker cannot lapse back into `HalfOpen` while the test is running.
+    ///
+    /// Tests that assert *short-circuit* behaviour need the `Open` window to outlive the
+    /// whole test body. With the 20ms default a loaded machine can drift past the
+    /// deadline between two attempts (the fixed retry sleep is only 1ms), which lazily
+    /// promotes the breaker to `HalfOpen`, admits a probe call, and inflates the
+    /// invocation count. `test_circuit_half_open_recovery_via_run_with_retries` is the
+    /// only test that actually exercises the reset deadline, so it keeps `cb_policy`.
+    fn cb_policy_stable_open(threshold: u32) -> CircuitPolicy {
+        CircuitPolicy {
+            reset_timeout: Duration::from_secs(60),
+            ..cb_policy(threshold)
+        }
+    }
+
     #[tokio::test]
     async fn test_circuit_open_short_circuits_without_invoking_task() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         // Threshold = 3, no retries, so the first three failing calls trip the breaker
         // and the fourth call must return CircuitOpen *without* invoking the task body.
-        let breaker = Arc::new(CircuitBreaker::new(cb_policy(3)));
+        let breaker = Arc::new(CircuitBreaker::new(cb_policy_stable_open(3)));
         let config = TaskConfig::minimal().with_circuit_breaker(Arc::clone(&breaker));
         let counter = Arc::new(AtomicUsize::new(0));
 
@@ -1044,7 +1060,7 @@ mod tests {
         // Even with retries enabled, a CircuitOpen must short-circuit immediately —
         // retries against an open breaker would only add load to the failing
         // dependency. The error should surface raw, not wrapped in RetryExhausted.
-        let breaker = Arc::new(CircuitBreaker::new(cb_policy(1)));
+        let breaker = Arc::new(CircuitBreaker::new(cb_policy_stable_open(1)));
         let config = TaskConfig::new()
             .with_fixed_retry(5, Duration::from_millis(1))
             .with_circuit_breaker(Arc::clone(&breaker));
@@ -1114,7 +1130,7 @@ mod tests {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         // Two tasks share one Arc<CircuitBreaker>; failures from task A trip it for B.
-        let breaker = Arc::new(CircuitBreaker::new(cb_policy(3)));
+        let breaker = Arc::new(CircuitBreaker::new(cb_policy_stable_open(3)));
         let config_a = TaskConfig::minimal().with_circuit_breaker(Arc::clone(&breaker));
         let config_b = TaskConfig::minimal().with_circuit_breaker(Arc::clone(&breaker));
 
@@ -1155,7 +1171,7 @@ mod tests {
         // raw CircuitOpen, not RetryExhausted.
         use std::sync::atomic::{AtomicUsize, Ordering};
 
-        let breaker = Arc::new(CircuitBreaker::new(cb_policy(2)));
+        let breaker = Arc::new(CircuitBreaker::new(cb_policy_stable_open(2)));
         let config = TaskConfig::new()
             .with_fixed_retry(5, Duration::from_millis(1))
             .with_circuit_breaker(Arc::clone(&breaker));
@@ -1207,7 +1223,7 @@ mod tests {
         // CircuitOpen without ever invoking the task body.
         use std::sync::atomic::{AtomicUsize, Ordering};
 
-        let breaker = Arc::new(CircuitBreaker::new(cb_policy(2)));
+        let breaker = Arc::new(CircuitBreaker::new(cb_policy_stable_open(2)));
         let config = TaskConfig::minimal()
             .with_attempt_timeout(Duration::from_millis(10))
             .with_circuit_breaker(Arc::clone(&breaker));

--- a/cano/src/task/stream.rs
+++ b/cano/src/task/stream.rs
@@ -332,16 +332,13 @@ where
 {
     use futures_util::StreamExt as _;
 
-    let count_limit = match window {
-        StreamWindow::Count(n) => Some((*n).max(1)),
-        StreamWindow::Duration(_) => None,
+    // One match: exactly one of these is `Some`. The duration is clamped once so the
+    // initial deadline and every re-arm agree.
+    let (count_limit, duration_len) = match window {
+        StreamWindow::Count(n) => (Some((*n).max(1)), None),
+        StreamWindow::Duration(d) => (None, Some((*d).max(MIN_DURATION_WINDOW))),
     };
-    let mut deadline: Option<tokio::time::Instant> = match window {
-        StreamWindow::Duration(d) => {
-            Some(tokio::time::Instant::now() + (*d).max(MIN_DURATION_WINDOW))
-        }
-        StreamWindow::Count(_) => None,
-    };
+    let mut deadline = duration_len.map(|len| tokio::time::Instant::now() + len);
 
     let mut buf: Vec<T::Output> = Vec::new();
     let mut last_cursor: Option<T::Cursor> = None;
@@ -351,18 +348,7 @@ where
         if let Some(limit) = count_limit
             && buf.len() >= limit
         {
-            #[cfg(feature = "metrics")]
-            crate::metrics::stream_window();
-            let outputs = std::mem::take(&mut buf);
-            return Ok(match task.flush_window(res, outputs).await? {
-                WindowSignal::Continue => WindowStep::Window {
-                    cursor: last_cursor.expect("a non-empty window always has a cursor"),
-                },
-                WindowSignal::Stop(result) => WindowStep::Done {
-                    final_cursor: last_cursor,
-                    result,
-                },
-            });
+            return flush_full_window(task, res, std::mem::take(&mut buf), last_cursor).await;
         }
 
         // Resolves at the duration-window deadline, or never (count windows).
@@ -404,24 +390,11 @@ where
             _ = tick => {
                 // Duration window elapsed.
                 if buf.is_empty() {
-                    // Empty tumbling window: advance the deadline and keep waiting.
-                    if let (Some(d), StreamWindow::Duration(dur)) = (deadline.as_mut(), window) {
-                        *d = tokio::time::Instant::now() + (*dur).max(MIN_DURATION_WINDOW);
-                    }
+                    // Empty tumbling window: re-arm the deadline and keep waiting.
+                    deadline = duration_len.map(|len| tokio::time::Instant::now() + len);
                     continue;
                 }
-                #[cfg(feature = "metrics")]
-                crate::metrics::stream_window();
-                let outputs = std::mem::take(&mut buf);
-                return Ok(match task.flush_window(res, outputs).await? {
-                    WindowSignal::Continue => WindowStep::Window {
-                        cursor: last_cursor.expect("a non-empty window always has a cursor"),
-                    },
-                    WindowSignal::Stop(result) => WindowStep::Done {
-                        final_cursor: last_cursor,
-                        result,
-                    },
-                });
+                return flush_full_window(task, res, std::mem::take(&mut buf), last_cursor).await;
             }
             item = stream.next() => {
                 match item {
@@ -488,6 +461,38 @@ where
             }
         }
     }
+}
+
+/// Flush one non-empty window and map the task's [`WindowSignal`] onto the terminal
+/// [`WindowStep`]. Shared by the count-window and duration-window flush arms of
+/// [`drive_window`]: both commit the window's cursor either way — `Continue` carries it
+/// forward, `Stop` commits it before the FSM transitions.
+///
+/// Deliberately *not* used by the cancel drain (which ignores `Stop`, because a cancelled
+/// run always surfaces `CanoError::Cancelled`) nor by the exhausted path (where `Continue`
+/// falls through to `on_close(Exhausted)`); those arms have different signal semantics.
+async fn flush_full_window<T, S, K>(
+    task: &T,
+    res: &Resources<K>,
+    outputs: Vec<T::Output>,
+    last_cursor: Option<T::Cursor>,
+) -> Result<WindowStep<T::Cursor, S>, CanoError>
+where
+    T: StreamTask<S, K> + ?Sized,
+    S: Clone + fmt::Debug + Send + Sync + 'static,
+    K: Hash + Eq + Send + Sync + 'static,
+{
+    #[cfg(feature = "metrics")]
+    crate::metrics::stream_window();
+    Ok(match task.flush_window(res, outputs).await? {
+        WindowSignal::Continue => WindowStep::Window {
+            cursor: last_cursor.expect("a non-empty window always has a cursor"),
+        },
+        WindowSignal::Stop(result) => WindowStep::Done {
+            final_cursor: last_cursor,
+            result,
+        },
+    })
 }
 
 /// In-memory companion loop: drive windows with a disabled token (no cancellation), no
@@ -632,9 +637,8 @@ where
         token: &'a CancellationToken,
     ) -> WindowFuture<'a, S> {
         Box::pin(async move {
-            let task = Arc::clone(&self.task);
             let step = drive_window(
-                &*task,
+                &*self.task,
                 res,
                 &mut self.stream,
                 &mut self.consecutive_errors,
@@ -652,17 +656,15 @@ where
                     final_cursor,
                     result,
                 } => ErasedWindowStep::Done {
-                    final_cursor: match final_cursor {
-                        Some(c) => Some(encode_cursor(&c, &self.task.name())?),
-                        None => None,
-                    },
+                    final_cursor: final_cursor
+                        .map(|c| encode_cursor(&c, &self.task.name()))
+                        .transpose()?,
                     result,
                 },
                 WindowStep::Cancelled { final_cursor } => ErasedWindowStep::Cancelled {
-                    final_cursor: match final_cursor {
-                        Some(c) => Some(encode_cursor(&c, &self.task.name())?),
-                        None => None,
-                    },
+                    final_cursor: final_cursor
+                        .map(|c| encode_cursor(&c, &self.task.name()))
+                        .transpose()?,
                 },
             })
         })

--- a/cano/src/workflow/execution.rs
+++ b/cano/src/workflow/execution.rs
@@ -405,7 +405,6 @@ where
                 let task_id = self
                     .states
                     .get(&current_state)
-                    .map(|e| e.as_ref())
                     .map_or(String::new(), |entry| entry.task_id());
                 let append_result = store
                     .append(
@@ -1098,6 +1097,8 @@ where
             tokio::time::Instant,
         )>,
     ) -> Result<TState, CanoError> {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
         // Aborts the spawned deadline-forwarder task when dropped, so a run that ends
         // normally (or via a real cancel, well before any deadline) doesn't leave that task
         // sleeping until the total-timeout deadline for no reason.
@@ -1121,23 +1122,22 @@ where
         // `dispatch_with_budget` to avoid. `token.clone()` is cheap (a disabled token clones
         // `None`; a live one bumps a `watch::Receiver`'s refcount), so the `step_budget: None`
         // path (no timeout configured — the common case) spawns no extra task.
-        let (effective_token, _forwarder_guard): (CancellationToken, Option<AbortOnDrop>) =
-            match step_budget {
-                None => (token.clone(), None),
-                Some((_, _, deadline)) => {
-                    let (handle, forwarded) = CancellationToken::new();
-                    let watched = token.clone();
-                    let join = tokio::spawn(async move {
-                        tokio::select! {
-                            biased;
-                            _ = watched.cancelled() => {}
-                            _ = tokio::time::sleep_until(deadline) => {}
-                        }
-                        handle.cancel();
-                    });
-                    (forwarded, Some(AbortOnDrop(join)))
-                }
-            };
+        let (effective_token, _forwarder_guard) = match step_budget {
+            None => (token.clone(), None),
+            Some((_, _, deadline)) => {
+                let (handle, forwarded) = CancellationToken::new();
+                let watched = token.clone();
+                let join = tokio::spawn(async move {
+                    tokio::select! {
+                        biased;
+                        _ = watched.cancelled() => {}
+                        _ = tokio::time::sleep_until(deadline) => {}
+                    }
+                    handle.cancel();
+                });
+                (forwarded, Some(AbortOnDrop(join)))
+            }
+        };
 
         // Set when the engine's own cooperative-drain path ends the run (the
         // `ErasedWindowStep::Cancelled` arm below, or the cancel-during-`open_session` race
@@ -1145,12 +1145,12 @@ where
         // `process_item`/`flush_window`/`on_close`, which must NOT flip metrics/observers
         // onto the cancelled path. `AtomicBool` (not `Cell`) so the spawned workflow future
         // stays `Send`.
-        let was_cancelled = std::sync::atomic::AtomicBool::new(false);
+        let was_cancelled = AtomicBool::new(false);
         let outcome: Result<TState, CanoError> = async {
             let mut session = tokio::select! {
                 biased;
                 _ = effective_token.cancelled() => {
-                    was_cancelled.store(true, std::sync::atomic::Ordering::Relaxed);
+                    was_cancelled.store(true, Ordering::Relaxed);
                     return Err(CanoError::cancelled());
                 }
                 res = task.open_session(&self.resources, resume_cursor, config.attempt_timeout) => res?,
@@ -1168,26 +1168,25 @@ where
                 // `terminal == Some(_)` ends the loop with that result after the cursor is
                 // persisted. A cancelled stream commits its final cursor, then surfaces
                 // `Cancelled` (so the log is NOT cleared and `resume_from` continues).
-                let (cursor_to_commit, terminal): (Option<Vec<u8>>, Option<Result<TState, CanoError>>) =
-                    match step {
-                        ErasedWindowStep::Window { cursor } => (Some(cursor), None),
-                        ErasedWindowStep::Done {
-                            final_cursor,
-                            result,
-                        } => {
-                            let next = match result {
-                                TaskResult::Single(next_state) => Ok(next_state),
-                                TaskResult::Split(_) => Err(CanoError::workflow(
-                                    "Stream task returned split result — split is not supported for Stream states",
-                                )),
-                            };
-                            (final_cursor, Some(next))
-                        }
-                        ErasedWindowStep::Cancelled { final_cursor } => {
-                            was_cancelled.store(true, std::sync::atomic::Ordering::Relaxed);
-                            (final_cursor, Some(Err(CanoError::cancelled())))
-                        }
-                    };
+                let (cursor_to_commit, terminal) = match step {
+                    ErasedWindowStep::Window { cursor } => (Some(cursor), None),
+                    ErasedWindowStep::Done {
+                        final_cursor,
+                        result,
+                    } => {
+                        let next = match result {
+                            TaskResult::Single(next_state) => Ok(next_state),
+                            TaskResult::Split(_) => Err(CanoError::workflow(
+                                "Stream task returned split result — split is not supported for Stream states",
+                            )),
+                        };
+                        (final_cursor, Some(next))
+                    }
+                    ErasedWindowStep::Cancelled { final_cursor } => {
+                        was_cancelled.store(true, Ordering::Relaxed);
+                        (final_cursor, Some(Err(CanoError::cancelled())))
+                    }
+                };
 
                 // Persist the window cursor before advancing so a crash/cancel resumes
                 // from this exact position. Gated on a store + workflow id both present.
@@ -1220,17 +1219,14 @@ where
         // The engine's drain path fired (`was_cancelled`) AND the outcome it produced is
         // still `Cancelled` (not overwritten by e.g. a later checkpoint-append failure,
         // which must report as a failure, not a cancel).
-        let drained_as_cancelled = was_cancelled.load(std::sync::atomic::Ordering::Relaxed)
-            && matches!(outcome, Err(CanoError::Cancelled));
+        let drained_as_cancelled =
+            was_cancelled.load(Ordering::Relaxed) && matches!(outcome, Err(CanoError::Cancelled));
 
         // The drain fired but the caller's ORIGINAL token was never cancelled — so the
         // *deadline* must be what fired the forwarded `effective_token`. Reclassify,
         // mirroring `dispatch_with_budget`'s `WorkflowTimeout` handling for every other
         // state kind.
-        let (outcome, timed_out): (
-            Result<TState, CanoError>,
-            Option<(std::time::Duration, std::time::Duration)>,
-        ) = if drained_as_cancelled
+        let (outcome, timed_out) = if drained_as_cancelled
             && let Some((start, limit, _)) = step_budget
             && !token.is_cancelled()
         {

--- a/cano/tests/batch_reliability.rs
+++ b/cano/tests/batch_reliability.rs
@@ -1,0 +1,266 @@
+//! Reliability contracts of [`BatchTask`] under critical scenarios.
+//!
+//! Black-box integration tests (public API only) documenting how the batch
+//! processing model behaves when items or the aggregation step fail:
+//!
+//! | Critical scenario | Contract |
+//! |-------------------|----------|
+//! | poisoned + flaky items, bounded concurrency | slot isolation, per-item retry budget, input-order slots, bulkhead bound |
+//! | `finish` fails → outer retry | the **whole** load→process→finish cycle replays (at-least-once per item) |
+
+mod support;
+
+use cano::prelude::*;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+use std::time::Duration;
+use support::Flow;
+
+// ===========================================================================
+// Slot isolation, per-item retries, order, bulkhead
+// ===========================================================================
+
+/// 12 uploads, concurrency 3. Item 7 is permanently poisoned; item 4 succeeds on
+/// its 3rd attempt. Records per-item attempts and the in-flight high-water mark.
+struct Uploads {
+    attempts: Arc<Mutex<HashMap<u32, u32>>>,
+    in_flight: Arc<AtomicUsize>,
+    high_water: Arc<AtomicUsize>,
+    slots: Arc<Mutex<Vec<Option<u32>>>>, // finish snapshot: None = Err slot
+}
+
+#[task::batch]
+impl BatchTask<Flow> for Uploads {
+    type Item = u32;
+    type ItemOutput = u32;
+
+    fn concurrency(&self) -> usize {
+        3
+    }
+
+    fn item_retry(&self) -> RetryMode {
+        RetryMode::fixed(2, Duration::from_millis(1)) // 3 attempts per item
+    }
+
+    fn config(&self) -> TaskConfig {
+        TaskConfig::minimal() // no outer retry: isolate per-item semantics
+    }
+
+    async fn load(&self, _res: &Resources) -> Result<Vec<u32>, CanoError> {
+        Ok((0..12).collect())
+    }
+
+    async fn process_item(&self, item: &u32) -> Result<u32, CanoError> {
+        let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.high_water.fetch_max(now, Ordering::SeqCst);
+        let attempt = {
+            let mut map = self.attempts.lock();
+            let n = map.entry(*item).or_insert(0);
+            *n += 1;
+            *n
+        };
+        // Varied durations shuffle completion order — the order test below is real.
+        tokio::time::sleep(Duration::from_millis(u64::from(*item % 3) * 4 + 1)).await;
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+
+        if *item == 7 {
+            return Err(CanoError::task_execution("upload 7: bucket gone"));
+        }
+        if *item == 4 && attempt < 3 {
+            return Err(CanoError::task_execution("upload 4: flaky link"));
+        }
+        Ok(*item * 10)
+    }
+
+    async fn finish(
+        &self,
+        _res: &Resources,
+        outputs: Vec<Result<u32, CanoError>>,
+    ) -> Result<TaskResult<Flow>, CanoError> {
+        *self.slots.lock() = outputs.into_iter().map(|r| r.ok()).collect();
+        // Partial-failure policy lives HERE: one bad upload is acceptable.
+        Ok(TaskResult::Single(Flow::Done))
+    }
+}
+
+/// Contract: a failing item fills its own `finish` slot with `Err` after its retry
+/// budget — it neither aborts siblings nor the batch. Slots arrive in *input*
+/// order regardless of completion order, and at most `concurrency` items are ever
+/// in flight (the data-level bulkhead).
+#[tokio::test]
+async fn batch_isolates_poison_items_retries_per_item_and_bounds_concurrency() {
+    let attempts = Arc::new(Mutex::new(HashMap::new()));
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let high_water = Arc::new(AtomicUsize::new(0));
+    let slots = Arc::new(Mutex::new(Vec::new()));
+
+    let workflow = Workflow::bare()
+        .register(
+            Flow::Work,
+            Uploads {
+                attempts: attempts.clone(),
+                in_flight: in_flight.clone(),
+                high_water: high_water.clone(),
+                slots: slots.clone(),
+            },
+        )
+        .add_exit_state(Flow::Done);
+
+    let result = workflow
+        .orchestrate(Flow::Work, CancellationToken::disabled())
+        .await
+        .unwrap();
+    assert_eq!(
+        result,
+        Flow::Done,
+        "one poisoned item must not fail the batch"
+    );
+
+    // Input-order slots: slot i belongs to item i even though completion order was
+    // shuffled by the varied per-item durations.
+    let slots = slots.lock().clone();
+    assert_eq!(slots.len(), 12);
+    for (i, slot) in slots.iter().enumerate() {
+        if i == 7 {
+            assert_eq!(*slot, None, "poisoned item lands as an Err slot");
+        } else {
+            assert_eq!(*slot, Some(i as u32 * 10), "slot {i} out of order");
+        }
+    }
+
+    // Per-item retry accounting: the poisoned item exhausts its 3 attempts; the
+    // flaky one recovers on attempt 3; healthy items run once.
+    let attempts = attempts.lock().clone();
+    assert_eq!(attempts[&7], 3, "poisoned item exhausts its retry budget");
+    assert_eq!(attempts[&4], 3, "flaky item recovered on the 3rd attempt");
+    for i in (0..12u32).filter(|i| *i != 4 && *i != 7) {
+        assert_eq!(attempts[&i], 1, "healthy item {i} must not be retried");
+    }
+
+    // Bulkhead: never more than `concurrency` in flight — and genuinely parallel.
+    let high = high_water.load(Ordering::SeqCst);
+    assert!(high <= 3, "concurrency bound violated: {high} in flight");
+    assert!(high >= 2, "expected real overlap, saw high-water {high}");
+}
+
+// ===========================================================================
+// Outer retry replays the entire load → process → finish cycle
+// ===========================================================================
+
+/// Loads 4 records; `finish` fails a scripted number of times (a downstream
+/// commit outage), counting every `load`/`process_item`/`finish` invocation.
+struct CommitBatch {
+    finish_failures_remaining: Arc<AtomicU32>,
+    load_calls: Arc<AtomicU32>,
+    item_calls: Arc<Mutex<HashMap<u32, u32>>>,
+    finish_calls: Arc<AtomicU32>,
+}
+
+#[task::batch]
+impl BatchTask<Flow> for CommitBatch {
+    type Item = u32;
+    type ItemOutput = u32;
+
+    fn config(&self) -> TaskConfig {
+        // Outer retry of the WHOLE cycle: 1 retry → 2 attempts.
+        TaskConfig::minimal().with_fixed_retry(1, Duration::from_millis(1))
+    }
+
+    async fn load(&self, _res: &Resources) -> Result<Vec<u32>, CanoError> {
+        self.load_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(vec![1, 2, 3, 4])
+    }
+
+    async fn process_item(&self, item: &u32) -> Result<u32, CanoError> {
+        *self.item_calls.lock().entry(*item).or_insert(0) += 1;
+        Ok(*item)
+    }
+
+    async fn finish(
+        &self,
+        _res: &Resources,
+        outputs: Vec<Result<u32, CanoError>>,
+    ) -> Result<TaskResult<Flow>, CanoError> {
+        self.finish_calls.fetch_add(1, Ordering::SeqCst);
+        assert_eq!(outputs.len(), 4);
+        if self.finish_failures_remaining.load(Ordering::SeqCst) > 0 {
+            self.finish_failures_remaining
+                .fetch_sub(1, Ordering::SeqCst);
+            return Err(CanoError::task_execution("commit endpoint 503"));
+        }
+        Ok(TaskResult::Single(Flow::Done))
+    }
+}
+
+/// A `CommitBatch` plus the shared counters the test inspects after the run.
+struct CommitProbe {
+    task: CommitBatch,
+    load_calls: Arc<AtomicU32>,
+    item_calls: Arc<Mutex<HashMap<u32, u32>>>,
+    finish_calls: Arc<AtomicU32>,
+}
+
+fn commit_batch(finish_failures: u32) -> CommitProbe {
+    let load_calls = Arc::new(AtomicU32::new(0));
+    let item_calls = Arc::new(Mutex::new(HashMap::new()));
+    let finish_calls = Arc::new(AtomicU32::new(0));
+    let task = CommitBatch {
+        finish_failures_remaining: Arc::new(AtomicU32::new(finish_failures)),
+        load_calls: load_calls.clone(),
+        item_calls: item_calls.clone(),
+        finish_calls: finish_calls.clone(),
+    };
+    CommitProbe {
+        task,
+        load_calls,
+        item_calls,
+        finish_calls,
+    }
+}
+
+/// Contract: only `load` or `finish` failures trip the batch's *outer* retry, and
+/// that retry replays the ENTIRE load → process → finish cycle. There is no
+/// partial memoization: every item is reprocessed, so item side effects must be
+/// idempotent. When the budget runs out the workflow reports `RetryExhausted`
+/// with the true attempt count.
+#[tokio::test]
+async fn batch_outer_retry_replays_the_entire_cycle() {
+    // finish fails once, second attempt lands.
+    let probe = commit_batch(1);
+    let workflow = Workflow::bare()
+        .register(Flow::Work, probe.task)
+        .add_exit_state(Flow::Done);
+    let result = workflow
+        .orchestrate(Flow::Work, CancellationToken::disabled())
+        .await
+        .unwrap();
+    assert_eq!(result, Flow::Done);
+    assert_eq!(probe.load_calls.load(Ordering::SeqCst), 2, "load re-ran");
+    assert_eq!(probe.finish_calls.load(Ordering::SeqCst), 2);
+    for (item, calls) in probe.item_calls.lock().iter() {
+        assert_eq!(
+            *calls, 2,
+            "item {item} must be reprocessed by the outer retry"
+        );
+    }
+
+    // finish fails on both attempts: the retry budget (2 attempts) is exhausted.
+    let probe = commit_batch(2);
+    let workflow = Workflow::bare()
+        .register(Flow::Work, probe.task)
+        .add_exit_state(Flow::Done);
+    let err = workflow
+        .orchestrate(Flow::Work, CancellationToken::disabled())
+        .await
+        .unwrap_err();
+    // The engine adds state/path context around the failure; `category()` sees
+    // through that wrapper to the RetryExhausted underneath.
+    assert_eq!(err.category(), "retry_exhausted", "got: {err}");
+    assert!(
+        err.to_string().contains("after 2 attempt(s)"),
+        "expected the true attempt count in the report, got: {err}"
+    );
+    assert_eq!(probe.load_calls.load(Ordering::SeqCst), 2, "no third cycle");
+}

--- a/cano/tests/pipeline_reliability.rs
+++ b/cano/tests/pipeline_reliability.rs
@@ -1,0 +1,212 @@
+//! Reliability contract of a multi-model pipeline under a mid-run crash.
+//!
+//! Black-box integration test (public API only) composing three processing models
+//! — [`PollTask`] → [`BatchTask`] → [`StreamTask`] — in one checkpointed workflow:
+//!
+//! | Critical scenario | Contract |
+//! |-------------------|----------|
+//! | crash in a late state → `resume_from` | only the crashed state re-enters; completed states are never re-executed |
+
+mod support;
+
+use cano::prelude::*;
+use futures_util::Stream;
+use parking_lot::Mutex;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use support::{MemStore, boxed};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Pipe {
+    Wait,
+    Crunch,
+    Pump,
+    Done,
+}
+
+/// Poll stage: ready on the 3rd check.
+struct Waiter {
+    poll_calls: Arc<AtomicU32>,
+}
+
+#[task::poll]
+impl PollTask<Pipe> for Waiter {
+    async fn poll(&self, _res: &Resources) -> Result<PollOutcome<Pipe>, CanoError> {
+        let n = self.poll_calls.fetch_add(1, Ordering::SeqCst) + 1;
+        if n >= 3 {
+            Ok(PollOutcome::Ready(TaskResult::Single(Pipe::Crunch)))
+        } else {
+            Ok(PollOutcome::Pending { delay_ms: 1 })
+        }
+    }
+}
+
+/// Batch stage: squares 1..=4 and records the aggregate.
+struct Cruncher {
+    load_calls: Arc<AtomicU32>,
+    sums: Arc<Mutex<Vec<u32>>>,
+}
+
+#[task::batch]
+impl BatchTask<Pipe> for Cruncher {
+    type Item = u32;
+    type ItemOutput = u32;
+
+    fn config(&self) -> TaskConfig {
+        TaskConfig::minimal()
+    }
+
+    async fn load(&self, _res: &Resources) -> Result<Vec<u32>, CanoError> {
+        self.load_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(vec![1, 2, 3, 4])
+    }
+
+    async fn process_item(&self, item: &u32) -> Result<u32, CanoError> {
+        Ok(item * item)
+    }
+
+    async fn finish(
+        &self,
+        _res: &Resources,
+        outputs: Vec<Result<u32, CanoError>>,
+    ) -> Result<TaskResult<Pipe>, CanoError> {
+        let sum = outputs.into_iter().filter_map(|r| r.ok()).sum();
+        self.sums.lock().push(sum);
+        Ok(TaskResult::Single(Pipe::Pump))
+    }
+}
+
+/// Stream stage: consumes 1..=6 in windows of 2; item 5 is corrupt exactly once.
+struct Pumper {
+    fail_once_at: Arc<Mutex<Option<u64>>>,
+    flushed: Arc<Mutex<Vec<Vec<u64>>>>,
+    opened_with: Arc<Mutex<Vec<Option<u64>>>>,
+}
+
+#[task::stream]
+impl StreamTask<Pipe> for Pumper {
+    type Item = u64;
+    type Output = u64;
+    type Cursor = u64;
+
+    fn window(&self) -> StreamWindow {
+        StreamWindow::Count(2)
+    }
+
+    async fn open(
+        &self,
+        _res: &Resources,
+        cursor: Option<u64>,
+    ) -> Result<Pin<Box<dyn Stream<Item = u64> + Send>>, CanoError> {
+        self.opened_with.lock().push(cursor);
+        Ok(boxed(cursor.map_or(1, |c| c + 1)..=6))
+    }
+
+    async fn process_item(&self, _res: &Resources, item: u64) -> Result<(u64, u64), CanoError> {
+        let mut fail = self.fail_once_at.lock();
+        if *fail == Some(item) {
+            *fail = None;
+            return Err(CanoError::task_execution(format!(
+                "pump item {item} corrupt"
+            )));
+        }
+        Ok((item, item))
+    }
+
+    async fn flush_window(
+        &self,
+        _res: &Resources,
+        outputs: Vec<u64>,
+    ) -> Result<WindowSignal<Pipe>, CanoError> {
+        self.flushed.lock().push(outputs);
+        Ok(WindowSignal::Continue)
+    }
+
+    async fn on_close(
+        &self,
+        _res: &Resources,
+        _reason: CloseReason,
+    ) -> Result<TaskResult<Pipe>, CanoError> {
+        Ok(TaskResult::Single(Pipe::Done))
+    }
+}
+
+/// Contract: the engine checkpoints one row per state entry, so `resume_from`
+/// jumps straight into the state that crashed — the poll and batch stages that
+/// already completed are NOT re-executed. Only the crashed stream state re-runs,
+/// and it re-opens from its own persisted cursor. This is what makes a multi-model
+/// pipeline restartable without double-charging earlier side effects.
+#[tokio::test]
+async fn pipeline_resume_reenters_only_the_crashed_state() {
+    let poll_calls = Arc::new(AtomicU32::new(0));
+    let load_calls = Arc::new(AtomicU32::new(0));
+    let sums = Arc::new(Mutex::new(Vec::new()));
+    let flushed = Arc::new(Mutex::new(Vec::new()));
+    let opened_with = Arc::new(Mutex::new(Vec::new()));
+
+    let store = Arc::new(MemStore::default());
+    let workflow = Workflow::bare()
+        .register(
+            Pipe::Wait,
+            Waiter {
+                poll_calls: poll_calls.clone(),
+            },
+        )
+        .register(
+            Pipe::Crunch,
+            Cruncher {
+                load_calls: load_calls.clone(),
+                sums: sums.clone(),
+            },
+        )
+        .register_stream(
+            Pipe::Pump,
+            Pumper {
+                fail_once_at: Arc::new(Mutex::new(Some(5))),
+                flushed: flushed.clone(),
+                opened_with: opened_with.clone(),
+            },
+        )
+        .add_exit_state(Pipe::Done)
+        .with_checkpoint_store(store.clone())
+        .with_workflow_id("pipeline");
+
+    // Run 1: Wait and Crunch complete; Pump flushes [1,2] and [3,4], then crashes
+    // on the corrupt item 5.
+    let err = workflow
+        .orchestrate(Pipe::Wait, CancellationToken::disabled())
+        .await
+        .unwrap_err();
+    assert_eq!(err.category(), "task_execution", "got: {err}");
+    assert_eq!(poll_calls.load(Ordering::SeqCst), 3);
+    assert_eq!(load_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(*sums.lock(), vec![30]);
+    assert_eq!(*flushed.lock(), vec![vec![1, 2], vec![3, 4]]);
+    assert_eq!(store.last_cursor("pipeline", "Pump"), Some(4));
+
+    // Run 2: resume enters at Pump directly.
+    let result = workflow
+        .resume_from("pipeline", CancellationToken::disabled())
+        .await
+        .unwrap();
+    assert_eq!(result, Pipe::Done);
+
+    // Completed stages did not re-execute…
+    assert_eq!(
+        poll_calls.load(Ordering::SeqCst),
+        3,
+        "the poll stage must not re-run on resume"
+    );
+    assert_eq!(
+        load_calls.load(Ordering::SeqCst),
+        1,
+        "the batch stage must not re-run on resume"
+    );
+    assert_eq!(*sums.lock(), vec![30], "no double aggregation");
+
+    // …while the crashed stream stage resumed from its own cursor.
+    assert_eq!(*opened_with.lock(), vec![None, Some(4)]);
+    assert_eq!(*flushed.lock(), vec![vec![1, 2], vec![3, 4], vec![5, 6]]);
+    assert!(store.rows("pipeline").is_empty(), "cleared on success");
+}

--- a/cano/tests/poll_reliability.rs
+++ b/cano/tests/poll_reliability.rs
@@ -1,0 +1,151 @@
+//! Reliability contracts of [`PollTask`] under critical scenarios.
+//!
+//! Black-box integration tests (public API only) documenting how the wait-until
+//! processing model behaves against a flaky or dead dependency:
+//!
+//! | Critical scenario | Contract |
+//! |-------------------|----------|
+//! | flaky dependency under `RetryOnError` | budget counts *consecutive* errors; `Pending` resets it; budget+1 kills the run |
+//! | condition never becomes true | `attempt_timeout` bounds the otherwise-infinite loop |
+
+mod support;
+
+use cano::prelude::*;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, Instant};
+use support::Flow;
+
+// ===========================================================================
+// Consecutive-error budget, reset by Pending
+// ===========================================================================
+
+#[derive(Clone, Copy)]
+enum Probe {
+    Fail,
+    Pending,
+    Ready,
+}
+
+/// Replays a fixed script, one entry per `poll` call.
+struct ScriptedProbe {
+    script: Vec<Probe>,
+    calls: Arc<AtomicU32>,
+}
+
+#[task::poll]
+impl PollTask<Flow> for ScriptedProbe {
+    fn on_poll_error(&self) -> PollErrorPolicy {
+        PollErrorPolicy::RetryOnError { max_errors: 2 }
+    }
+
+    async fn poll(&self, _res: &Resources) -> Result<PollOutcome<Flow>, CanoError> {
+        let n = self.calls.fetch_add(1, Ordering::SeqCst) as usize;
+        match self.script.get(n).copied().unwrap_or(Probe::Ready) {
+            Probe::Fail => Err(CanoError::task_execution(format!("probe {n} refused"))),
+            Probe::Pending => Ok(PollOutcome::Pending { delay_ms: 0 }),
+            Probe::Ready => Ok(PollOutcome::Ready(TaskResult::Single(Flow::Done))),
+        }
+    }
+}
+
+/// Contract: unlike the stream policy, poll's `RetryOnError` really does re-ask
+/// (the condition is re-checked next iteration). The budget counts *consecutive*
+/// errors only — a successful `Pending` resets it — and the run dies when a burst
+/// reaches budget+1, surfacing the underlying error unwrapped (poll defaults to
+/// no outer retry).
+#[tokio::test]
+async fn poll_error_budget_resets_on_pending_and_kills_on_burst() {
+    // Two bursts of exactly max_errors=2, separated by a Pending: survives.
+    let calls = Arc::new(AtomicU32::new(0));
+    let workflow = Workflow::bare()
+        .register(
+            Flow::Work,
+            ScriptedProbe {
+                script: vec![
+                    Probe::Fail,
+                    Probe::Fail,
+                    Probe::Pending, // resets the consecutive-error counter
+                    Probe::Fail,
+                    Probe::Fail,
+                    Probe::Ready,
+                ],
+                calls: calls.clone(),
+            },
+        )
+        .add_exit_state(Flow::Done);
+    let result = workflow
+        .orchestrate(Flow::Work, CancellationToken::disabled())
+        .await
+        .unwrap();
+    assert_eq!(result, Flow::Done);
+    assert_eq!(calls.load(Ordering::SeqCst), 6);
+
+    // Three consecutive errors exceed the budget: the third one propagates.
+    let calls = Arc::new(AtomicU32::new(0));
+    let workflow = Workflow::bare()
+        .register(
+            Flow::Work,
+            ScriptedProbe {
+                script: vec![Probe::Fail, Probe::Fail, Probe::Fail],
+                calls: calls.clone(),
+            },
+        )
+        .add_exit_state(Flow::Done);
+    let err = workflow
+        .orchestrate(Flow::Work, CancellationToken::disabled())
+        .await
+        .unwrap_err();
+    assert_eq!(err.category(), "task_execution", "got: {err}");
+    assert!(err.to_string().contains("probe 2 refused"), "got: {err}");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        3,
+        "no fourth poll after the budget"
+    );
+}
+
+// ===========================================================================
+// An eternally-pending condition is bounded by attempt_timeout
+// ===========================================================================
+
+/// The watched condition never becomes true.
+struct StuckProbe;
+
+#[task::poll]
+impl PollTask<Flow> for StuckProbe {
+    fn config(&self) -> TaskConfig {
+        TaskConfig::minimal().with_attempt_timeout(Duration::from_millis(200))
+    }
+
+    async fn poll(&self, _res: &Resources) -> Result<PollOutcome<Flow>, CanoError> {
+        Ok(PollOutcome::Pending { delay_ms: 5 })
+    }
+}
+
+/// Contract: there is no built-in iteration cap — an always-Pending poller loops
+/// forever unless `attempt_timeout` bounds the whole loop. The engine then fails
+/// the state with category `timeout` near the configured budget.
+#[tokio::test]
+async fn poll_eternal_pending_is_bounded_by_attempt_timeout() {
+    let workflow = Workflow::bare()
+        .register(Flow::Work, StuckProbe)
+        .add_exit_state(Flow::Done);
+
+    let started = Instant::now();
+    let err = workflow
+        .orchestrate(Flow::Work, CancellationToken::disabled())
+        .await
+        .unwrap_err();
+    let elapsed = started.elapsed();
+
+    assert_eq!(err.category(), "timeout", "got: {err}");
+    assert!(
+        elapsed >= Duration::from_millis(200),
+        "fired early: {elapsed:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "liveness: took {elapsed:?}"
+    );
+}

--- a/cano/tests/stepped_reliability.rs
+++ b/cano/tests/stepped_reliability.rs
@@ -1,0 +1,199 @@
+//! Reliability contracts of [`SteppedTask`] under critical scenarios.
+//!
+//! Black-box integration tests (public API only, engine-driven `register_stepped`
+//! path) documenting how the stepped processing model behaves when a step fails:
+//!
+//! | Critical scenario | Contract |
+//! |-------------------|----------|
+//! | transient step error | per-step retry re-runs the **same cursor** — no restart from `None` |
+//! | hard step failure → `resume_from` | resume continues at the last persisted cursor; earlier steps never re-run |
+//!
+//! The SIGKILL (process-death) variant of cursor resume is covered separately by
+//! `stepped_resume_e2e.rs`; these tests exercise the in-process failure paths.
+
+mod support;
+
+use cano::prelude::*;
+use parking_lot::Mutex;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::time::Duration;
+use support::{Flow, MemStore};
+
+// ===========================================================================
+// A transient step error retries the SAME cursor
+// ===========================================================================
+
+/// Pages 0→5 via `More(n+1)`; the step at a scripted cursor fails a scripted
+/// number of times before succeeding.
+struct PagedMigration {
+    flaky_cursor: u32,
+    failures_remaining: Arc<AtomicU32>,
+    calls: Arc<Mutex<Vec<Option<u32>>>>,
+}
+
+#[task::stepped]
+impl SteppedTask<Flow> for PagedMigration {
+    type Cursor = u32;
+
+    fn config(&self) -> TaskConfig {
+        TaskConfig::minimal().with_fixed_retry(2, Duration::from_millis(1)) // 3 attempts/step
+    }
+
+    async fn step(
+        &self,
+        _res: &Resources,
+        cursor: Option<u32>,
+    ) -> Result<StepOutcome<u32, Flow>, CanoError> {
+        self.calls.lock().push(cursor);
+        if cursor == Some(self.flaky_cursor) && self.failures_remaining.load(Ordering::SeqCst) > 0 {
+            self.failures_remaining.fetch_sub(1, Ordering::SeqCst);
+            return Err(CanoError::task_execution("page fetch flaked"));
+        }
+        let n = cursor.unwrap_or(0);
+        if n >= 5 {
+            Ok(StepOutcome::Done(TaskResult::Single(Flow::Done)))
+        } else {
+            Ok(StepOutcome::More(n + 1))
+        }
+    }
+}
+
+/// Contract: the retry budget wraps each *step call*, not the whole loop. A
+/// transient error re-invokes `step` with the SAME cursor — progress made by
+/// earlier steps is never redone, and the loop does not restart from `None`.
+#[tokio::test]
+async fn stepped_transient_error_retries_same_cursor_without_restarting() {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let workflow = Workflow::bare()
+        .register_stepped(
+            Flow::Work,
+            PagedMigration {
+                flaky_cursor: 3,
+                failures_remaining: Arc::new(AtomicU32::new(2)),
+                calls: calls.clone(),
+            },
+        )
+        .add_exit_state(Flow::Done);
+
+    let result = workflow
+        .orchestrate(Flow::Work, CancellationToken::disabled())
+        .await
+        .unwrap();
+    assert_eq!(result, Flow::Done);
+    assert_eq!(
+        *calls.lock(),
+        vec![
+            None,
+            Some(1),
+            Some(2),
+            Some(3), // fails
+            Some(3), // retry 1 — same cursor
+            Some(3), // retry 2 — same cursor, succeeds
+            Some(4),
+            Some(5),
+        ],
+        "retries pin the cursor; earlier pages are never refetched"
+    );
+}
+
+// ===========================================================================
+// Hard failure, then resume from the persisted cursor
+// ===========================================================================
+
+/// Counts 0→6; the step at `blocked_at` fails until `unblocked` flips (a
+/// dependency outage that is later repaired).
+struct BlockingMigration {
+    blocked_at: u32,
+    unblocked: Arc<AtomicBool>,
+    calls: Arc<Mutex<Vec<Option<u32>>>>,
+}
+
+#[task::stepped]
+impl SteppedTask<Flow> for BlockingMigration {
+    type Cursor = u32;
+
+    fn config(&self) -> TaskConfig {
+        TaskConfig::minimal() // one attempt per step: fail fast to the workflow
+    }
+
+    async fn step(
+        &self,
+        _res: &Resources,
+        cursor: Option<u32>,
+    ) -> Result<StepOutcome<u32, Flow>, CanoError> {
+        self.calls.lock().push(cursor);
+        if cursor == Some(self.blocked_at) && !self.unblocked.load(Ordering::SeqCst) {
+            return Err(CanoError::task_execution("downstream outage"));
+        }
+        let n = cursor.unwrap_or(0);
+        if n >= 6 {
+            Ok(StepOutcome::Done(TaskResult::Single(Flow::Done)))
+        } else {
+            Ok(StepOutcome::More(n + 1))
+        }
+    }
+}
+
+/// Contract: every `More` persists its cursor BEFORE the next step runs, so a
+/// hard mid-loop failure leaves an exact restart position. `resume_from`
+/// re-enters the stepped state at that cursor — completed steps never re-run.
+#[tokio::test]
+async fn stepped_hard_failure_resumes_from_last_persisted_cursor() {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let unblocked = Arc::new(AtomicBool::new(false));
+    let store = Arc::new(MemStore::default());
+
+    let workflow = Workflow::bare()
+        .register_stepped(
+            Flow::Work,
+            BlockingMigration {
+                blocked_at: 4,
+                unblocked: unblocked.clone(),
+                calls: calls.clone(),
+            },
+        )
+        .add_exit_state(Flow::Done)
+        .with_checkpoint_store(store.clone())
+        .with_workflow_id("stepped-outage");
+
+    // Run 1: advances through cursors 1..=4, then the step at 4 hits the outage.
+    let err = workflow
+        .orchestrate(Flow::Work, CancellationToken::disabled())
+        .await
+        .unwrap_err();
+    assert_eq!(err.category(), "task_execution", "got: {err}");
+    assert_eq!(
+        *calls.lock(),
+        vec![None, Some(1), Some(2), Some(3), Some(4)]
+    );
+    assert_eq!(
+        store.last_cursor("stepped-outage", "Work"),
+        Some(4),
+        "the cursor reached before the failure is durably persisted"
+    );
+
+    // Outage repaired; resume continues AT cursor 4 — not from None.
+    unblocked.store(true, Ordering::SeqCst);
+    let result = workflow
+        .resume_from("stepped-outage", CancellationToken::disabled())
+        .await
+        .unwrap();
+    assert_eq!(result, Flow::Done);
+
+    let all = calls.lock().clone();
+    assert_eq!(
+        all[5..],
+        [Some(4), Some(5), Some(6)],
+        "resume re-runs only the failed step and the remainder"
+    );
+    assert_eq!(
+        all.iter().filter(|c| c.is_none()).count(),
+        1,
+        "the loop never restarted from the beginning"
+    );
+    assert!(
+        store.rows("stepped-outage").is_empty(),
+        "cleared on success"
+    );
+}

--- a/cano/tests/stream_reliability.rs
+++ b/cano/tests/stream_reliability.rs
@@ -1,0 +1,481 @@
+//! Reliability contracts of [`StreamTask`] under critical scenarios.
+//!
+//! Black-box integration tests (public API only, engine-driven `register_stream`
+//! path) documenting how the stream processing model behaves when things go wrong
+//! mid-flight:
+//!
+//! | Critical scenario | Contract |
+//! |-------------------|----------|
+//! | crash mid-window → `resume_from` | loss is bounded to the uncommitted window; replay is at-least-once |
+//! | cancel mid-window → drain → resume | in-flight window is flushed + committed ⇒ resume produces **no duplicates** |
+//! | flaky source items under `RetryOnError` | error *budget*: failed items are dropped (never re-pulled), counter resets on success |
+//! | `process_item` hangs | `attempt_timeout` is the liveness ceiling; surfaces as `timeout` |
+
+mod support;
+
+use cano::prelude::*;
+use futures_util::Stream;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use support::{Flow, MemStore, boxed};
+
+// ===========================================================================
+// Crash mid-window, then resume from the committed cursor
+// ===========================================================================
+
+/// Emits `cursor+1 ..= 10`. Fails exactly once at a scripted item (FailFast policy),
+/// recording every `process_item` call, every flushed window, and every `open` cursor.
+struct MeterFeed {
+    fail_once_at: Arc<Mutex<Option<u64>>>,
+    processed: Arc<Mutex<Vec<u64>>>,
+    flushed: Arc<Mutex<Vec<Vec<u64>>>>,
+    opened_with: Arc<Mutex<Vec<Option<u64>>>>,
+}
+
+#[task::stream]
+impl StreamTask<Flow> for MeterFeed {
+    type Item = u64;
+    type Output = u64;
+    type Cursor = u64;
+
+    fn window(&self) -> StreamWindow {
+        StreamWindow::Count(3)
+    }
+
+    async fn open(
+        &self,
+        _res: &Resources,
+        cursor: Option<u64>,
+    ) -> Result<Pin<Box<dyn Stream<Item = u64> + Send>>, CanoError> {
+        self.opened_with.lock().push(cursor);
+        Ok(boxed(cursor.map_or(1, |c| c + 1)..=10))
+    }
+
+    async fn process_item(&self, _res: &Resources, item: u64) -> Result<(u64, u64), CanoError> {
+        self.processed.lock().push(item);
+        let mut fail = self.fail_once_at.lock();
+        if *fail == Some(item) {
+            *fail = None; // fail exactly once, like a transient poison read
+            return Err(CanoError::task_execution(format!("meter {item} corrupt")));
+        }
+        Ok((item, item)) // output = item; cursor = position of this item
+    }
+
+    async fn flush_window(
+        &self,
+        _res: &Resources,
+        outputs: Vec<u64>,
+    ) -> Result<WindowSignal<Flow>, CanoError> {
+        self.flushed.lock().push(outputs);
+        Ok(WindowSignal::Continue)
+    }
+
+    async fn on_close(
+        &self,
+        _res: &Resources,
+        _reason: CloseReason,
+    ) -> Result<TaskResult<Flow>, CanoError> {
+        Ok(TaskResult::Single(Flow::Done))
+    }
+}
+
+/// Contract: a crash between window flushes loses only the *uncommitted* buffer.
+/// The engine persists the cursor after each flushed window, so `resume_from`
+/// re-opens the source right after the last committed window and replays the
+/// partially-consumed one — at-least-once, window-granular.
+#[tokio::test]
+async fn stream_crash_loses_only_uncommitted_window_and_resumes_from_cursor() {
+    let processed = Arc::new(Mutex::new(Vec::new()));
+    let flushed = Arc::new(Mutex::new(Vec::new()));
+    let opened_with = Arc::new(Mutex::new(Vec::new()));
+    let task = MeterFeed {
+        fail_once_at: Arc::new(Mutex::new(Some(8))),
+        processed: processed.clone(),
+        flushed: flushed.clone(),
+        opened_with: opened_with.clone(),
+    };
+
+    let store = Arc::new(MemStore::default());
+    let workflow = Workflow::bare()
+        .register_stream(Flow::Work, task)
+        .add_exit_state(Flow::Done)
+        .with_checkpoint_store(store.clone())
+        .with_workflow_id("stream-crash");
+
+    // Run 1: windows [1,2,3] and [4,5,6] flush and commit; 7 is buffered; 8 errors.
+    let err = workflow
+        .orchestrate(Flow::Work, CancellationToken::disabled())
+        .await
+        .unwrap_err();
+    assert_eq!(err.category(), "task_execution", "got: {err}");
+    assert_eq!(*flushed.lock(), vec![vec![1, 2, 3], vec![4, 5, 6]]);
+    // The buffered-but-unflushed item 7 is NOT committed: the cursor stays at 6.
+    assert_eq!(store.last_cursor("stream-crash", "Work"), Some(6));
+
+    // Run 2: resume re-opens the source *after* the committed cursor.
+    let result = workflow
+        .resume_from("stream-crash", CancellationToken::disabled())
+        .await
+        .unwrap();
+    assert_eq!(result, Flow::Done);
+    assert_eq!(*opened_with.lock(), vec![None, Some(6)]);
+    assert_eq!(
+        *flushed.lock(),
+        vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9], vec![10]],
+        "resume replays the uncommitted window and finishes the tail"
+    );
+
+    // At-least-once accounting: 7 and 8 were consumed in both runs (the replayed
+    // window), everything else exactly once. This is why `process_item` must be
+    // idempotent.
+    let mut per_item: HashMap<u64, usize> = HashMap::new();
+    for item in processed.lock().iter() {
+        *per_item.entry(*item).or_default() += 1;
+    }
+    for item in 1..=6u64 {
+        assert_eq!(per_item[&item], 1, "committed item {item} must not replay");
+    }
+    assert_eq!(per_item[&7], 2, "uncommitted item 7 replays on resume");
+    assert_eq!(per_item[&8], 2, "failed item 8 replays on resume");
+    for item in 9..=10u64 {
+        assert_eq!(per_item[&item], 1);
+    }
+
+    // A successful run clears its checkpoint log.
+    assert!(store.rows("stream-crash").is_empty());
+}
+
+// ===========================================================================
+// Cooperative cancel: drain flushes + commits, resume dedups
+// ===========================================================================
+
+/// Emits `cursor+1 ..= 12` and fires its own cancellation handle after processing
+/// a scripted item — deterministic (no timing races): cancellation is observed at
+/// the next item boundary via the engine's biased select.
+struct TickerFeed {
+    cancel_at: u64,
+    handle: Mutex<Option<CancellationHandle>>,
+    processed: Arc<Mutex<Vec<u64>>>,
+    flushed: Arc<Mutex<Vec<Vec<u64>>>>,
+    closes: Arc<Mutex<Vec<String>>>,
+}
+
+#[task::stream]
+impl StreamTask<Flow> for TickerFeed {
+    type Item = u64;
+    type Output = u64;
+    type Cursor = u64;
+
+    fn window(&self) -> StreamWindow {
+        StreamWindow::Count(5)
+    }
+
+    async fn open(
+        &self,
+        _res: &Resources,
+        cursor: Option<u64>,
+    ) -> Result<Pin<Box<dyn Stream<Item = u64> + Send>>, CanoError> {
+        Ok(boxed(cursor.map_or(1, |c| c + 1)..=12))
+    }
+
+    async fn process_item(&self, _res: &Resources, item: u64) -> Result<(u64, u64), CanoError> {
+        self.processed.lock().push(item);
+        if item == self.cancel_at
+            && let Some(handle) = self.handle.lock().take()
+        {
+            handle.cancel(); // e.g. operator-initiated shutdown mid-window
+        }
+        Ok((item, item))
+    }
+
+    async fn flush_window(
+        &self,
+        _res: &Resources,
+        outputs: Vec<u64>,
+    ) -> Result<WindowSignal<Flow>, CanoError> {
+        self.flushed.lock().push(outputs);
+        Ok(WindowSignal::Continue)
+    }
+
+    async fn on_close(
+        &self,
+        _res: &Resources,
+        reason: CloseReason,
+    ) -> Result<TaskResult<Flow>, CanoError> {
+        self.closes.lock().push(format!("{reason:?}"));
+        Ok(TaskResult::Single(Flow::Done))
+    }
+}
+
+/// Contract: cancel means "stop cleanly + resumable", not "transition onward".
+/// The in-flight partial window is flushed, its cursor IS committed, and
+/// `on_close(Cancelled)` runs — so the later resume continues right after the
+/// drained window with **zero duplicates** (contrast with the crash test above,
+/// where the uncommitted window replays).
+#[tokio::test]
+async fn stream_cancel_drains_partial_window_commits_cursor_and_resume_dedups() {
+    let processed = Arc::new(Mutex::new(Vec::new()));
+    let flushed = Arc::new(Mutex::new(Vec::new()));
+    let closes = Arc::new(Mutex::new(Vec::new()));
+
+    let (handle, token) = CancellationToken::new();
+    let task = TickerFeed {
+        cancel_at: 7,
+        handle: Mutex::new(Some(handle)),
+        processed: processed.clone(),
+        flushed: flushed.clone(),
+        closes: closes.clone(),
+    };
+
+    let store = Arc::new(MemStore::default());
+    let workflow = Workflow::bare()
+        .register_stream(Flow::Work, task)
+        .add_exit_state(Flow::Done)
+        .with_checkpoint_store(store.clone())
+        .with_workflow_id("stream-cancel");
+
+    // Run 1: [1..=5] flushes normally; cancel fires inside item 7; the drain
+    // flushes the partial [6,7] and commits cursor 7 before surfacing Cancelled.
+    let err = workflow.orchestrate(Flow::Work, token).await.unwrap_err();
+    assert_eq!(err.category(), "cancelled", "got: {err}");
+    assert_eq!(
+        *flushed.lock(),
+        vec![vec![1, 2, 3, 4, 5], vec![6, 7]],
+        "cancel drain must flush the in-flight partial window"
+    );
+    assert_eq!(*closes.lock(), vec!["Cancelled"]);
+    assert_eq!(
+        store.last_cursor("stream-cancel", "Work"),
+        Some(7),
+        "the drained window's cursor is committed — cancel is resumable"
+    );
+
+    // Run 2: resume picks up at 8; the run completes and nothing is reprocessed.
+    let result = workflow
+        .resume_from("stream-cancel", CancellationToken::disabled())
+        .await
+        .unwrap();
+    assert_eq!(result, Flow::Done);
+    assert_eq!(
+        *flushed.lock(),
+        vec![vec![1, 2, 3, 4, 5], vec![6, 7], vec![8, 9, 10, 11, 12]]
+    );
+    assert_eq!(*closes.lock(), vec!["Cancelled", "Exhausted"]);
+
+    // Exactly-once effective delivery for the cancel path: the committed drain
+    // means the resume introduces no duplicates.
+    let all = processed.lock().clone();
+    assert_eq!(all, (1..=12).collect::<Vec<_>>());
+}
+
+// ===========================================================================
+// RetryOnError is an error *budget*, not a re-read
+// ===========================================================================
+
+/// Fails deterministically on a scripted set of items.
+struct FlakyFeed {
+    fail_items: Vec<u64>,
+    budget: u32,
+    flushed: Arc<Mutex<Vec<Vec<u64>>>>,
+}
+
+#[task::stream]
+impl StreamTask<Flow> for FlakyFeed {
+    type Item = u64;
+    type Output = u64;
+    type Cursor = u64;
+
+    fn window(&self) -> StreamWindow {
+        StreamWindow::Count(3)
+    }
+
+    fn on_item_error(&self) -> StreamErrorPolicy {
+        StreamErrorPolicy::RetryOnError {
+            max_errors: self.budget,
+        }
+    }
+
+    async fn open(
+        &self,
+        _res: &Resources,
+        cursor: Option<u64>,
+    ) -> Result<Pin<Box<dyn Stream<Item = u64> + Send>>, CanoError> {
+        Ok(boxed(cursor.map_or(1, |c| c + 1)..=10))
+    }
+
+    async fn process_item(&self, _res: &Resources, item: u64) -> Result<(u64, u64), CanoError> {
+        if self.fail_items.contains(&item) {
+            return Err(CanoError::task_execution(format!("record {item} rotten")));
+        }
+        Ok((item, item))
+    }
+
+    async fn flush_window(
+        &self,
+        _res: &Resources,
+        outputs: Vec<u64>,
+    ) -> Result<WindowSignal<Flow>, CanoError> {
+        self.flushed.lock().push(outputs);
+        Ok(WindowSignal::Continue)
+    }
+
+    async fn on_close(
+        &self,
+        _res: &Resources,
+        _reason: CloseReason,
+    ) -> Result<TaskResult<Flow>, CanoError> {
+        Ok(TaskResult::Single(Flow::Done))
+    }
+}
+
+/// Contract: a stream cannot re-pull a consumed item, so `RetryOnError` does NOT
+/// retry the item — it *tolerates* up to `max_errors` consecutive failures, each
+/// failed item being dropped, and the counter resets on every success. The run
+/// dies on the (budget+1)-th consecutive failure, discarding the in-flight buffer.
+#[tokio::test]
+async fn stream_error_budget_drops_failed_items_resets_on_success_and_kills_on_burst() {
+    // Bursts of 1 (item 2) and 2 (items 5,6) both fit budget=2: the run survives,
+    // the rotten items are simply missing from the output.
+    let flushed = Arc::new(Mutex::new(Vec::new()));
+    let workflow = Workflow::bare()
+        .register_stream(
+            Flow::Work,
+            FlakyFeed {
+                fail_items: vec![2, 5, 6],
+                budget: 2,
+                flushed: flushed.clone(),
+            },
+        )
+        .add_exit_state(Flow::Done);
+    let result = workflow
+        .orchestrate(Flow::Work, CancellationToken::disabled())
+        .await
+        .unwrap();
+    assert_eq!(result, Flow::Done);
+    assert_eq!(
+        *flushed.lock(),
+        vec![vec![1, 3, 4], vec![7, 8, 9], vec![10]],
+        "failed items are dropped, not retried; survivors keep flowing"
+    );
+
+    // A burst of 3 consecutive failures (5,6,7) exceeds budget=2: the third error
+    // propagates and the buffered-but-unflushed item 4 is discarded with the run.
+    let flushed = Arc::new(Mutex::new(Vec::new()));
+    let workflow = Workflow::bare()
+        .register_stream(
+            Flow::Work,
+            FlakyFeed {
+                fail_items: vec![5, 6, 7],
+                budget: 2,
+                flushed: flushed.clone(),
+            },
+        )
+        .add_exit_state(Flow::Done);
+    let err = workflow
+        .orchestrate(Flow::Work, CancellationToken::disabled())
+        .await
+        .unwrap_err();
+    assert_eq!(err.category(), "task_execution");
+    assert!(err.to_string().contains("record 7 rotten"), "got: {err}");
+    assert_eq!(
+        *flushed.lock(),
+        vec![vec![1, 2, 3]],
+        "only the fully-flushed window survives; the partial buffer is lost"
+    );
+}
+
+// ===========================================================================
+// A hung process_item is bounded by attempt_timeout
+// ===========================================================================
+
+/// Item 3 hangs "forever"; `attempt_timeout` must convert that into an item error.
+struct StallFeed {
+    flushed: Arc<Mutex<Vec<Vec<u64>>>>,
+}
+
+#[task::stream]
+impl StreamTask<Flow> for StallFeed {
+    type Item = u64;
+    type Output = u64;
+    type Cursor = u64;
+
+    fn window(&self) -> StreamWindow {
+        StreamWindow::Count(2)
+    }
+
+    fn config(&self) -> TaskConfig {
+        // For streams only attempt_timeout is honored — as a per-item bound. This
+        // is also what bounds cancel latency when items can hang.
+        TaskConfig::minimal().with_attempt_timeout(Duration::from_millis(50))
+    }
+
+    async fn open(
+        &self,
+        _res: &Resources,
+        cursor: Option<u64>,
+    ) -> Result<Pin<Box<dyn Stream<Item = u64> + Send>>, CanoError> {
+        Ok(boxed(cursor.map_or(1, |c| c + 1)..=5))
+    }
+
+    async fn process_item(&self, _res: &Resources, item: u64) -> Result<(u64, u64), CanoError> {
+        if item == 3 {
+            tokio::time::sleep(Duration::from_secs(3600)).await; // dead upstream call
+        }
+        Ok((item, item))
+    }
+
+    async fn flush_window(
+        &self,
+        _res: &Resources,
+        outputs: Vec<u64>,
+    ) -> Result<WindowSignal<Flow>, CanoError> {
+        self.flushed.lock().push(outputs);
+        Ok(WindowSignal::Continue)
+    }
+
+    async fn on_close(
+        &self,
+        _res: &Resources,
+        _reason: CloseReason,
+    ) -> Result<TaskResult<Flow>, CanoError> {
+        Ok(TaskResult::Single(Flow::Done))
+    }
+}
+
+/// Contract: without `attempt_timeout` a hung item wedges the stream forever
+/// (cancellation is only observed between items). With it, the hang becomes an
+/// ordinary item error routed through the error policy — FailFast here, so the
+/// run fails promptly with category `timeout`.
+#[tokio::test]
+async fn stream_hung_item_is_bounded_by_attempt_timeout() {
+    let flushed = Arc::new(Mutex::new(Vec::new()));
+    let workflow = Workflow::bare()
+        .register_stream(
+            Flow::Work,
+            StallFeed {
+                flushed: flushed.clone(),
+            },
+        )
+        .add_exit_state(Flow::Done);
+
+    let started = Instant::now();
+    let err = workflow
+        .orchestrate(Flow::Work, CancellationToken::disabled())
+        .await
+        .unwrap_err();
+    let elapsed = started.elapsed();
+
+    assert_eq!(err.category(), "timeout", "got: {err}");
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "liveness: the run must fail near the 50ms budget, took {elapsed:?}"
+    );
+    assert_eq!(
+        *flushed.lock(),
+        vec![vec![1, 2]],
+        "work committed before the hang is preserved"
+    );
+}

--- a/cano/tests/support/mod.rs
+++ b/cano/tests/support/mod.rs
@@ -1,0 +1,76 @@
+//! Shared scaffolding for the processing-model reliability suites
+//! (`stream_reliability`, `batch_reliability`, `stepped_reliability`,
+//! `poll_reliability`, `pipeline_reliability`).
+//!
+//! Compiled into each test binary via `mod support;` — a `tests/` subdirectory is
+//! not itself a test target. No feature flags required: checkpointing uses the
+//! in-memory [`MemStore`].
+#![allow(dead_code)] // each test binary uses a different subset of this module
+
+use cano::prelude::*;
+use futures_util::{Stream, stream};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::pin::Pin;
+
+/// Two-state flow used by the single-model tests.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Flow {
+    Work,
+    Done,
+}
+
+/// In-memory append-only checkpoint store (the doc-example shape from
+/// `cano::recovery`), plus test-side introspection helpers.
+#[derive(Default)]
+pub struct MemStore(Mutex<HashMap<String, Vec<CheckpointRow>>>);
+
+#[cano::checkpoint_store]
+impl MemStore {
+    async fn append(&self, workflow_id: &str, row: CheckpointRow) -> Result<(), CanoError> {
+        let mut runs = self.0.lock();
+        let rows = runs.entry(workflow_id.to_string()).or_default();
+        if rows.iter().any(|r| r.sequence == row.sequence) {
+            return Err(CanoError::checkpoint_store(format!(
+                "duplicate sequence {} for {workflow_id:?}",
+                row.sequence
+            )));
+        }
+        rows.push(row);
+        Ok(())
+    }
+
+    async fn load_run(&self, workflow_id: &str) -> Result<Vec<CheckpointRow>, CanoError> {
+        let mut rows = self.0.lock().get(workflow_id).cloned().unwrap_or_default();
+        rows.sort_by_key(|r| r.sequence);
+        Ok(rows)
+    }
+
+    async fn clear(&self, workflow_id: &str) -> Result<(), CanoError> {
+        self.0.lock().remove(workflow_id);
+        Ok(())
+    }
+}
+
+impl MemStore {
+    pub fn rows(&self, workflow_id: &str) -> Vec<CheckpointRow> {
+        self.0.lock().get(workflow_id).cloned().unwrap_or_default()
+    }
+
+    /// Latest persisted `StepCursor` row for `state`, decoded as the integer the
+    /// stream/stepped adapters serialize via `serde_json`.
+    pub fn last_cursor(&self, workflow_id: &str, state: &str) -> Option<u64> {
+        let mut rows = self.rows(workflow_id);
+        rows.sort_by_key(|r| r.sequence);
+        rows.iter()
+            .rev()
+            .find(|r| r.kind == RowKind::StepCursor && r.state == state)
+            .and_then(|r| r.output_blob.as_deref())
+            .map(|b| serde_json::from_slice(b).expect("cursor blob is a serde_json integer"))
+    }
+}
+
+/// A finite, always-ready source stream over an inclusive range.
+pub fn boxed(range: std::ops::RangeInclusive<u64>) -> Pin<Box<dyn Stream<Item = u64> + Send>> {
+    Box::pin(stream::iter(range))
+}

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -7,7 +7,7 @@ build_search_index = false
 generate_feeds = false
 
 [extra]
-version = "0.14.0"
+version = "0.15.0"
 github_url = "https://github.com/nassor/cano"
 crates_url = "https://crates.io/crates/cano"
 docsrs_url = "https://docs.rs/cano"

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -84,6 +84,60 @@ It excels at managing complex lifecycles where state transitions matter:
 </div>
 </div>
 
+<div class="diagram-frame">
+<p class="diagram-label">One trigger &rarr; one FSM run &rarr; one task per state</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 466" role="img">
+<title>How Cano fits together: a run starts either from a direct orchestrate() call or from the Scheduler's interval, cron and manual triggers; the Workflow FSM dispatches the Task registered for the current state and routes the returned TaskResult onward, appends every state entry to the CheckpointStore that resume_from replays after a crash, hands each task the shared Resources, and stops at an exit state &mdash; while observer hooks, tracing spans and metrics counters listen on a rail underneath.</title>
+<defs><marker id="arch-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e e-dim e-dash" d="M97,320 V392" marker-end="url(#arch-ah)"/>
+<path class="e e-dim e-dash" d="M390,370 V392" marker-end="url(#arch-ah)"/>
+<path class="e e-dim e-dash" d="M683,206 V392" marker-end="url(#arch-ah)"/>
+<path class="e" d="M390,94 V144" marker-end="url(#arch-ah)"/>
+<text class="t-mut ta-s" x="400" y="121">one run per trigger</text>
+<path class="e" d="M97,96 V122 Q97,130 105,130 H312 Q320,130 320,138 V144" marker-end="url(#arch-ah)"/>
+<rect class="n" x="16" y="40" width="162" height="54" rx="10"/>
+<text class="t-strong" x="97" y="59">Direct run</text>
+<text class="t-code" x="97" y="78">orchestrate()</text>
+<path class="e e-hot" d="M266,175 H182" marker-end="url(#arch-ah)"/>
+<text class="t-mut t-hot" x="222" y="162">reaches exit</text>
+<path class="e" d="M510,161 H598" marker-end="url(#arch-ah)"/>
+<text class="t-code" x="554" y="147">append()</text>
+<path class="e e-dash" d="M598,189 H514" marker-end="url(#arch-ah)"/>
+<text class="t-code" x="556" y="205">resume_from</text>
+<path class="e" d="M366,202 V258" marker-end="url(#arch-ah)"/>
+<text class="t-mut ta-e" x="358" y="232">dispatch</text>
+<path class="e" d="M414,262 V206" marker-end="url(#arch-ah)"/>
+<text class="t-code ta-s" x="422" y="232">TaskResult</text>
+<path class="e" d="M266,289 H182" marker-end="url(#arch-ah)"/>
+<text class="t-code" x="224" y="276">&amp;Resources</text>
+<rect class="n" x="270" y="40" width="240" height="54" rx="10"/>
+<text class="t-strong" x="390" y="59">Scheduler</text>
+<text class="t-mut" x="390" y="78">interval &middot; cron &middot; manual</text>
+<rect class="n-ok" x="16" y="148" width="162" height="54" rx="10"/>
+<text class="t-strong" x="97" y="167">Exit state</text>
+<text class="t-mut" x="97" y="186">run complete</text>
+<rect class="n-hot" x="270" y="148" width="240" height="54" rx="10"/>
+<text class="t-strong" x="390" y="167">Workflow FSM</text>
+<text class="t-mut" x="390" y="186">one task per state</text>
+<rect class="n-cop" x="602" y="148" width="162" height="54" rx="10"/>
+<text class="t-code" x="683" y="167">CheckpointStore</text>
+<text class="t-mut" x="683" y="186">one row per state</text>
+<rect class="n-cop" x="16" y="262" width="162" height="54" rx="10"/>
+<text class="t-strong" x="97" y="281">Resources</text>
+<text class="t-code" x="97" y="300">MemoryStore</text>
+<rect class="n" x="270" y="262" width="240" height="104" rx="10"/>
+<text class="t-strong" x="390" y="284">Task family</text>
+<text class="t-mut" x="390" y="310">Task &middot; RouterTask &middot; PollTask</text>
+<text class="t-mut" x="390" y="330">TimerTask &middot; BatchTask</text>
+<text class="t-mut" x="390" y="350">SteppedTask &middot; StreamTask</text>
+<rect class="n" x="16" y="396" width="748" height="56" rx="10"/>
+<text class="t-strong" x="390" y="415">Observability rail &mdash; opt-in, zero-cost when unused</text>
+<text class="t-mut" x="390" y="435">WorkflowObserver hooks &middot; tracing spans &middot; metrics counters</text>
+</svg>
+</div>
+</div>
+
 <h2>Resilient, Self-Healing</h2>
 <p>
 What the tagline means, concretely. Every one of these is <strong>opt-in and zero-cost when unused</strong> —

--- a/docs/content/batch-task/_index.md
+++ b/docs/content/batch-task/_index.md
@@ -85,11 +85,31 @@ for "map this one operation over N <em>items</em>".
 
 <div class="diagram-frame">
 <p class="diagram-label">BatchTask: load &rarr; process_item (&times;N) &rarr; finish</p>
-<div class="mermaid">
-graph LR
-A[load] -->|"items: Vec of Item"| B[process_item ×N]
-B -->|"per-item Results — input order"| C[finish]
-C -->|TaskResult| D[Next State]
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 708 246" role="img">
+<title>A BatchTask fans out over data inside one state: load produces the items, process_item runs over all N with bounded concurrency, and finish re-joins the per-item results in input order before returning a TaskResult.</title>
+<defs><marker id="batch-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e e-dim" d="M626,64 V44 Q626,36 618,36 H84 Q76,36 76,44 V59" marker-end="url(#batch-ah)"/>
+<text class="t-mut" x="351" y="18">Err in load or finish &rarr; retry the whole cycle</text>
+<path class="e" d="M128,87 H262" marker-end="url(#batch-ah)"/>
+<text class="t-code" x="195" y="70">items: Vec&lt;Item&gt;</text>
+<path class="e" d="M444,87 H570" marker-end="url(#batch-ah)"/>
+<text class="t-mut" x="507" y="54">per-item Results</text>
+<text class="t-mut" x="507" y="70">in input order</text>
+<rect class="n" x="24" y="64" width="104" height="46" rx="10"/>
+<text class="t-code" x="76" y="88">load</text>
+<rect class="n" x="282" y="48" width="158" height="46" rx="10"/>
+<rect class="n" x="274" y="56" width="158" height="46" rx="10"/>
+<rect class="n-hot" x="266" y="64" width="158" height="46" rx="10"/>
+<text class="t-code t-strong" x="345" y="88">process_item</text>
+<text class="t-mut" x="345" y="130">&times;N &mdash; up to concurrency() at once</text>
+<rect class="n" x="574" y="64" width="104" height="46" rx="10"/>
+<text class="t-code" x="626" y="88">finish</text>
+<path class="e" d="M626,110 V171" marker-end="url(#batch-ah)"/>
+<text class="t-code t-mut ta-e" x="616" y="142">TaskResult</text>
+<rect class="n-ok" x="568" y="176" width="116" height="46" rx="10"/>
+<text x="626" y="200">Next State</text>
+</svg>
 </div>
 </div>
 

--- a/docs/content/metrics/_index.md
+++ b/docs/content/metrics/_index.md
@@ -139,6 +139,64 @@ Histograms record raw <code>f64</code> seconds samples — bucketing and quantil
 exporter's responsibility. Metric names follow <code>metrics</code>-crate underscore conventions.
 </p>
 
+<div class="diagram-frame">
+<p class="diagram-label">Where the counters fire along one run</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 510" role="img">
+<title>Emission points along a single workflow run: entering orchestrate, entering a state, acquiring the resilience guards, each retry-loop attempt, the split join and the exit state each emit their counters and histograms into the metrics facade, which forwards them to whatever recorder the application installed.</title>
+<defs><marker id="emit-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<text class="t-mut" x="110" y="34">one run, top to bottom</text>
+<text class="t-mut" x="556" y="34">emit point</text>
+<path class="e" d="M200,82 H592" marker-end="url(#emit-ah)"/>
+<text class="t-code t-mut" x="380" y="66">cano_workflow_active</text>
+<path class="e" d="M200,150 H592" marker-end="url(#emit-ah)"/>
+<text class="t-code t-mut" x="380" y="134">cano_state_enters_total{state}</text>
+<path class="e" d="M200,218 H592" marker-end="url(#emit-ah)"/>
+<text class="t-code t-mut" x="380" y="185">cano_circuit_acquires_total{result}</text>
+<text class="t-code t-mut" x="380" y="202">cano_rate_limiter_throttled_total{result}</text>
+<path class="e" d="M200,286 H592" marker-end="url(#emit-ah)"/>
+<text class="t-code t-mut" x="380" y="253">cano_task_attempts_total{outcome}</text>
+<text class="t-code t-mut" x="380" y="270">cano_task_retries_total{task}</text>
+<path class="e" d="M200,354 H592" marker-end="url(#emit-ah)"/>
+<text class="t-code t-mut" x="380" y="338">cano_split_branch_results_total{result}</text>
+<path class="e" d="M200,422 H592" marker-end="url(#emit-ah)"/>
+<text class="t-code t-mut" x="380" y="389">cano_workflow_runs_total{outcome}</text>
+<text class="t-code t-mut" x="380" y="406">cano_workflow_duration_seconds{outcome}</text>
+<path class="e e-dim" d="M110,106 V122" marker-end="url(#emit-ah)"/>
+<path class="e e-dim" d="M110,174 V190" marker-end="url(#emit-ah)"/>
+<path class="e e-dim" d="M110,242 V258" marker-end="url(#emit-ah)"/>
+<path class="e e-dim" d="M110,310 V326" marker-end="url(#emit-ah)"/>
+<path class="e e-dim" d="M110,378 V394" marker-end="url(#emit-ah)"/>
+<rect class="n" x="20" y="58" width="180" height="48" rx="10"/>
+<text class="t-code" x="110" y="83">orchestrate()</text>
+<rect class="n" x="20" y="126" width="180" height="48" rx="10"/>
+<text class="t-strong" x="110" y="151">state enter</text>
+<rect class="n" x="20" y="194" width="180" height="48" rx="10"/>
+<text class="t-strong" x="110" y="208">circuit breaker</text>
+<text class="t-mut" x="110" y="229">&middot; rate limiter</text>
+<rect class="n" x="20" y="262" width="180" height="48" rx="10"/>
+<text class="t-strong" x="110" y="276">task attempt</text>
+<text class="t-mut" x="110" y="297">inside the retry loop</text>
+<rect class="n" x="20" y="330" width="180" height="48" rx="10"/>
+<text class="t-strong" x="110" y="355">split &rarr; join</text>
+<rect class="n" x="20" y="398" width="180" height="48" rx="10"/>
+<text class="t-strong" x="110" y="412">exit state</text>
+<text class="t-mut" x="110" y="433">workflow returns</text>
+<circle class="n-hot" cx="556" cy="82" r="7"/>
+<circle class="n-hot" cx="556" cy="150" r="7"/>
+<circle class="n-hot" cx="556" cy="218" r="7"/>
+<circle class="n-hot" cx="556" cy="286" r="7"/>
+<circle class="n-hot" cx="556" cy="354" r="7"/>
+<circle class="n-hot" cx="556" cy="422" r="7"/>
+<rect class="n-cop" x="600" y="58" width="160" height="388" rx="12"/>
+<text class="t-strong" x="680" y="242">metrics facade</text>
+<text class="t-mut" x="680" y="264">&rarr; your recorder</text>
+<text class="t-mut" x="390" y="470">Dots mark emission points. Recovery, scheduler and poll/batch/step loop counters emit on the same rail.</text>
+<text class="t-mut" x="390" y="490">MetricsObserver supplies the state and retry counters; the rest is always-on engine instrumentation.</text>
+</svg>
+</div>
+</div>
+
 <div class="card-grid">
 <div class="card">
 <h3>Workflow</h3>

--- a/docs/content/observers/_index.md
+++ b/docs/content/observers/_index.md
@@ -99,6 +99,60 @@ Every method on <code>WorkflowObserver</code> has a default no-op body — overr
 ones you care about.
 </p>
 
+<div class="diagram-frame">
+<p class="diagram-label">One state of an observed run, and the hooks that end a run</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 554" role="img">
+<title>Hook order across one state: the engine reports on_state_enter and on_task_start, the first attempt fails so on_retry fires, the second attempt succeeds and on_task_success fires, a checkpoint is reported when a checkpoint store is attached, and entering the next state starts the cycle again.</title>
+<defs><marker id="obs-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<line class="lifeline" x1="120" y1="46" x2="120" y2="424"/>
+<line class="lifeline" x1="390" y1="46" x2="390" y2="424"/>
+<line class="lifeline" x1="650" y1="46" x2="650" y2="424"/>
+<rect class="n" x="50" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="120" y="28">Engine</text>
+<rect class="n" x="320" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="390" y="28">Task</text>
+<rect class="n-hot" x="560" y="8" width="180" height="38" rx="8"/>
+<text class="t-strong" x="650" y="28">WorkflowObserver</text>
+<path class="e" d="M120,80 H646" marker-end="url(#obs-ah)"/>
+<text class="t-code ta-s" x="136" y="68">on_state_enter("Load")</text>
+<path class="e" d="M120,114 H646" marker-end="url(#obs-ah)"/>
+<text class="t-code ta-s" x="136" y="102">on_task_start("load")</text>
+<path class="e" d="M120,148 H386" marker-end="url(#obs-ah)"/>
+<text class="t-mut ta-s" x="136" y="136">attempt 1</text>
+<path class="e e-dash" d="M390,182 H124" marker-end="url(#obs-ah)"/>
+<text class="t-code t-err ta-e" x="374" y="170">Err(CanoError)</text>
+<path class="e" d="M120,216 H646" marker-end="url(#obs-ah)"/>
+<text class="t-code t-warn ta-s" x="136" y="204">on_retry("load", 1)</text>
+<path class="e" d="M120,250 H386" marker-end="url(#obs-ah)"/>
+<text class="t-mut ta-s" x="136" y="238">attempt 2</text>
+<path class="e e-dash" d="M390,284 H124" marker-end="url(#obs-ah)"/>
+<text class="t-code t-ok ta-e" x="374" y="272">Ok(TaskResult)</text>
+<path class="e" d="M120,318 H646" marker-end="url(#obs-ah)"/>
+<text class="t-code t-ok ta-s" x="136" y="306">on_task_success("load")</text>
+<path class="e e-dash" d="M120,368 H646" marker-end="url(#obs-ah)"/>
+<text class="t-mut ta-s" x="136" y="336">only with a checkpoint store</text>
+<text class="t-code ta-s" x="136" y="354">on_checkpoint(id, seq)</text>
+<path class="e" d="M120,412 H646" marker-end="url(#obs-ah)"/>
+<text class="t-code ta-s" x="136" y="400">on_state_enter("Done")</text>
+<rect class="n-warn" x="12" y="442" width="180" height="38" rx="10"/>
+<text class="t-code t-warn" x="102" y="462">on_circuit_open</text>
+<text class="t-mut" x="102" y="494">breaker is open</text>
+<rect class="n-err" x="204" y="442" width="180" height="38" rx="10"/>
+<text class="t-code t-err" x="294" y="462">on_task_failure</text>
+<text class="t-mut" x="294" y="494">retries exhausted</text>
+<rect class="n-ghost" x="396" y="442" width="180" height="38" rx="10"/>
+<text class="t-code t-warn" x="486" y="462">on_cancelled</text>
+<text class="t-mut" x="486" y="494">token cancelled</text>
+<rect class="n-warn" x="588" y="442" width="180" height="38" rx="10"/>
+<text class="t-code t-warn" x="678" y="462">on_workflow_timeout</text>
+<text class="t-mut" x="678" y="494">total budget spent</text>
+<text class="t-mut" x="390" y="520">on_resume fires once at the start of resume_from; every other hook fires inside the run.</text>
+<text class="t-mut" x="390" y="540">All hooks are synchronous — they run inline on the workflow's task.</text>
+</svg>
+</div>
+</div>
+
 <div class="card-stack">
 <div class="card">
 <h3 id="on-state-enter"><a href="#on-state-enter" class="anchor-link" aria-hidden="true">#</a><code>on_state_enter(state: &amp;str)</code></h3>

--- a/docs/content/poll-task/_index.md
+++ b/docs/content/poll-task/_index.md
@@ -76,11 +76,23 @@ retry rarely makes sense, since the loop already keeps trying. For tolerating tr
 
 <div class="diagram-frame">
 <p class="diagram-label">The poll loop: poll &rarr; sleep &rarr; poll &hellip; until Ready</p>
-<div class="mermaid">
-graph LR
-A[poll] -->|"Pending { delay_ms }"| B[sleep delay_ms]
-B --> A
-A -->|"Ready(result)"| C[Next State]
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 720 196" role="img">
+<title>The poll loop: poll returns Pending with a delay, the engine sleeps that long and polls again; Ready(result) moves the workflow to the next state.</title>
+<defs><marker id="poll-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e e-hot" d="M100,58 V32 Q100,24 108,24 H617 Q625,24 625,32 V53" marker-end="url(#poll-ah)"/>
+<text class="t-code t-hot" x="362" y="41">Ready(result)</text>
+<rect class="n-hot" x="40" y="58" width="120" height="46" rx="10"/>
+<text class="t-strong" x="100" y="82">poll</text>
+<rect class="n" x="330" y="58" width="170" height="46" rx="10"/>
+<text x="415" y="82">sleep delay_ms</text>
+<rect class="n-ok" x="560" y="58" width="130" height="46" rx="10"/>
+<text x="625" y="82">Next State</text>
+<path class="e" d="M160,81 H326" marker-end="url(#poll-ah)"/>
+<text class="t-code t-mut" x="243" y="64">Pending { delay_ms }</text>
+<path class="e e-dim" d="M415,104 V138 Q415,146 407,146 H108 Q100,146 100,138 V107" marker-end="url(#poll-ah)"/>
+<text class="t-mut" x="257" y="162">repeat until Ready</text>
+</svg>
 </div>
 </div>
 

--- a/docs/content/recovery/_index.md
+++ b/docs/content/recovery/_index.md
@@ -142,6 +142,52 @@ sequence order" — which is exactly what <code>CheckpointStore::load_run</code>
 <code>Workflow::resume_from(workflow_id)</code> loads the run via <code>load_run</code> and routes by
 each row's <code>kind</code>:
 </p>
+
+<div class="diagram-frame">
+<p class="diagram-label">Run 1 appends a row per state and crashes; run 2 resumes from the last row</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 566" role="img">
+<title>A run appends one StateEntry row per state entered, before that state's task runs; the process crashes mid-Work, and resume_from loads the log, re-enters at the highest-sequence row's state and continues the same sequence.</title>
+<defs><marker id="rec-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<line class="lifeline" x1="150" y1="46" x2="150" y2="206"/>
+<line class="lifeline" x1="400" y1="46" x2="400" y2="526"/>
+<line class="lifeline" x1="650" y1="46" x2="650" y2="526"/>
+<rect class="band" x="142" y="94" width="16" height="34" rx="5"/>
+<rect class="band" x="142" y="162" width="16" height="32" rx="5"/>
+<rect class="band" x="642" y="462" width="16" height="30" rx="5"/>
+<rect class="n" x="70" y="8" width="160" height="38" rx="8"/>
+<text class="t-strong" x="150" y="28">Engine (run 1)</text>
+<rect class="n-cop" x="315" y="8" width="170" height="38" rx="8"/>
+<text class="t-strong" x="400" y="28">CheckpointStore</text>
+<rect class="n" x="570" y="8" width="160" height="38" rx="8"/>
+<text class="t-strong" x="650" y="28">Engine (run 2)</text>
+<path class="e" d="M154,82 H396" marker-end="url(#rec-ah)"/>
+<text class="t-code" x="275" y="70">append #0 · StateEntry · Start</text>
+<text class="t-mut ta-e" x="134" y="112">StartTask runs</text>
+<path class="e" d="M154,150 H396" marker-end="url(#rec-ah)"/>
+<text class="t-code" x="275" y="138">append #1 · StateEntry · Work</text>
+<text class="t-mut ta-e" x="134" y="179">WorkTask starts</text>
+<text class="t-strong t-err" x="150" y="226">✗ crash</text>
+<text class="t-mut" x="150" y="244">process dies mid-WorkTask</text>
+<text class="t-mut ta-s" x="414" y="234">rows #0&ndash;#1 are durable</text>
+<rect class="n" x="550" y="252" width="200" height="40" rx="10"/>
+<text class="t-code" x="650" y="273">resume_from("run-42")</text>
+<path class="e" d="M646,322 H404" marker-end="url(#rec-ah)"/>
+<text class="t-code" x="525" y="310">load_run("run-42")</text>
+<path class="e e-dash" d="M404,356 H646" marker-end="url(#rec-ah)"/>
+<text class="t-code t-mut" x="525" y="344">[#0 Start, #1 Work]</text>
+<rect class="n-hot" x="542" y="374" width="216" height="48" rx="10"/>
+<text class="t-strong" x="650" y="390">re-enter at Work</text>
+<text class="t-mut" x="650" y="407">last StateEntry row wins</text>
+<path class="e" d="M646,452 H404" marker-end="url(#rec-ah)"/>
+<text class="t-code" x="525" y="440">append #2 · StateEntry · Work</text>
+<text class="t-mut t-warn ta-e" x="634" y="478">WorkTask re-runs &mdash; idempotent</text>
+<path class="e" d="M646,512 H404" marker-end="url(#rec-ah)"/>
+<text class="t-code" x="525" y="500">append #3 · StateEntry · Done</text>
+<text class="t-mut" x="390" y="546">Every row is appended before its task runs, so the resumed state runs again.</text>
+</svg>
+</div>
+</div>
 <ul>
 <li><code>StateEntry</code> rows drive the <strong>state replay</strong> — it takes the highest-<code>sequence</code>
 <code>StateEntry</code> row, maps its label back to a state, and re-enters the FSM loop from there,
@@ -218,6 +264,34 @@ compares the highest-sequence row's <code>workflow_version</code> against
 runs. A mismatch returns <code>CanoError::WorkflowVersionMismatch { stored, expected }</code>
 immediately — no task re-runs, no partial side effects.
 </p>
+
+<div class="diagram-frame">
+<p class="diagram-label">The <code>workflow_version</code> gate on <code>resume_from</code></p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 250" role="img">
+<title>On resume_from the engine compares the highest-sequence row's workflow_version with the version configured on this workflow: equal versions resume the run, a mismatch returns WorkflowVersionMismatch before any state is re-entered.</title>
+<defs><marker id="recver-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e" d="M170,113 H246" marker-end="url(#recver-ah)"/>
+<text class="t-mut" x="208" y="101">latest row</text>
+<path class="e" d="M480,104 H492 Q500,104 500,96 V58 Q500,50 508,50 H516" marker-end="url(#recver-ah)"/>
+<text class="t-mut t-ok ta-e" x="492" y="76">equal</text>
+<path class="e" d="M480,122 H492 Q500,122 500,130 V168 Q500,176 508,176 H516" marker-end="url(#recver-ah)"/>
+<text class="t-mut t-err ta-e" x="492" y="158">differs</text>
+<rect class="n" x="20" y="90" width="150" height="46" rx="10"/>
+<text class="t-code" x="95" y="114">resume_from(id)</text>
+<rect class="n-hot" x="250" y="84" width="230" height="58" rx="10"/>
+<text class="t-strong" x="365" y="105">workflow_version gate</text>
+<text class="t-code t-mut" x="365" y="123">stored vs expected</text>
+<rect class="n-ok" x="520" y="22" width="240" height="56" rx="10"/>
+<text class="t-strong" x="640" y="41">resume the run</text>
+<text class="t-mut" x="640" y="59">re-enter at the last state</text>
+<rect class="n-err" x="520" y="148" width="240" height="56" rx="10"/>
+<text class="t-strong" x="640" y="167">refuse the resume</text>
+<text class="t-code t-err" x="640" y="185">WorkflowVersionMismatch</text>
+<text class="t-mut" x="390" y="232">The check runs before any state is re-entered &mdash; no task re-runs, no partial side effects.</text>
+</svg>
+</div>
+</div>
 
 <p>
 <strong>Operator guidance:</strong> bump the version whenever a deploy changes the FSM in a way

--- a/docs/content/resilience/_index.md
+++ b/docs/content/resilience/_index.md
@@ -159,6 +159,55 @@ Lifecycle Events</a> for the full hook reference.
 </p>
 
 <h3 id="workflow-total-timeout-vs"><a href="#workflow-total-timeout-vs" class="anchor-link" aria-hidden="true">#</a>The two timeout knobs</h3>
+<div class="diagram-frame">
+<p class="diagram-label">Two knobs, two scopes — the total budget wins</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 232" role="img">
+<title>A workflow with a 7 second total budget: State A finishes in 1s, then State B retries three times under a 2 second per-attempt timeout — attempts 1 and 2 each blow their own deadline and are retried, and the total budget fires at 7s, aborting attempt 3 mid-flight before its own 8s deadline could.</title>
+<path class="e e-dim e-dash" d="M664,34 V148"/>
+<text class="t-code t-err" x="664" y="22">WorkflowTimeout</text>
+<text class="t-strong ta-s" x="16" y="54">Total budget</text>
+<rect class="band" x="132" y="40" width="532" height="26" rx="6"/>
+<text class="t-code t-mut" x="398" y="54">with_total_timeout(7s)</text>
+<text class="t-strong ta-s" x="16" y="108">Workflow</text>
+<text class="t-code t-err" x="360" y="80">Timeout</text>
+<text class="t-code t-err" x="550" y="80">Timeout</text>
+<text class="t-mut" x="626" y="80">attempt 3</text>
+<text class="t-mut t-warn" x="702" y="80">cut short</text>
+<rect class="band-hot" x="132" y="94" width="76" height="26" rx="6"/>
+<text class="t-mut" x="170" y="108">State A</text>
+<rect class="band-hot" x="208" y="94" width="152" height="26" rx="6"/>
+<text class="t-mut" x="284" y="108">attempt 1</text>
+<rect class="band" x="360" y="94" width="38" height="26" rx="6"/>
+<rect class="band-hot" x="398" y="94" width="152" height="26" rx="6"/>
+<text class="t-mut" x="474" y="108">attempt 2</text>
+<rect class="band" x="550" y="94" width="38" height="26" rx="6"/>
+<rect class="band-hot" x="588" y="94" width="76" height="26" rx="6"/>
+<rect class="n-ghost" x="664" y="94" width="76" height="26" rx="6"/>
+<line class="axis" x1="132" y1="140" x2="740" y2="140"/>
+<line class="tick" x1="132" y1="140" x2="132" y2="146"/>
+<line class="tick" x1="208" y1="140" x2="208" y2="146"/>
+<line class="tick" x1="284" y1="140" x2="284" y2="146"/>
+<line class="tick" x1="360" y1="140" x2="360" y2="146"/>
+<line class="tick" x1="436" y1="140" x2="436" y2="146"/>
+<line class="tick" x1="512" y1="140" x2="512" y2="146"/>
+<line class="tick" x1="588" y1="140" x2="588" y2="146"/>
+<line class="tick" x1="664" y1="140" x2="664" y2="146"/>
+<line class="tick" x1="740" y1="140" x2="740" y2="146"/>
+<text class="t-mut" x="132" y="164">0s</text>
+<text class="t-mut" x="208" y="164">1s</text>
+<text class="t-mut" x="284" y="164">2s</text>
+<text class="t-mut" x="360" y="164">3s</text>
+<text class="t-mut" x="436" y="164">4s</text>
+<text class="t-mut" x="512" y="164">5s</text>
+<text class="t-mut" x="588" y="164">6s</text>
+<text class="t-mut" x="664" y="164">7s</text>
+<text class="t-mut" x="740" y="164">8s</text>
+<text class="t-mut" x="436" y="192">attempt_timeout(2s) fires twice and is retried; the 7s budget then aborts attempt 3 mid-flight</text>
+<text class="t-mut" x="436" y="210">the total budget wins — no retry policy can outlive it</text>
+</svg>
+</div>
+</div>
 <table class="styled-table">
 <thead><tr><th>API</th><th>Scope</th><th>On expiry</th><th>Compensation drain</th></tr></thead>
 <tbody>
@@ -316,6 +365,55 @@ demo: <code>cargo run --example scheduler_backoff --features scheduler</code>).
 <p>
 These stack cleanly. A typical "talk to a flaky external service" state:
 </p>
+<div class="diagram-frame">
+<p class="diagram-label">One dispatch, four nested layers — and the CanoError each one surfaces</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 392" role="img">
+<title>One task dispatch passes through four nested layers: the workflow total timeout wraps the retry loop, the retry loop checks the circuit breaker before each attempt, and the per-attempt timeout wraps the attempt — your task body, where the rate limiter permit is taken before the upstream call. An open breaker leaves immediately with CircuitOpen; a Timeout or RateLimited is retried; exhausting the attempts returns RetryExhausted.</title>
+<defs><marker id="layers-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<rect class="n-ghost" x="22" y="12" width="736" height="278" rx="14"/>
+<text class="t-strong ta-s" x="36" y="34">Workflow total timeout</text>
+<text class="t-code t-mut ta-s" x="228" y="34">timeout_at(start + limit)</text>
+<text class="t-code t-err ta-s" x="432" y="34">→ WorkflowTimeout</text>
+<text class="t-mut ta-s" x="572" y="34">aborts mid-flight</text>
+<rect class="n-ghost" x="44" y="48" width="700" height="222" rx="12"/>
+<text class="t-strong ta-s" x="58" y="70">retry loop</text>
+<text class="t-code t-mut ta-s" x="152" y="70">run_with_retries — attempts 1..max_attempts</text>
+<rect class="n-ghost" x="280" y="84" width="444" height="112" rx="12"/>
+<text class="t-code t-mut ta-s" x="298" y="104">tokio::time::timeout(attempt_timeout)</text>
+<text class="t-mut ta-e" x="712" y="104">your task body</text>
+<circle class="n" cx="10" cy="151" r="5"/>
+<path class="e" d="M17,151 H64" marker-end="url(#layers-ah)"/>
+<path class="e" d="M240,151 H300" marker-end="url(#layers-ah)"/>
+<path class="e" d="M480,151 H516" marker-end="url(#layers-ah)"/>
+<path class="e e-dim" d="M502,196 V238 Q502,246 494,246 H162 Q154,246 154,238 V182" marker-end="url(#layers-ah)"/>
+<text class="t-code t-err" x="328" y="212">Timeout · RateLimited · any task Err</text>
+<text class="t-mut" x="328" y="234">retried per RetryMode, then a backoff sleep</text>
+<path class="e" d="M110,178 V308" marker-end="url(#layers-ah)"/>
+<path class="e" d="M305,246 V308" marker-end="url(#layers-ah)"/>
+<path class="e e-hot" d="M610,178 V308" marker-end="url(#layers-ah)"/>
+<text class="t-mut t-hot ta-s" x="622" y="250">success</text>
+<rect class="n" x="68" y="124" width="172" height="54" rx="10"/>
+<text class="t-strong" x="154" y="145">circuit breaker</text>
+<text class="t-code t-mut" x="154" y="165">try_acquire()</text>
+<rect class="n" x="304" y="124" width="176" height="54" rx="10"/>
+<text class="t-strong" x="392" y="145">rate limiter</text>
+<text class="t-code t-mut" x="392" y="165">acquire()</text>
+<rect class="n-hot" x="520" y="124" width="180" height="54" rx="10"/>
+<text class="t-strong" x="610" y="145">upstream call</text>
+<text class="t-mut" x="610" y="165">the flaky thing</text>
+<rect class="n-err" x="30" y="312" width="160" height="44" rx="10"/>
+<text class="t-code" x="110" y="335">CircuitOpen</text>
+<text class="t-mut" x="110" y="374">no attempt, no retry burned</text>
+<rect class="n-err" x="220" y="312" width="170" height="44" rx="10"/>
+<text class="t-code" x="305" y="335">RetryExhausted</text>
+<text class="t-mut" x="305" y="374">after max_attempts</text>
+<rect class="n-ok" x="530" y="312" width="160" height="44" rx="10"/>
+<text class="t-code" x="610" y="335">Ok(next state)</text>
+<text class="t-mut" x="610" y="374">workflow advances</text>
+</svg>
+</div>
+</div>
 <ul>
 <li><strong>Circuit breaker</strong> (shared across every task hitting that service) — bail fast when it's down.</li>
 <li><strong>Rate limiter</strong> (also shared) — stay under the service's quota when it's up.</li>

--- a/docs/content/resilience/circuit-breakers.md
+++ b/docs/content/resilience/circuit-breakers.md
@@ -46,13 +46,34 @@ acquires from split tasks are safe.
 <h3 id="cb-state-machine"><a href="#cb-state-machine" class="anchor-link" aria-hidden="true">#</a>The state machine</h3>
 <div class="diagram-frame">
 <p class="diagram-label">CircuitBreaker state machine</p>
-<div class="mermaid">
-stateDiagram-v2
-    [*] --> Closed
-    Closed --> Open: failure_threshold consecutive failures
-    Open --> HalfOpen: reset_timeout elapsed (lazy, on next acquire)
-    HalfOpen --> Closed: half_open_max_calls consecutive successes
-    HalfOpen --> Open: any failure (fresh cool-down)
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 740 316" role="img">
+<title>CircuitBreaker state machine: Closed trips to Open after failure_threshold consecutive failures; Open becomes HalfOpen lazily once reset_timeout has elapsed; HalfOpen closes after half_open_max_calls consecutive successes, or re-opens with a fresh cool-down on any failure.</title>
+<defs><marker id="cb-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<circle class="n" cx="24" cy="85" r="5"/>
+<path class="e" d="M31,85 H44" marker-end="url(#cb-ah)"/>
+<path class="e" d="M244,85 H484" marker-end="url(#cb-ah)"/>
+<text class="t-code t-mut" x="364" y="58">failure_threshold</text>
+<text class="t-mut" x="364" y="74">consecutive failures</text>
+<path class="e e-dash" d="M572,114 V228" marker-end="url(#cb-ah)"/>
+<text class="t-code t-mut ta-e" x="558" y="158">reset_timeout</text>
+<text class="t-mut ta-e" x="558" y="174">elapsed — lazy, on next acquire</text>
+<path class="e" d="M600,232 V118" marker-end="url(#cb-ah)"/>
+<text class="t-mut ta-s" x="612" y="158">any failure</text>
+<text class="t-mut ta-s" x="612" y="174">fresh cool-down</text>
+<path class="e e-hot" d="M488,261 H154 Q146,261 146,253 V118" marker-end="url(#cb-ah)"/>
+<text class="t-code t-hot" x="320" y="232">half_open_max_calls</text>
+<text class="t-mut t-hot" x="320" y="248">consecutive successes → close</text>
+<rect class="n-ok" x="48" y="56" width="196" height="58" rx="12"/>
+<text class="t-strong" x="146" y="81">Closed</text>
+<text class="t-mut" x="146" y="101">calls flow through</text>
+<rect class="n-err" x="488" y="56" width="196" height="58" rx="12"/>
+<text class="t-strong" x="586" y="81">Open { until }</text>
+<text class="t-code t-mut" x="586" y="101">CircuitOpen · no call</text>
+<rect class="n-warn" x="488" y="232" width="196" height="58" rx="12"/>
+<text class="t-strong" x="586" y="257">HalfOpen</text>
+<text class="t-mut" x="586" y="277">trial calls admitted</text>
+</svg>
 </div>
 </div>
 <p>

--- a/docs/content/resilience/rate-limiting.md
+++ b/docs/content/resilience/rate-limiting.md
@@ -42,6 +42,51 @@ no background task. Every acquire reads a single <code>Instant</code>, adds
 builds a limiter pays nothing. The bucket starts <strong>full</strong>, so a burst of up to
 <code>capacity</code> calls is admitted instantly before sustained traffic settles to the refill rate.
 </p>
+<div class="diagram-frame">
+<p class="diagram-label">A full bucket admits an instant burst, then the refill paces the rest</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 288" role="img">
+<title>Nine calls arrive at once against a per_second(5) bucket: the first five are admitted instantly because the bucket starts full, and calls six through nine park on acquire until the lazy refill hands them a token every 200 milliseconds.</title>
+<text class="t-code t-mut ta-s" x="16" y="20">RateLimiterPolicy::per_second(5)</text>
+<text class="t-strong ta-s" x="16" y="72">admitted</text>
+<text class="t-mut t-hot" x="147" y="46">#1–#5</text>
+<text class="t-mut" x="260" y="46">#6</text>
+<text class="t-mut" x="380" y="46">#7</text>
+<text class="t-mut" x="500" y="46">#8</text>
+<text class="t-mut" x="620" y="46">#9</text>
+<rect class="band-hot" x="132" y="58" width="30" height="26" rx="6"/>
+<rect class="band-hot" x="253" y="58" width="14" height="26" rx="4"/>
+<rect class="band-hot" x="373" y="58" width="14" height="26" rx="4"/>
+<rect class="band-hot" x="493" y="58" width="14" height="26" rx="4"/>
+<rect class="band-hot" x="613" y="58" width="14" height="26" rx="4"/>
+<text class="t-strong ta-s" x="16" y="126">parked</text>
+<text class="t-code t-mut ta-s" x="16" y="146">acquire()</text>
+<rect class="band" x="132" y="98" width="121" height="14" rx="4"/>
+<rect class="band" x="132" y="118" width="241" height="14" rx="4"/>
+<rect class="band" x="132" y="138" width="361" height="14" rx="4"/>
+<rect class="band" x="132" y="158" width="481" height="14" rx="4"/>
+<text class="t-mut ta-s" x="261" y="109">#6 · 200ms</text>
+<text class="t-mut ta-s" x="381" y="129">#7 · 400ms</text>
+<text class="t-mut ta-s" x="501" y="149">#8 · 600ms</text>
+<text class="t-mut ta-s" x="621" y="169">#9 · 800ms</text>
+<line class="axis" x1="132" y1="196" x2="740" y2="196"/>
+<line class="tick" x1="132" y1="196" x2="132" y2="202"/>
+<line class="tick" x1="260" y1="196" x2="260" y2="202"/>
+<line class="tick" x1="380" y1="196" x2="380" y2="202"/>
+<line class="tick" x1="500" y1="196" x2="500" y2="202"/>
+<line class="tick" x1="620" y1="196" x2="620" y2="202"/>
+<line class="tick" x1="740" y1="196" x2="740" y2="202"/>
+<text class="t-mut" x="132" y="218">0</text>
+<text class="t-mut" x="260" y="218">200ms</text>
+<text class="t-mut" x="380" y="218">400ms</text>
+<text class="t-mut" x="500" y="218">600ms</text>
+<text class="t-mut" x="620" y="218">800ms</text>
+<text class="t-mut" x="740" y="218">1s</text>
+<text class="t-mut" x="436" y="246">the bucket starts full: 5 calls admitted instantly, then one token every 200ms</text>
+<text class="t-mut" x="436" y="264">try_acquire() would return None for #6–#9 instead of parking</text>
+</svg>
+</div>
+</div>
 <p>
 Like a breaker, a limiter is cheap to clone (it's an <code>Arc</code> inside) — <strong>share one
 <code>Arc&lt;RateLimiter&gt;</code> across every task that draws on the same quota</strong> so the budget
@@ -80,6 +125,40 @@ available (and consumes it), <code>None</code> if the bucket is empty. Use it to
 the next token refills, <code>tokio::time::sleep</code>s that long, and retries. Use it to <em>pace</em>
 work.</li>
 </ul>
+<div class="diagram-frame">
+<p class="diagram-label">One acquisition: lazy refill, then shed or park</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 294" role="img">
+<title>Every acquisition first refills the bucket lazily from the clock, then checks whether it holds enough tokens: if so it debits them and returns a Permit; if not, try_acquire returns None to shed the call while acquire sleeps for exactly the computed refill time and re-checks.</title>
+<defs><marker id="acq-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<circle class="n" cx="10" cy="71" r="5"/>
+<path class="e" d="M17,71 H40" marker-end="url(#acq-ah)"/>
+<path class="e" d="M264,71 H294" marker-end="url(#acq-ah)"/>
+<path class="e e-hot" d="M468,71 H556" marker-end="url(#acq-ah)"/>
+<text class="t-mut t-hot" x="512" y="58">yes</text>
+<path class="e" d="M383,98 V128 Q383,136 375,136 H278 Q270,136 270,144 V166" marker-end="url(#acq-ah)"/>
+<path class="e" d="M383,98 V128 Q383,136 391,136 H556 Q564,136 564,144 V166" marker-end="url(#acq-ah)"/>
+<text class="t-mut ta-s" x="395" y="116">no — bucket short</text>
+<path class="e e-dim" d="M564,224 V248 Q564,256 556,256 H162 Q154,256 154,248 V102" marker-end="url(#acq-ah)"/>
+<text class="t-mut" x="359" y="274">recompute the wait, re-check — best-effort wakeups, no queue</text>
+<rect class="n-hot" x="44" y="44" width="220" height="54" rx="10"/>
+<text class="t-strong" x="154" y="65">lazy refill</text>
+<text class="t-code t-mut" x="154" y="85">elapsed × refill_per_sec</text>
+<rect class="n" x="298" y="44" width="170" height="54" rx="10"/>
+<text class="t-strong" x="383" y="65">enough tokens?</text>
+<text class="t-code t-mut" x="383" y="85">tokens &gt;= cost</text>
+<rect class="n-ok" x="560" y="44" width="190" height="54" rx="10"/>
+<text class="t-strong" x="655" y="65">Permit</text>
+<text class="t-code t-mut" x="655" y="85">tokens -= cost</text>
+<rect class="n-warn" x="170" y="170" width="200" height="54" rx="10"/>
+<text class="t-code" x="270" y="191">try_acquire() → None</text>
+<text class="t-mut" x="270" y="211">shed the call</text>
+<rect class="n" x="440" y="170" width="248" height="54" rx="10"/>
+<text class="t-code" x="564" y="191">acquire(): sleep(time_until)</text>
+<text class="t-mut" x="564" y="211">park until a token refills</text>
+</svg>
+</div>
+</div>
 <p>
 The returned <code>Permit</code> is a lightweight RAII marker for the call's scope. Unlike a
 <a href="../circuit-breakers/#cb-permits">circuit-breaker permit</a> (which records a success/failure outcome) or a semaphore

--- a/docs/content/resources/_index.md
+++ b/docs/content/resources/_index.md
@@ -47,6 +47,56 @@ Define a resource, register it, retrieve it by typed key in any task. The engine
 <code>setup</code> / <code>teardown</code> automatically.
 </p>
 
+<div class="diagram-frame">
+<p class="diagram-label">insert(key, value) at build time &rarr; res.get::&lt;R, _&gt;(key) inside tasks</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 316" role="img">
+<title>Resources is a typed map: every build-time insert stores one value under a key, and inside a task res.get names both the key and the resource type to pull an Arc handle back out, so one entry can be handed to several tasks.</title>
+<defs><marker id="res-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<text class="t-strong" x="107" y="24">Build time</text>
+<text class="t-code t-mut" x="107" y="43">.insert(key, value)</text>
+<text class="t-strong" x="386" y="24">Typed map</text>
+<text class="t-code t-mut" x="386" y="43">Resources::&lt;Key&gt;::new()</text>
+<text class="t-strong" x="669" y="24">In tasks</text>
+<text class="t-code t-mut" x="669" y="43">res.get::&lt;R, _&gt;(key)?</text>
+<path class="e" d="M200,96 H262" marker-end="url(#res-ah)"/>
+<path class="e" d="M200,166 H262" marker-end="url(#res-ah)"/>
+<path class="e" d="M200,236 H262" marker-end="url(#res-ah)"/>
+<path class="e e-hot" d="M506,96 H572" marker-end="url(#res-ah)"/>
+<path class="e e-hot" d="M506,108 H524 Q536,108 536,120 V133 Q536,145 548,145 H572" marker-end="url(#res-ah)"/>
+<path class="e" d="M506,166 H572" marker-end="url(#res-ah)"/>
+<path class="e" d="M506,236 H572" marker-end="url(#res-ah)"/>
+<rect class="n" x="14" y="72" width="186" height="48" rx="10"/>
+<text class="t-code" x="107" y="87">Key::Store</text>
+<text class="t-code t-mut" x="107" y="107">MemoryStore::new()</text>
+<rect class="n" x="14" y="142" width="186" height="48" rx="10"/>
+<text class="t-code" x="107" y="157">Key::Config</text>
+<text class="t-code t-mut" x="107" y="177">AppConfig { .. }</text>
+<rect class="n" x="14" y="212" width="186" height="48" rx="10"/>
+<text class="t-code" x="107" y="227">Key::Params</text>
+<text class="t-code t-mut" x="107" y="247">WorkflowParams { .. }</text>
+<rect class="n-cop" x="266" y="56" width="240" height="216" rx="12"/>
+<rect class="n-hot" x="282" y="76" width="208" height="40" rx="6"/>
+<text class="t-code" x="386" y="97">Store &rarr; MemoryStore</text>
+<rect class="n" x="282" y="146" width="208" height="40" rx="6"/>
+<text class="t-code" x="386" y="167">Config &rarr; AppConfig</text>
+<rect class="n" x="282" y="216" width="208" height="40" rx="6"/>
+<text class="t-code" x="386" y="237">Params &rarr; WorkflowParams</text>
+<rect class="n" x="576" y="69" width="186" height="54" rx="10"/>
+<text class="t-strong" x="669" y="86">InitTask</text>
+<text class="t-code t-mut" x="669" y="108">Arc&lt;MemoryStore&gt;</text>
+<rect class="n" x="576" y="133" width="186" height="66" rx="10"/>
+<text class="t-strong" x="669" y="149">ProcessTask</text>
+<text class="t-code t-mut" x="669" y="169">Arc&lt;MemoryStore&gt;</text>
+<text class="t-code t-mut" x="669" y="186">Arc&lt;AppConfig&gt;</text>
+<rect class="n" x="576" y="209" width="186" height="54" rx="10"/>
+<text class="t-strong" x="669" y="226">ReportTask</text>
+<text class="t-code t-mut" x="669" y="248">Arc&lt;WorkflowParams&gt;</text>
+<text class="t-mut" x="390" y="296">One entry, many readers: get matches on both key and type, and returns an Arc clone.</text>
+</svg>
+</div>
+</div>
+
 <div class="code-block">
 <span class="code-block-label"><span class="label-icon">&#9889;</span> End-to-end example</span>
 

--- a/docs/content/resources/lifecycle-and-concurrency.md
+++ b/docs/content/resources/lifecycle-and-concurrency.md
@@ -29,21 +29,59 @@ and concurrency guarantees.
 
 <div class="diagram-frame">
 <p class="diagram-label">setup_all() in FIFO order; teardown in LIFO order</p>
-<div class="mermaid">
-sequenceDiagram
-participant E as Engine
-participant R0 as Resource A
-participant R1 as Resource B
-participant R2 as Resource C
-Note over E: setup_all() — FIFO
-E->>R0: setup()
-E->>R1: setup()
-E->>R2: setup()
-Note over E: execute_workflow()
-Note over E: teardown_range(all) — LIFO
-E->>R2: teardown()
-E->>R1: teardown()
-E->>R0: teardown()
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 750 496" role="img">
+<title>The engine calls setup() on resources in insertion order (FIFO) and teardown() in exactly the reverse order (LIFO), so each resource's live span nests inside the spans of the resources set up before it.</title>
+<defs><marker id="life-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<line class="lifeline" x1="110" y1="46" x2="110" y2="458"/>
+<line class="lifeline" x1="300" y1="46" x2="300" y2="458"/>
+<line class="lifeline" x1="480" y1="46" x2="480" y2="458"/>
+<line class="lifeline" x1="660" y1="46" x2="660" y2="458"/>
+<rect class="band" x="295" y="126" width="10" height="316" rx="5"/>
+<rect class="band" x="475" y="170" width="10" height="228" rx="5"/>
+<rect class="band" x="655" y="214" width="10" height="140" rx="5"/>
+<rect class="n" x="50" y="8" width="120" height="38" rx="8"/>
+<text class="t-strong" x="110" y="28">Engine</text>
+<rect class="n" x="235" y="8" width="130" height="38" rx="8"/>
+<text class="t-strong" x="300" y="28">Resource A</text>
+<rect class="n" x="415" y="8" width="130" height="38" rx="8"/>
+<text class="t-strong" x="480" y="28">Resource B</text>
+<rect class="n" x="595" y="8" width="130" height="38" rx="8"/>
+<text class="t-strong" x="660" y="28">Resource C</text>
+<rect class="n" x="22" y="58" width="176" height="44" rx="10"/>
+<text class="t-code" x="110" y="72">setup_all()</text>
+<text class="t-strong" x="110" y="89">FIFO order</text>
+<path class="e" d="M124,126 H293" marker-end="url(#life-ah)"/>
+<text class="t-code ta-s" x="142" y="113">setup()</text>
+<circle class="n" cx="110" cy="126" r="10"/>
+<text class="t-mut" x="110" y="127">1</text>
+<path class="e" d="M124,170 H473" marker-end="url(#life-ah)"/>
+<text class="t-code ta-s" x="142" y="157">setup()</text>
+<circle class="n" cx="110" cy="170" r="10"/>
+<text class="t-mut" x="110" y="171">2</text>
+<path class="e" d="M124,214 H653" marker-end="url(#life-ah)"/>
+<text class="t-code ta-s" x="142" y="201">setup()</text>
+<circle class="n" cx="110" cy="214" r="10"/>
+<text class="t-mut" x="110" y="215">3</text>
+<rect class="n" x="22" y="238" width="176" height="34" rx="10"/>
+<text class="t-code" x="110" y="256">execute_workflow()</text>
+<rect class="n-hot" x="22" y="286" width="176" height="44" rx="10"/>
+<text class="t-code" x="110" y="300">teardown_range(all)</text>
+<text class="t-strong t-hot" x="110" y="317">LIFO order</text>
+<path class="e" d="M124,354 H653" marker-end="url(#life-ah)"/>
+<text class="t-code ta-s" x="142" y="341">teardown()</text>
+<circle class="n" cx="110" cy="354" r="10"/>
+<text class="t-mut" x="110" y="355">4</text>
+<path class="e" d="M124,398 H473" marker-end="url(#life-ah)"/>
+<text class="t-code ta-s" x="142" y="385">teardown()</text>
+<circle class="n" cx="110" cy="398" r="10"/>
+<text class="t-mut" x="110" y="399">5</text>
+<path class="e" d="M124,442 H293" marker-end="url(#life-ah)"/>
+<text class="t-code ta-s" x="142" y="429">teardown()</text>
+<circle class="n" cx="110" cy="442" r="10"/>
+<text class="t-mut" x="110" y="443">6</text>
+<text class="t-mut" x="375" y="478">Bars mark each resource's live span — they nest, so teardown mirrors setup exactly.</text>
+</svg>
 </div>
 </div>
 

--- a/docs/content/router-task/_index.md
+++ b/docs/content/router-task/_index.md
@@ -56,6 +56,41 @@ to an inherent <code>impl</code> block — the macro synthesises the
 <code>register</code> if you ever want the checkpoint-recording behaviour back.
 </p>
 
+<div class="diagram-frame">
+<p class="diagram-label">route() reads, decides, and returns &mdash; nothing else</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 330" role="img">
+<title>A router dispatch: the Classify state calls route(&amp;Resources), which reads the config out of Resources without writing anything and returns TaskResult::Single — Step::FastPath when the flag is set, Step::SlowPath otherwise; because the decision has no side effects the engine writes no CheckpointRow for the state.</title>
+<defs><marker id="route-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e" d="M393,70 V112" marker-end="url(#route-ah)"/>
+<text class="t-mut ta-e" x="383" y="93">reads, never writes</text>
+<path class="e" d="M156,143 H296" marker-end="url(#route-ah)"/>
+<text class="t-code t-mut" x="226" y="127">register_router</text>
+<path class="e" d="M486,143 H536 Q544,143 544,135 V75 Q544,67 552,67 H586" marker-end="url(#route-ah)"/>
+<text class="t-code t-mut ta-s" x="554" y="110">Single(Step::FastPath)</text>
+<path class="e" d="M486,143 H536 Q544,143 544,151 V211 Q544,219 552,219 H586" marker-end="url(#route-ah)"/>
+<text class="t-code t-mut ta-s" x="554" y="176">Single(Step::SlowPath)</text>
+<path class="e e-dash e-dim" d="M393,170 V248" marker-end="url(#route-ah)"/>
+<text class="t-mut ta-s" x="403" y="205">no side effects</text>
+<rect class="n-cop" x="298" y="16" width="190" height="54" rx="10"/>
+<text class="t-strong" x="393" y="34">Resources</text>
+<text class="t-code" x="393" y="53">config.use_fast_path</text>
+<rect class="n" x="16" y="120" width="140" height="46" rx="10"/>
+<text class="t-code" x="86" y="144">Step::Classify</text>
+<rect class="n-hot" x="300" y="116" width="186" height="54" rx="10"/>
+<text class="t-code t-strong" x="393" y="134">route(&amp;Resources)</text>
+<text class="t-code t-mut" x="393" y="153">&#8594; TaskResult&lt;Step&gt;</text>
+<rect class="n" x="590" y="44" width="170" height="46" rx="10"/>
+<text class="t-code" x="675" y="68">Step::FastPath</text>
+<rect class="n" x="590" y="196" width="170" height="46" rx="10"/>
+<text class="t-code" x="675" y="220">Step::SlowPath</text>
+<rect class="n-ghost" x="298" y="252" width="190" height="54" rx="10"/>
+<text class="t-code t-warn" x="393" y="270">CheckpointRow</text>
+<text class="t-mut t-warn" x="393" y="289">no row, no sequence</text>
+</svg>
+</div>
+</div>
+
 <div class="code-block">
 <span class="code-block-label"><span class="label-icon">&#9889;</span> Inference form — <code>#[task::router(state = ...)]</code> on an inherent impl</span>
 
@@ -85,12 +120,14 @@ impl Classifier {
 ```
 </div>
 
-<div class="callout callout-tip">
-<div class="callout-label">Tip</div>
+<div class="callout callout-warning">
+<div class="callout-label">Heads-up</div>
 <p>
-<code>route</code> may return <code>TaskResult::Split</code> as well as <code>TaskResult::Single</code>,
-so a router can fan a workflow out into parallel states. See <a href="../split-join/">Split &amp; Join</a>
-for what happens next.
+<code>route</code> must return <code>TaskResult::Single</code> — a router state is dispatched through
+the single-task path, and returning <code>TaskResult::Split</code> from it fails at run time with
+<code>CanoError::Workflow</code> (&ldquo;use <code>register_split()</code> for split tasks&rdquo;). To fan
+out into parallel states, route <em>to</em> a state registered with
+<a href="../split-join/"><code>register_split()</code></a> instead.
 </p>
 </div>
 
@@ -129,6 +166,41 @@ inside <code>FastProcessor</code>, <code>resume_from</code> re-enters at <code>F
 never needed to "remember" the routing decision — it just runs the router again on the way through if
 the resume point happens to land before it.
 </p>
+</div>
+
+<div class="diagram-frame">
+<p class="diagram-label">Recovery footprint of a run that passes through a router</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 236" role="img">
+<title>A Start to Classify to FastPath to Done run: the checkpoint log holds one row per state entered — sequence 0 for Start, 1 for FastPath, 2 for Done — while the Classify router state writes no row and consumes no sequence number.</title>
+<defs><marker id="rrec-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e" d="M178,63 H214" marker-end="url(#rrec-ah)"/>
+<path class="e" d="M370,63 H406" marker-end="url(#rrec-ah)"/>
+<path class="e" d="M562,63 H598" marker-end="url(#rrec-ah)"/>
+<path class="e e-dash" d="M102,86 V142" marker-end="url(#rrec-ah)"/>
+<path class="e e-dash e-dim" d="M294,86 V142" marker-end="url(#rrec-ah)"/>
+<path class="e e-dash" d="M486,86 V142" marker-end="url(#rrec-ah)"/>
+<path class="e e-dash" d="M678,86 V142" marker-end="url(#rrec-ah)"/>
+<text class="t-mut" x="294" y="18">router state</text>
+<rect class="n" x="26" y="40" width="152" height="46" rx="10"/>
+<text class="t-strong" x="102" y="64">Start</text>
+<rect class="n-hot" x="218" y="40" width="152" height="46" rx="10"/>
+<text class="t-strong" x="294" y="64">Classify</text>
+<rect class="n" x="410" y="40" width="152" height="46" rx="10"/>
+<text class="t-strong" x="486" y="64">FastPath</text>
+<rect class="n-ok" x="602" y="40" width="152" height="46" rx="10"/>
+<text class="t-strong" x="678" y="64">Done</text>
+<rect class="n-cop" x="26" y="146" width="152" height="46" rx="10"/>
+<text class="t-code" x="102" y="170">seq 0 &#183; Start</text>
+<rect class="n-ghost" x="218" y="146" width="152" height="46" rx="10"/>
+<text class="t-mut t-warn" x="294" y="170">no row written</text>
+<rect class="n-cop" x="410" y="146" width="152" height="46" rx="10"/>
+<text class="t-code" x="486" y="170">seq 1 &#183; FastPath</text>
+<rect class="n-cop" x="602" y="146" width="152" height="46" rx="10"/>
+<text class="t-code" x="678" y="170">seq 2 &#183; Done</text>
+<text class="t-mut ta-s" x="26" y="212">Checkpoint log: one row per state entered &#8212; Classify writes none and burns no sequence number.</text>
+</svg>
+</div>
 </div>
 
 <!-- Section: Explicit form -->

--- a/docs/content/saga/_index.md
+++ b/docs/content/saga/_index.md
@@ -124,6 +124,46 @@ compensatable step that ran before it.
 <hr class="section-divider">
 
 <h2 id="stack"><a href="#stack" class="anchor-link" aria-hidden="true">#</a>The Compensation Stack</h2>
+
+<div class="diagram-frame">
+<p class="diagram-label">Forward run pushes; a terminal failure drains the stack LIFO</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 320" role="img">
+<title>Reserve and Charge each push (task name, serialized output) onto the compensation stack; when the plain Ship task fails the engine drains the stack last-in first-out, so Charge compensates before Reserve, and each compensate receives back the Output its own run produced.</title>
+<defs><marker id="saga-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e e-hot" d="M670,98 V144 Q670,152 662,152 H438 Q430,152 430,160 V190" marker-end="url(#saga-ah)"/>
+<text class="t-mut t-err" x="550" y="126">terminal failure</text>
+<text class="t-strong t-hot" x="550" y="143">drain stack LIFO</text>
+<path class="e e-dash" d="M70,98 V190" marker-end="url(#saga-ah)"/>
+<text class="t-code t-mut ta-s" x="80" y="132">Reservation</text>
+<path class="e e-dash" d="M350,98 V190" marker-end="url(#saga-ah)"/>
+<text class="t-code t-mut ta-s" x="360" y="132">Charge</text>
+<rect class="n" x="25" y="40" width="170" height="58" rx="10"/>
+<text class="t-strong" x="110" y="65">Reserve</text>
+<text class="t-mut" x="110" y="85">push 1 · Reservation</text>
+<rect class="n" x="305" y="40" width="170" height="58" rx="10"/>
+<text class="t-strong" x="390" y="65">Charge</text>
+<text class="t-mut" x="390" y="85">push 2 · Charge</text>
+<rect class="n-err" x="585" y="40" width="170" height="58" rx="10"/>
+<text class="t-strong" x="670" y="65">Ship</text>
+<text class="t-mut" x="670" y="85">plain task — fails</text>
+<path class="e" d="M199,69 H301" marker-end="url(#saga-ah)"/>
+<text class="t-mut t-ok" x="250" y="57">success</text>
+<path class="e" d="M479,69 H581" marker-end="url(#saga-ah)"/>
+<text class="t-mut t-ok" x="530" y="57">success</text>
+<rect class="n" x="25" y="196" width="170" height="58" rx="10"/>
+<text class="t-code" x="110" y="221">compensate()</text>
+<text class="t-mut" x="110" y="241">pop 2 · release hold</text>
+<rect class="n" x="305" y="196" width="170" height="58" rx="10"/>
+<text class="t-code" x="390" y="221">compensate()</text>
+<text class="t-mut" x="390" y="241">pop 1 · refund</text>
+<path class="e e-hot" d="M301,225 H199" marker-end="url(#saga-ah)"/>
+<text class="t-mut" x="250" y="213">next entry</text>
+<rect class="n-hot" x="25" y="274" width="730" height="34" rx="10"/>
+<text class="t-strong" x="390" y="296">Rollback clean → orchestrate returns the original error, not CompensationFailed</text>
+</svg>
+</div>
+</div>
 <ul>
 <li>Each <strong>successful</strong> compensatable task pushes <code>(task name, serialized output)</code>
 onto the run's stack.</li>
@@ -197,6 +237,40 @@ resume point must likewise be idempotent.</p>
 With a <a href="../recovery/">checkpoint store</a> attached
 (<code>with_checkpoint_store</code> + <code>with_workflow_id</code>):
 </p>
+
+<div class="diagram-frame">
+<p class="diagram-label">The compensation stack survives a crash inside the checkpoint log</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 358" role="img">
+<title>Each successful compensatable state appends a CompensationCompletion row carrying its serialized output; after the process crashes, resume_from reloads those rows in sequence order and rebuilds the LIFO compensation stack in the new process.</title>
+<defs><marker id="sagaresume-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<line class="lifeline" x1="110" y1="46" x2="110" y2="160"/>
+<line class="lifeline" x1="390" y1="46" x2="390" y2="300"/>
+<line class="lifeline" x1="670" y1="46" x2="670" y2="300"/>
+<rect class="band" x="385" y="94" width="10" height="186" rx="5"/>
+<rect class="n" x="20" y="8" width="180" height="38" rx="8"/>
+<text class="t-strong" x="110" y="28">Process 1</text>
+<rect class="n-cop" x="300" y="8" width="180" height="38" rx="8"/>
+<text class="t-strong" x="390" y="28">Checkpoint store</text>
+<rect class="n" x="580" y="8" width="180" height="38" rx="8"/>
+<text class="t-strong" x="670" y="28">Process 2</text>
+<path class="e" d="M110,94 H386" marker-end="url(#sagaresume-ah)"/>
+<text class="t-mut" x="248" y="82">Reserve ✓ — append completion row</text>
+<path class="e" d="M110,138 H386" marker-end="url(#sagaresume-ah)"/>
+<text class="t-mut" x="248" y="126">Charge ✓ — append completion row</text>
+<rect class="n-ghost" x="20" y="160" width="180" height="40" rx="10"/>
+<text class="t-strong t-warn" x="110" y="178">✗ crash</text>
+<text class="t-mut t-warn" x="110" y="194">in-memory stack lost</text>
+<path class="e" d="M670,228 H394" marker-end="url(#sagaresume-ah)"/>
+<text class="t-code" x="532" y="216">Workflow::resume_from</text>
+<path class="e e-dash" d="M396,280 H666" marker-end="url(#sagaresume-ah)"/>
+<text class="t-code t-mut" x="528" y="252">RowKind::CompensationCompletion</text>
+<text class="t-mut" x="528" y="268">rows in sequence order → LIFO stack</text>
+<rect class="n-hot" x="20" y="312" width="740" height="34" rx="10"/>
+<text class="t-strong" x="390" y="334">A failure after the resume point still rolls back what the crashed process did</text>
+</svg>
+</div>
+</div>
 <ul>
 <li>A successful compensatable state writes a second <em>completion</em>
 <a href="../recovery/"><code>CheckpointRow</code></a> — <code>kind == RowKind::CompensationCompletion</code>,

--- a/docs/content/scheduler/_index.md
+++ b/docs/content/scheduler/_index.md
@@ -124,17 +124,41 @@ scheduler.manual(...)
 
 <div class="diagram-frame">
 <p class="diagram-label">Interval Scheduling Timeline</p>
-<div class="mermaid">
-gantt
-title Interval Scheduling (Every 30 seconds)
-dateFormat ss
-axisFormat %Ss
-section Workflow
-Run 1 :0, 2s
-Wait  :2, 28s
-Run 2 :30, 2s
-Wait  :32, 28s
-Run 3 :60, 2s
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 760 180" role="img">
+<title>Interval scheduling every 30 seconds: a 2-second run is followed by a 28-second wait, so the workflow is busy for only 2 seconds out of every 30.</title>
+<defs><marker id="interval-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e e-dim" d="M150,36 H420" marker-start="url(#interval-ah)" marker-end="url(#interval-ah)"/>
+<text class="t-mut" x="285" y="22">30s period</text>
+<text class="t-strong ta-s" x="20" y="78">Workflow</text>
+<rect class="band" x="168" y="64" width="252" height="26" rx="6"/>
+<text class="t-mut" x="294" y="78">wait 28s</text>
+<rect class="band" x="438" y="64" width="252" height="26" rx="6"/>
+<text class="t-mut" x="564" y="78">wait 28s</text>
+<rect class="band-hot" x="150" y="64" width="18" height="26" rx="4"/>
+<rect class="band-hot" x="420" y="64" width="18" height="26" rx="4"/>
+<rect class="band-hot" x="690" y="64" width="18" height="26" rx="4"/>
+<text class="t-mut t-hot" x="159" y="52">Run 1</text>
+<text class="t-mut t-hot" x="429" y="52">Run 2</text>
+<text class="t-mut t-hot" x="699" y="52">Run 3</text>
+<line class="axis" x1="150" y1="112" x2="726" y2="112"/>
+<path class="e e-dim" d="M726,112 H744" marker-end="url(#interval-ah)"/>
+<line class="tick" x1="150" y1="112" x2="150" y2="118"/>
+<line class="tick" x1="240" y1="112" x2="240" y2="118"/>
+<line class="tick" x1="330" y1="112" x2="330" y2="118"/>
+<line class="tick" x1="420" y1="112" x2="420" y2="118"/>
+<line class="tick" x1="510" y1="112" x2="510" y2="118"/>
+<line class="tick" x1="600" y1="112" x2="600" y2="118"/>
+<line class="tick" x1="690" y1="112" x2="690" y2="118"/>
+<text class="t-mut" x="150" y="132">0s</text>
+<text class="t-mut" x="240" y="132">10s</text>
+<text class="t-mut" x="330" y="132">20s</text>
+<text class="t-mut" x="420" y="132">30s</text>
+<text class="t-mut" x="510" y="132">40s</text>
+<text class="t-mut" x="600" y="132">50s</text>
+<text class="t-mut" x="690" y="132">60s</text>
+<text class="t-mut" x="438" y="160">2s busy, 28s idle — the loop sleeps to the next 30s boundary, it does not spin</text>
+</svg>
 </div>
 </div>
 
@@ -193,16 +217,43 @@ plus cron and manual flows).</p>
 
 <div class="diagram-frame">
 <p class="diagram-label">Cron Scheduling Timeline</p>
-<div class="mermaid">
-gantt
-title Cron Scheduling (Daily at 9 AM and 6 PM)
-dateFormat HH
-axisFormat %H:00
-section Workflow
-Run 1 :09, 1h
-Run 2 :18, 1h
-%% Add empty space to ensure full visibility
-Space :20, 0h
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 760 180" role="img">
+<title>Cron scheduling: the workflow is idle through the day and runs for one hour at 09:00 and again at 18:00, repeating at the same wall-clock times daily.</title>
+<defs><marker id="cron-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<text class="t-code t-mut" x="378" y="26">0 0 9 * * *</text>
+<text class="t-code t-mut" x="594" y="26">0 0 18 * * *</text>
+<text class="t-mut t-hot" x="378" y="48">Run 1 · 09:00</text>
+<text class="t-mut t-hot" x="594" y="48">Run 2 · 18:00</text>
+<text class="t-strong ta-s" x="20" y="78">Workflow</text>
+<rect class="band" x="150" y="64" width="576" height="26" rx="6"/>
+<text class="t-mut" x="486" y="78">idle</text>
+<rect class="band-hot" x="366" y="64" width="24" height="26" rx="4"/>
+<rect class="band-hot" x="582" y="64" width="24" height="26" rx="4"/>
+<text class="t-mut" x="378" y="104">1h</text>
+<text class="t-mut" x="594" y="104">1h</text>
+<line class="axis" x1="150" y1="122" x2="726" y2="122"/>
+<path class="e e-dim" d="M726,122 H744" marker-end="url(#cron-ah)"/>
+<line class="tick" x1="150" y1="122" x2="150" y2="128"/>
+<line class="tick" x1="222" y1="122" x2="222" y2="128"/>
+<line class="tick" x1="294" y1="122" x2="294" y2="128"/>
+<line class="tick" x1="366" y1="122" x2="366" y2="128"/>
+<line class="tick" x1="438" y1="122" x2="438" y2="128"/>
+<line class="tick" x1="510" y1="122" x2="510" y2="128"/>
+<line class="tick" x1="582" y1="122" x2="582" y2="128"/>
+<line class="tick" x1="654" y1="122" x2="654" y2="128"/>
+<line class="tick" x1="726" y1="122" x2="726" y2="128"/>
+<text class="t-mut" x="150" y="142">00:00</text>
+<text class="t-mut" x="222" y="142">03:00</text>
+<text class="t-mut" x="294" y="142">06:00</text>
+<text class="t-mut" x="366" y="142">09:00</text>
+<text class="t-mut" x="438" y="142">12:00</text>
+<text class="t-mut" x="510" y="142">15:00</text>
+<text class="t-mut" x="582" y="142">18:00</text>
+<text class="t-mut" x="654" y="142">21:00</text>
+<text class="t-mut" x="726" y="142">24:00</text>
+<text class="t-mut" x="438" y="166">two 1-hour runs a day — idle the other 22 hours, then the same times tomorrow</text>
+</svg>
 </div>
 </div>
 
@@ -285,15 +336,30 @@ scheduler is running.
 
 <div class="diagram-frame">
 <p class="diagram-label">Manual Trigger Sequence</p>
-<div class="mermaid">
-sequenceDiagram
-participant API as API Request
-participant S as Scheduler
-participant W as Workflow
-API->>S: trigger("data_export")
-S->>W: Start Workflow
-W-->>S: Complete
-S-->>API: Success
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 720 284" role="img">
+<title>Manual triggering: an API request calls trigger on the running scheduler, which starts the workflow and relays its completion back to the caller.</title>
+<defs><marker id="manual-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<line class="lifeline" x1="110" y1="46" x2="110" y2="222"/>
+<line class="lifeline" x1="360" y1="46" x2="360" y2="222"/>
+<line class="lifeline" x1="610" y1="46" x2="610" y2="222"/>
+<rect class="n" x="35" y="8" width="150" height="38" rx="8"/>
+<text class="t-strong" x="110" y="28">API Request</text>
+<rect class="n-hot" x="285" y="8" width="150" height="38" rx="8"/>
+<text class="t-strong" x="360" y="28">Scheduler</text>
+<rect class="n" x="535" y="8" width="150" height="38" rx="8"/>
+<text class="t-strong" x="610" y="28">Workflow</text>
+<path class="e" d="M110,78 H356" marker-end="url(#manual-ah)"/>
+<text class="t-code" x="233" y="66">trigger("data_export")</text>
+<path class="e" d="M360,122 H606" marker-end="url(#manual-ah)"/>
+<text class="t-mut" x="483" y="110">Start Workflow</text>
+<path class="e e-dash" d="M610,166 H364" marker-end="url(#manual-ah)"/>
+<text class="t-mut t-ok" x="487" y="154">Complete</text>
+<path class="e e-dash" d="M360,210 H114" marker-end="url(#manual-ah)"/>
+<text class="t-mut t-ok" x="237" y="198">Success ✓</text>
+<rect class="n-hot" x="35" y="230" width="650" height="34" rx="10"/>
+<text class="t-strong" x="360" y="248">Nothing runs until trigger() is called — no interval, no cron</text>
+</svg>
 </div>
 </div>
 
@@ -357,18 +423,46 @@ async fn main() -> Result<(), CanoError> {
 
 <div class="diagram-frame">
 <p class="diagram-label">Mixed Strategy Overview</p>
-<div class="mermaid">
-gantt
-title Mixed Scheduling Strategies
-dateFormat HH:mm
-axisFormat %H:%M
-section Interval Tasks
-Sync Every 5min :00:00, 24h
-section Cron Tasks
-Daily Backup :03:00, 1h
-Weekly Report :09:00, 1h
-section Manual Tasks
-Emergency Export :done, 14:30, 15m
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 760 254" role="img">
+<title>Mixed scheduling over one day: an interval flow pulses all day long, two cron flows take one hour each at 03:00 and 09:00, and a manual export fires once at 14:30.</title>
+<defs><marker id="mixed-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<text class="t-mut t-hot" x="438" y="38">every 5 min · 288 runs/day (cadence illustrated)</text>
+<text class="t-strong ta-s" x="20" y="61">Interval</text>
+<rect class="band" x="150" y="48" width="576" height="26" rx="6"/>
+<path class="band-hot" d="M150,48h4v26h-4z M174,48h4v26h-4z M198,48h4v26h-4z M222,48h4v26h-4z M246,48h4v26h-4z M270,48h4v26h-4z M294,48h4v26h-4z M318,48h4v26h-4z M342,48h4v26h-4z M366,48h4v26h-4z M390,48h4v26h-4z M414,48h4v26h-4z M438,48h4v26h-4z M462,48h4v26h-4z M486,48h4v26h-4z M510,48h4v26h-4z M534,48h4v26h-4z M558,48h4v26h-4z M582,48h4v26h-4z M606,48h4v26h-4z M630,48h4v26h-4z M654,48h4v26h-4z M678,48h4v26h-4z M702,48h4v26h-4z"/>
+<text class="t-mut t-hot" x="234" y="84">Daily Backup</text>
+<text class="t-mut t-hot" x="378" y="84">Weekly Report</text>
+<text class="t-strong ta-s" x="20" y="107">Cron</text>
+<rect class="band" x="150" y="94" width="576" height="26" rx="6"/>
+<rect class="band-hot" x="222" y="94" width="24" height="26" rx="4"/>
+<rect class="band-hot" x="366" y="94" width="24" height="26" rx="4"/>
+<text class="t-mut t-hot" x="501" y="130">Emergency Export · 14:30</text>
+<text class="t-strong ta-s" x="20" y="153">Manual</text>
+<rect class="band" x="150" y="140" width="576" height="26" rx="6"/>
+<rect class="band-hot" x="498" y="140" width="6" height="26" rx="2"/>
+<line class="axis" x1="150" y1="190" x2="726" y2="190"/>
+<path class="e e-dim" d="M726,190 H744" marker-end="url(#mixed-ah)"/>
+<line class="tick" x1="150" y1="190" x2="150" y2="196"/>
+<line class="tick" x1="222" y1="190" x2="222" y2="196"/>
+<line class="tick" x1="294" y1="190" x2="294" y2="196"/>
+<line class="tick" x1="366" y1="190" x2="366" y2="196"/>
+<line class="tick" x1="438" y1="190" x2="438" y2="196"/>
+<line class="tick" x1="510" y1="190" x2="510" y2="196"/>
+<line class="tick" x1="582" y1="190" x2="582" y2="196"/>
+<line class="tick" x1="654" y1="190" x2="654" y2="196"/>
+<line class="tick" x1="726" y1="190" x2="726" y2="196"/>
+<text class="t-mut" x="150" y="210">00:00</text>
+<text class="t-mut" x="222" y="210">03:00</text>
+<text class="t-mut" x="294" y="210">06:00</text>
+<text class="t-mut" x="366" y="210">09:00</text>
+<text class="t-mut" x="438" y="210">12:00</text>
+<text class="t-mut" x="510" y="210">15:00</text>
+<text class="t-mut" x="582" y="210">18:00</text>
+<text class="t-mut" x="654" y="210">21:00</text>
+<text class="t-mut" x="726" y="210">24:00</text>
+<text class="t-mut" x="438" y="234">one scheduler, three trigger sources — interval, cron, and on-demand</text>
+</svg>
 </div>
 </div>
 

--- a/docs/content/scheduler/backoff-and-trip.md
+++ b/docs/content/scheduler/backoff-and-trip.md
@@ -119,6 +119,68 @@ backoff window. <code>BackoffPolicy::default()</code> gives 1s initial, 2.0× mu
 0.1 jitter, and <strong>no trip limit</strong>. Use <code>BackoffPolicy::with_trip(n)</code> to ask for a
 trip after <code>n</code> consecutive failures.
 </p>
+<div class="diagram-frame">
+<p class="diagram-label">Backoff timeline for a flaky flow</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 860 196" role="img" style="max-width: 860px">
+<title>A flaky flow on a 1s interval: each consecutive failure parks it for a longer backoff window — 2s, 4s, 8s, then 8s capped at max_delay — and the first success clears the streak so the 1s cadence resumes.</title>
+<defs><marker id="bt-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<text class="t-code t-mut ta-s" x="16" y="28">initial 2s · multiplier 2.0 · max_delay 8s · jitter 0</text>
+<text class="t-mut t-ok ta-e" x="816" y="28">success → failure_streak 0, next_eligible cleared</text>
+<text class="t-mut ta-e" x="132" y="50">streak</text>
+<text class="t-mut t-err" x="191" y="50">1</text>
+<text class="t-mut t-err" x="241" y="50">2</text>
+<text class="t-mut t-err" x="343" y="50">3</text>
+<text class="t-mut t-err" x="545" y="50">4</text>
+<text class="t-mut t-ok" x="748" y="50">0</text>
+<text class="t-strong t-ok" x="140" y="68">✓</text>
+<text class="t-strong t-ok" x="165" y="68">✓</text>
+<text class="t-strong t-err" x="191" y="68">✗</text>
+<text class="t-strong t-err" x="241" y="68">✗</text>
+<text class="t-strong t-err" x="343" y="68">✗</text>
+<text class="t-strong t-err" x="545" y="68">✗</text>
+<text class="t-strong t-ok" x="748" y="68">✓</text>
+<text class="t-strong t-ok" x="773" y="68">✓</text>
+<text class="t-strong t-ok" x="799" y="68">✓</text>
+<text class="t-strong ta-s" x="16" y="90">flaky</text>
+<text class="t-code t-mut ta-s" x="16" y="106">every(1s)</text>
+<rect class="band" x="197" y="78" width="38" height="26" rx="6"/>
+<rect class="band" x="247" y="78" width="90" height="26" rx="6"/>
+<rect class="band" x="349" y="78" width="190" height="26" rx="6"/>
+<rect class="band" x="551" y="78" width="191" height="26" rx="6"/>
+<text class="t-mut" x="216" y="92">2s</text>
+<text class="t-mut" x="292" y="92">4s</text>
+<text class="t-mut" x="444" y="92">8s</text>
+<text class="t-mut" x="646" y="92">8s · max_delay cap</text>
+<rect class="band-hot" x="134" y="78" width="12" height="26" rx="4"/>
+<rect class="band-hot" x="159" y="78" width="12" height="26" rx="4"/>
+<rect class="band-hot" x="185" y="78" width="12" height="26" rx="4"/>
+<rect class="band-hot" x="235" y="78" width="12" height="26" rx="4"/>
+<rect class="band-hot" x="337" y="78" width="12" height="26" rx="4"/>
+<rect class="band-hot" x="539" y="78" width="12" height="26" rx="4"/>
+<rect class="band-hot" x="742" y="78" width="12" height="26" rx="4"/>
+<rect class="band-hot" x="767" y="78" width="12" height="26" rx="4"/>
+<rect class="band-hot" x="793" y="78" width="12" height="26" rx="4"/>
+<line class="axis" x1="140" y1="126" x2="812" y2="126"/>
+<path class="e e-dim" d="M812,126 H830" marker-end="url(#bt-ah)"/>
+<line class="tick" x1="140" y1="126" x2="140" y2="132"/>
+<line class="tick" x1="241" y1="126" x2="241" y2="132"/>
+<line class="tick" x1="343" y1="126" x2="343" y2="132"/>
+<line class="tick" x1="444" y1="126" x2="444" y2="132"/>
+<line class="tick" x1="545" y1="126" x2="545" y2="132"/>
+<line class="tick" x1="647" y1="126" x2="647" y2="132"/>
+<line class="tick" x1="748" y1="126" x2="748" y2="132"/>
+<text class="t-mut" x="140" y="150">0s</text>
+<text class="t-mut" x="241" y="150">4s</text>
+<text class="t-mut" x="343" y="150">8s</text>
+<text class="t-mut" x="444" y="150">12s</text>
+<text class="t-mut" x="545" y="150">16s</text>
+<text class="t-mut" x="647" y="150">20s</text>
+<text class="t-mut" x="748" y="150">24s</text>
+<text class="t-mut" x="483" y="176">failures push next_eligible out exponentially — capped at max_delay, cleared by the first success</text>
+</svg>
+</div>
+</div>
 
 <h3 id="status-variants"><a href="#status-variants" class="anchor-link" aria-hidden="true">#</a>Status Variants</h3>
 <p>
@@ -134,6 +196,52 @@ a wildcard. The variants are:
 <li><code>Tripped { streak, last_error }</code> — streak reached <code>streak_limit</code>; the scheduler
 will not dispatch this flow again until <code>reset_flow</code> is called.</li>
 </ul>
+<div class="diagram-frame">
+<p class="diagram-label">Flow status: backoff, trip, and recovery</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 356" role="img">
+<title>Scheduler flow status machine: a dispatched flow runs, success marks it Completed and clears the streak, a failure parks it in Backoff until the delay elapses, and a failure that reaches streak_limit trips it until reset_flow returns it to Idle.</title>
+<defs><marker id="trip-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e e-dim" d="M636,48 V32 Q636,24 628,24 H374 Q366,24 366,32 V44" marker-end="url(#trip-ah)"/>
+<text class="t-mut" x="496" y="41">next tick</text>
+<circle class="n" cx="20" cy="64" r="5"/>
+<path class="e" d="M27,64 H40" marker-end="url(#trip-ah)"/>
+<path class="e" d="M194,77 H282" marker-end="url(#trip-ah)"/>
+<text class="t-mut" x="238" y="63">dispatch</text>
+<path class="e" d="M446,77 H542" marker-end="url(#trip-ah)"/>
+<text class="t-mut t-ok" x="494" y="63">success</text>
+<path class="e" d="M320,106 V152 Q320,160 312,160 H148 Q140,160 140,168 V228" marker-end="url(#trip-ah)"/>
+<text class="t-mut t-err" x="230" y="134">failure</text>
+<text class="t-mut" x="230" y="150">streak &lt; streak_limit</text>
+<path class="e" d="M180,232 V196 Q180,188 188,188 H392 Q400,188 400,180 V110" marker-end="url(#trip-ah)"/>
+<text class="t-mut" x="300" y="206">until elapsed · next dispatch</text>
+<path class="e" d="M436,106 V202 Q436,210 444,210 H588 Q596,210 596,218 V228" marker-end="url(#trip-ah)"/>
+<text class="t-mut t-err ta-s" x="450" y="176">failure</text>
+<text class="t-mut ta-s" x="450" y="192">streak reaches streak_limit</text>
+<path class="e e-hot" d="M700,308 V330 Q700,338 692,338 H28 Q20,338 20,330 V102 Q20,94 28,94 H40" marker-end="url(#trip-ah)"/>
+<text class="t-code t-hot ta-e" x="316" y="326">reset_flow(id)</text>
+<text class="t-mut t-hot ta-s" x="324" y="326">· clears the streak, un-trips the flow</text>
+<rect class="n" x="44" y="48" width="150" height="58" rx="12"/>
+<text class="t-strong" x="119" y="73">Idle</text>
+<text class="t-mut" x="119" y="93">awaiting dispatch</text>
+<rect class="n" x="286" y="48" width="160" height="58" rx="12"/>
+<text class="t-strong" x="366" y="73">Running</text>
+<text class="t-mut" x="366" y="93">workflow executing</text>
+<rect class="n-ok" x="546" y="48" width="180" height="58" rx="12"/>
+<text class="t-strong" x="636" y="73">Completed</text>
+<text class="t-mut" x="636" y="93">reached an exit state</text>
+<text class="t-code t-mut" x="636" y="130">streak = 0 · next_eligible = None</text>
+<rect class="n-warn" x="40" y="232" width="250" height="76" rx="12"/>
+<text class="t-strong" x="165" y="256">Backoff</text>
+<text class="t-code t-mut" x="165" y="276">{ until, streak, last_error }</text>
+<text class="t-mut" x="165" y="295">parked until the delay elapses</text>
+<rect class="n-err" x="476" y="232" width="250" height="76" rx="12"/>
+<text class="t-strong" x="601" y="256">Tripped</text>
+<text class="t-code t-mut" x="601" y="276">{ streak, last_error }</text>
+<text class="t-mut" x="601" y="295">scheduler stops dispatching</text>
+</svg>
+</div>
+</div>
 <p>
 Outcome writes are atomic: a single write decides this run's terminal status (<code>Completed</code> on
 success, otherwise <code>Backoff</code> or <code>Tripped</code>), so observers never see a transient

--- a/docs/content/split-join/_index.md
+++ b/docs/content/split-join/_index.md
@@ -40,16 +40,36 @@ consumes <code>self</code> and returns a new <code>Workflow</code> — capture t
 
 <div class="diagram-frame">
 <p class="diagram-label">Split / Join Pattern</p>
-<div class="mermaid">
-graph TD
-A[Process State] -->|Split| B[Task 1]
-A -->|Split| C[Task 2]
-A -->|Split| D[Task 3]
-B --> E{Join Strategy}
-C --> E
-D --> E
-E -->|Satisfied| F[Aggregate State]
-E -->|Failed/Timeout| G[Error State]
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 720 440" role="img">
+<title>register_split fans one Process State out to three tasks that run concurrently; the join strategy gate collects their results and advances the workflow to the aggregate state once satisfied, or to the error state on failure or timeout.</title>
+<defs><marker id="split-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<rect class="n" x="280" y="20" width="160" height="46" rx="10"/>
+<text class="t-strong" x="360" y="44">Process State</text>
+<path class="e" d="M360,66 V88 Q360,96 352,96 H148 Q140,96 140,104 V122" marker-end="url(#split-ah)"/>
+<path class="e" d="M360,66 V122" marker-end="url(#split-ah)"/>
+<path class="e" d="M360,66 V88 Q360,96 368,96 H572 Q580,96 580,104 V122" marker-end="url(#split-ah)"/>
+<text class="t-mut ta-s" x="371" y="80">Split</text>
+<rect class="n" x="80" y="126" width="120" height="46" rx="10"/>
+<text x="140" y="150">Task 1</text>
+<rect class="n" x="300" y="126" width="120" height="46" rx="10"/>
+<text x="360" y="150">Task 2</text>
+<rect class="n" x="520" y="126" width="120" height="46" rx="10"/>
+<text x="580" y="150">Task 3</text>
+<path class="e" d="M140,172 V196 Q140,204 148,204 H292 Q300,204 300,212 V245" marker-end="url(#split-ah)"/>
+<path class="e" d="M360,172 V228" marker-end="url(#split-ah)"/>
+<path class="e" d="M580,172 V196 Q580,204 572,204 H428 Q420,204 420,212 V245" marker-end="url(#split-ah)"/>
+<path class="n-hot" d="M360,232 L490,270 L360,308 L230,270 Z"/>
+<text class="t-strong" x="360" y="271">Join Strategy</text>
+<path class="e e-hot" d="M230,270 H198 Q190,270 190,278 V358" marker-end="url(#split-ah)"/>
+<text class="t-mut t-hot ta-e" x="181" y="316">Satisfied</text>
+<path class="e" d="M490,270 H522 Q530,270 530,278 V358" marker-end="url(#split-ah)"/>
+<text class="t-mut ta-s" x="539" y="316">Failed / Timeout</text>
+<rect class="n-ok" x="105" y="364" width="170" height="46" rx="10"/>
+<text x="190" y="388">Aggregate State</text>
+<rect class="n-err" x="460" y="364" width="140" height="46" rx="10"/>
+<text x="530" y="388">Error State</text>
+</svg>
 </div>
 </div>
 

--- a/docs/content/split-join/join-strategies.md
+++ b/docs/content/split-join/join-strategies.md
@@ -46,19 +46,37 @@ with staggered task delays so you can see exactly when each one returns.</p>
 
 <div class="diagram-frame">
 <p class="diagram-label">All Strategy</p>
-<div class="mermaid">
-sequenceDiagram
-participant W as Workflow
-participant T1 as Task 1
-participant T2 as Task 2
-participant T3 as Task 3
-W->>T1: Start
-W->>T2: Start
-W->>T3: Start
-T1-->>W: Complete ✓
-T2-->>W: Complete ✓
-T3-->>W: Complete ✓
-Note over W: All Complete → Proceed
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 840 374" role="img" style="max-width: 860px">
+<title>All strategy: the workflow starts three tasks, every one of them reports success, and only when the last result lands does the join fire — nothing is cancelled.</title>
+<defs><marker id="all-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<rect class="n" x="10" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="80" y="28">Workflow</text>
+<rect class="n" x="180" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="250" y="28">Task 1</text>
+<rect class="n" x="350" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="420" y="28">Task 2</text>
+<rect class="n" x="520" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="590" y="28">Task 3</text>
+<line class="lifeline" x1="80" y1="46" x2="80" y2="310"/>
+<line class="lifeline" x1="250" y1="46" x2="250" y2="310"/>
+<line class="lifeline" x1="420" y1="46" x2="420" y2="310"/>
+<line class="lifeline" x1="590" y1="46" x2="590" y2="310"/>
+<text class="t-mut" x="165" y="66">Start</text>
+<path class="e" d="M80,78 H247" marker-end="url(#all-ah)"/>
+<text class="t-mut" x="250" y="110">Start</text>
+<path class="e" d="M80,122 H417" marker-end="url(#all-ah)"/>
+<text class="t-mut" x="335" y="154">Start</text>
+<path class="e" d="M80,166 H587" marker-end="url(#all-ah)"/>
+<text class="t-mut t-ok" x="165" y="198">Complete ✓</text>
+<path class="e e-dash" d="M250,210 H83" marker-end="url(#all-ah)"/>
+<text class="t-mut t-ok" x="250" y="242">Complete ✓</text>
+<path class="e e-dash" d="M420,254 H83" marker-end="url(#all-ah)"/>
+<text class="t-mut t-ok" x="335" y="286">Complete ✓</text>
+<path class="e e-dash" d="M590,298 H83" marker-end="url(#all-ah)"/>
+<rect class="n-hot" x="16" y="318" width="808" height="34" rx="10"/>
+<text class="t-strong" x="420" y="336">All Complete → Proceed</text>
+</svg>
 </div>
 </div>
 
@@ -121,19 +139,37 @@ calls where the fastest response wins.</p>
 
 <div class="diagram-frame">
 <p class="diagram-label">Any Strategy</p>
-<div class="mermaid">
-sequenceDiagram
-participant W as Workflow
-participant T1 as Task 1 (slow)
-participant T2 as Task 2 (fast)
-participant T3 as Task 3 (slow)
-W->>T1: Start
-W->>T2: Start
-W->>T3: Start
-T2-->>W: Complete ✓
-Note over W: First Complete → Proceed
-W->>T1: Cancel
-W->>T3: Cancel
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 840 374" role="img" style="max-width: 860px">
+<title>Any strategy: three redundant tasks start, the fast one reports success first, the join fires on that single result and both slow tasks are cancelled before they finish.</title>
+<defs><marker id="any-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<rect class="n" x="10" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="80" y="28">Workflow</text>
+<rect class="n-ghost" x="180" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="250" y="28">Task 1 (slow)</text>
+<rect class="n" x="350" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="420" y="28">Task 2 (fast)</text>
+<rect class="n-ghost" x="520" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="590" y="28">Task 3 (slow)</text>
+<line class="lifeline" x1="80" y1="46" x2="80" y2="352"/>
+<line class="n-ghost" x1="250" y1="46" x2="250" y2="352"/>
+<line class="lifeline" x1="420" y1="46" x2="420" y2="352"/>
+<line class="n-ghost" x1="590" y1="46" x2="590" y2="352"/>
+<text class="t-mut" x="165" y="66">Start</text>
+<path class="e" d="M80,78 H247" marker-end="url(#any-ah)"/>
+<text class="t-mut" x="250" y="110">Start</text>
+<path class="e" d="M80,122 H417" marker-end="url(#any-ah)"/>
+<text class="t-mut" x="335" y="154">Start</text>
+<path class="e" d="M80,166 H587" marker-end="url(#any-ah)"/>
+<text class="t-mut t-ok" x="250" y="198">Complete ✓</text>
+<path class="e e-dash" d="M420,210 H83" marker-end="url(#any-ah)"/>
+<rect class="n-hot" x="16" y="230" width="808" height="34" rx="10"/>
+<text class="t-strong" x="420" y="248">First Complete → Proceed</text>
+<text class="t-mut t-warn" x="165" y="284">Cancel ⏱</text>
+<path class="e e-dim" d="M80,296 H247" marker-end="url(#any-ah)"/>
+<text class="t-mut t-warn" x="335" y="328">Cancel ⏱</text>
+<path class="e e-dim" d="M80,340 H587" marker-end="url(#any-ah)"/>
+</svg>
 </div>
 </div>
 
@@ -190,22 +226,44 @@ distributed consensus and majority-vote writes.</p>
 
 <div class="diagram-frame">
 <p class="diagram-label">Quorum Strategy</p>
-<div class="mermaid">
-sequenceDiagram
-participant W as Workflow
-participant T1 as Task 1
-participant T2 as Task 2
-participant T3 as Task 3
-participant T4 as Task 4
-W->>T1: Start
-W->>T2: Start
-W->>T3: Start
-W->>T4: Start
-T1-->>W: Complete ✓
-T3-->>W: Complete ✓
-T2-->>W: Complete ✓
-Note over W: Quorum (3/4) Met → Proceed
-W->>T4: Cancel
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 840 462" role="img" style="max-width: 860px">
+<title>Quorum strategy: four tasks start, the join waits for the third success to land in whatever order they arrive, fires as soon as the quorum of 3 of 4 is met, and cancels the task still running.</title>
+<defs><marker id="quorum-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<rect class="n" x="10" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="80" y="28">Workflow</text>
+<rect class="n" x="180" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="250" y="28">Task 1</text>
+<rect class="n" x="350" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="420" y="28">Task 2</text>
+<rect class="n" x="520" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="590" y="28">Task 3</text>
+<rect class="n-ghost" x="690" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="760" y="28">Task 4</text>
+<line class="lifeline" x1="80" y1="46" x2="80" y2="440"/>
+<line class="lifeline" x1="250" y1="46" x2="250" y2="440"/>
+<line class="lifeline" x1="420" y1="46" x2="420" y2="440"/>
+<line class="lifeline" x1="590" y1="46" x2="590" y2="440"/>
+<line class="n-ghost" x1="760" y1="46" x2="760" y2="440"/>
+<text class="t-mut" x="165" y="66">Start</text>
+<path class="e" d="M80,78 H247" marker-end="url(#quorum-ah)"/>
+<text class="t-mut" x="250" y="110">Start</text>
+<path class="e" d="M80,122 H417" marker-end="url(#quorum-ah)"/>
+<text class="t-mut" x="335" y="154">Start</text>
+<path class="e" d="M80,166 H587" marker-end="url(#quorum-ah)"/>
+<text class="t-mut" x="420" y="198">Start</text>
+<path class="e" d="M80,210 H757" marker-end="url(#quorum-ah)"/>
+<text class="t-mut t-ok" x="165" y="242">Complete ✓</text>
+<path class="e e-dash" d="M250,254 H83" marker-end="url(#quorum-ah)"/>
+<text class="t-mut t-ok" x="335" y="286">Complete ✓</text>
+<path class="e e-dash" d="M590,298 H83" marker-end="url(#quorum-ah)"/>
+<text class="t-mut t-ok" x="250" y="330">Complete ✓</text>
+<path class="e e-dash" d="M420,342 H83" marker-end="url(#quorum-ah)"/>
+<rect class="n-hot" x="16" y="362" width="808" height="34" rx="10"/>
+<text class="t-strong" x="420" y="380">Quorum (3/4) Met → Proceed</text>
+<text class="t-mut t-warn" x="420" y="416">Cancel ⏱</text>
+<path class="e e-dim" d="M80,428 H757" marker-end="url(#quorum-ah)"/>
+</svg>
 </div>
 </div>
 
@@ -274,22 +332,44 @@ well when the number of split tasks varies.</p>
 
 <div class="diagram-frame">
 <p class="diagram-label">Percentage Strategy</p>
-<div class="mermaid">
-sequenceDiagram
-participant W as Workflow
-participant T1 as Task 1
-participant T2 as Task 2
-participant T3 as Task 3
-participant T4 as Task 4
-W->>T1: Start
-W->>T2: Start
-W->>T3: Start
-W->>T4: Start
-T1-->>W: Complete ✓
-T2-->>W: Complete ✓
-T4-->>W: Complete ✓
-Note over W: 75% (3/4) Met → Proceed
-W->>T3: Cancel
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 840 462" role="img" style="max-width: 860px">
+<title>Percentage strategy: four tasks start and the join fires the moment the configured fraction of them has succeeded — here 75%, three of four — cancelling the one still in flight.</title>
+<defs><marker id="pct-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<rect class="n" x="10" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="80" y="28">Workflow</text>
+<rect class="n" x="180" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="250" y="28">Task 1</text>
+<rect class="n" x="350" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="420" y="28">Task 2</text>
+<rect class="n-ghost" x="520" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="590" y="28">Task 3</text>
+<rect class="n" x="690" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="760" y="28">Task 4</text>
+<line class="lifeline" x1="80" y1="46" x2="80" y2="440"/>
+<line class="lifeline" x1="250" y1="46" x2="250" y2="440"/>
+<line class="lifeline" x1="420" y1="46" x2="420" y2="440"/>
+<line class="n-ghost" x1="590" y1="46" x2="590" y2="440"/>
+<line class="lifeline" x1="760" y1="46" x2="760" y2="440"/>
+<text class="t-mut" x="165" y="66">Start</text>
+<path class="e" d="M80,78 H247" marker-end="url(#pct-ah)"/>
+<text class="t-mut" x="250" y="110">Start</text>
+<path class="e" d="M80,122 H417" marker-end="url(#pct-ah)"/>
+<text class="t-mut" x="335" y="154">Start</text>
+<path class="e" d="M80,166 H587" marker-end="url(#pct-ah)"/>
+<text class="t-mut" x="420" y="198">Start</text>
+<path class="e" d="M80,210 H757" marker-end="url(#pct-ah)"/>
+<text class="t-mut t-ok" x="165" y="242">Complete ✓</text>
+<path class="e e-dash" d="M250,254 H83" marker-end="url(#pct-ah)"/>
+<text class="t-mut t-ok" x="250" y="286">Complete ✓</text>
+<path class="e e-dash" d="M420,298 H83" marker-end="url(#pct-ah)"/>
+<text class="t-mut t-ok" x="420" y="330">Complete ✓</text>
+<path class="e e-dash" d="M760,342 H83" marker-end="url(#pct-ah)"/>
+<rect class="n-hot" x="16" y="362" width="808" height="34" rx="10"/>
+<text class="t-strong" x="420" y="380">75% (3/4) Met → Proceed</text>
+<text class="t-mut t-warn" x="335" y="416">Cancel ⏱</text>
+<path class="e e-dim" d="M80,428 H587" marker-end="url(#pct-ah)"/>
+</svg>
 </div>
 </div>
 
@@ -354,23 +434,46 @@ walk-through lives in <code>cargo run --example workflow_partial_results</code>.
 
 <div class="diagram-frame">
 <p class="diagram-label">PartialResults Strategy</p>
-<div class="mermaid">
-sequenceDiagram
-participant W as Workflow
-participant T1 as Task 1
-participant T2 as Task 2
-participant T3 as Task 3
-participant T4 as Task 4
-W->>T1: Start
-W->>T2: Start
-W->>T3: Start
-W->>T4: Start
-T1-->>W: Complete ✓
-T2-->>W: Failed ✗
-T3-->>W: Complete ✓
-Note over W: 3 completions → Proceed
-W->>T4: Cancel
-Note over W: Track: 2 success, 1 error, 1 cancelled
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 840 504" role="img" style="max-width: 860px">
+<title>PartialResults strategy: four tasks start and the join counts completions rather than successes, so a failure still counts — three outcomes arrive, the join fires, the last task is cancelled and every outcome is tracked for the downstream task.</title>
+<defs><marker id="partial-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<rect class="n" x="10" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="80" y="28">Workflow</text>
+<rect class="n" x="180" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="250" y="28">Task 1</text>
+<rect class="n" x="350" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="420" y="28">Task 2</text>
+<rect class="n" x="520" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="590" y="28">Task 3</text>
+<rect class="n-ghost" x="690" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="760" y="28">Task 4</text>
+<line class="lifeline" x1="80" y1="46" x2="80" y2="440"/>
+<line class="lifeline" x1="250" y1="46" x2="250" y2="440"/>
+<line class="lifeline" x1="420" y1="46" x2="420" y2="440"/>
+<line class="lifeline" x1="590" y1="46" x2="590" y2="440"/>
+<line class="n-ghost" x1="760" y1="46" x2="760" y2="440"/>
+<text class="t-mut" x="165" y="66">Start</text>
+<path class="e" d="M80,78 H247" marker-end="url(#partial-ah)"/>
+<text class="t-mut" x="250" y="110">Start</text>
+<path class="e" d="M80,122 H417" marker-end="url(#partial-ah)"/>
+<text class="t-mut" x="335" y="154">Start</text>
+<path class="e" d="M80,166 H587" marker-end="url(#partial-ah)"/>
+<text class="t-mut" x="420" y="198">Start</text>
+<path class="e" d="M80,210 H757" marker-end="url(#partial-ah)"/>
+<text class="t-mut t-ok" x="165" y="242">Complete ✓</text>
+<path class="e e-dash" d="M250,254 H83" marker-end="url(#partial-ah)"/>
+<text class="t-mut t-err" x="250" y="286">Failed ✗</text>
+<path class="e e-dash" d="M420,298 H83" marker-end="url(#partial-ah)"/>
+<text class="t-mut t-ok" x="335" y="330">Complete ✓</text>
+<path class="e e-dash" d="M590,342 H83" marker-end="url(#partial-ah)"/>
+<rect class="n-hot" x="16" y="362" width="808" height="34" rx="10"/>
+<text class="t-strong" x="420" y="380">3 completions → Proceed</text>
+<text class="t-mut t-warn" x="420" y="416">Cancel ⏱</text>
+<path class="e e-dim" d="M80,428 H757" marker-end="url(#partial-ah)"/>
+<rect class="n-hot" x="16" y="448" width="808" height="34" rx="10"/>
+<text class="t-strong" x="420" y="466">Track: <tspan class="t-ok">2 success</tspan>, <tspan class="t-err">1 error</tspan>, <tspan class="t-warn">1 cancelled</tspan></text>
+</svg>
 </div>
 </div>
 
@@ -438,23 +541,46 @@ remaining tasks are cancelled. The go-to strategy for hard SLAs. Requires <code>
 
 <div class="diagram-frame">
 <p class="diagram-label">PartialTimeout Strategy</p>
-<div class="mermaid">
-sequenceDiagram
-participant W as Workflow
-participant T1 as Task 1
-participant T2 as Task 2
-participant T3 as Task 3
-participant T4 as Task 4
-W->>T1: Start
-W->>T2: Start
-W->>T3: Start
-W->>T4: Start
-T1-->>W: Complete ✓
-T3-->>W: Complete ✓
-Note over W: Timeout Reached
-W->>T2: Cancel
-W->>T4: Cancel
-Note over W: Proceed with 2 results
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 840 504" role="img" style="max-width: 860px">
+<title>PartialTimeout strategy: four tasks start, two report success before the deadline, and the timeout itself fires the join — the two tasks still running are cancelled and the workflow proceeds with the results it has.</title>
+<defs><marker id="ptimeout-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<rect class="n" x="10" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="80" y="28">Workflow</text>
+<rect class="n" x="180" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="250" y="28">Task 1</text>
+<rect class="n-ghost" x="350" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="420" y="28">Task 2</text>
+<rect class="n" x="520" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="590" y="28">Task 3</text>
+<rect class="n-ghost" x="690" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="760" y="28">Task 4</text>
+<line class="lifeline" x1="80" y1="46" x2="80" y2="440"/>
+<line class="lifeline" x1="250" y1="46" x2="250" y2="440"/>
+<line class="n-ghost" x1="420" y1="46" x2="420" y2="440"/>
+<line class="lifeline" x1="590" y1="46" x2="590" y2="440"/>
+<line class="n-ghost" x1="760" y1="46" x2="760" y2="440"/>
+<text class="t-mut" x="165" y="66">Start</text>
+<path class="e" d="M80,78 H247" marker-end="url(#ptimeout-ah)"/>
+<text class="t-mut" x="250" y="110">Start</text>
+<path class="e" d="M80,122 H417" marker-end="url(#ptimeout-ah)"/>
+<text class="t-mut" x="335" y="154">Start</text>
+<path class="e" d="M80,166 H587" marker-end="url(#ptimeout-ah)"/>
+<text class="t-mut" x="420" y="198">Start</text>
+<path class="e" d="M80,210 H757" marker-end="url(#ptimeout-ah)"/>
+<text class="t-mut t-ok" x="165" y="242">Complete ✓</text>
+<path class="e e-dash" d="M250,254 H83" marker-end="url(#ptimeout-ah)"/>
+<text class="t-mut t-ok" x="335" y="286">Complete ✓</text>
+<path class="e e-dash" d="M590,298 H83" marker-end="url(#ptimeout-ah)"/>
+<rect class="n-hot" x="16" y="318" width="808" height="34" rx="10"/>
+<text class="t-strong" x="420" y="336">Timeout Reached</text>
+<text class="t-mut t-warn" x="250" y="372">Cancel ⏱</text>
+<path class="e e-dim" d="M80,384 H417" marker-end="url(#ptimeout-ah)"/>
+<text class="t-mut t-warn" x="420" y="416">Cancel ⏱</text>
+<path class="e e-dim" d="M80,428 H757" marker-end="url(#ptimeout-ah)"/>
+<rect class="n-hot" x="16" y="448" width="808" height="34" rx="10"/>
+<text class="t-strong" x="420" y="466">Proceed with 2 results</text>
+</svg>
 </div>
 </div>
 

--- a/docs/content/split-join/parallel-patterns.md
+++ b/docs/content/split-join/parallel-patterns.md
@@ -46,6 +46,50 @@ use a single workflow that pulls a batch, splits it into per-item processors via
 <code>TaskResult::Split</code>, and loops until the queue drains.
 </p>
 
+<div class="diagram-frame">
+<p class="diagram-label">Queue consumer: pull, split, drain</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 720 416" role="img">
+<title>Queue consumer pattern: PullBatch pops a batch off the external queue, ProcessBatch returns TaskResult::Split with one Complete branch per item, and the outer loop calls orchestrate again until the queue drains.</title>
+<defs><marker id="queue-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e e-dim" d="M360,342 V372 Q360,380 352,380 H40 Q32,380 32,372 V160 Q32,152 40,152 H302 Q310,152 310,144" marker-end="url(#queue-ah)"/>
+<text class="t-mut" x="376" y="400">outer loop — orchestrate(PullBatch) again until the queue drains</text>
+<rect class="n-cop" x="280" y="16" width="160" height="46" rx="10"/>
+<text class="t-strong" x="360" y="40">Queue</text>
+<text class="t-mut ta-s" x="452" y="44">SQS · Redis · Kafka</text>
+<path class="e" d="M360,62 V90" marker-end="url(#queue-ah)"/>
+<text class="t-mut ta-s" x="372" y="82">pop up to batch_size items</text>
+<path class="e e-dim" d="M280,102 H232 Q224,102 224,110 V122 Q224,130 232,130 H276" marker-end="url(#queue-ah)"/>
+<text class="t-mut ta-e" x="212" y="110">empty batch</text>
+<text class="t-mut ta-e" x="212" y="126">sleep 1s, retry</text>
+<rect class="n" x="280" y="94" width="160" height="46" rx="10"/>
+<text class="t-strong" x="360" y="118">PullBatch</text>
+<text class="t-code t-mut ta-s" x="452" y="122">QueuePuller</text>
+<path class="e" d="M360,140 V168" marker-end="url(#queue-ah)"/>
+<text class="t-code t-mut ta-s" x="372" y="160">store.put("current_batch")</text>
+<rect class="n-hot" x="260" y="172" width="200" height="56" rx="10"/>
+<text class="t-strong" x="360" y="194">ProcessBatch</text>
+<text class="t-code t-mut" x="360" y="214">TaskResult::Split</text>
+<text class="t-code t-mut ta-s" x="472" y="204">BatchSplitter</text>
+<path class="e" d="M360,228 V248"/>
+<path class="e" d="M130,248 H590"/>
+<path class="e" d="M130,248 V286" marker-end="url(#queue-ah)"/>
+<path class="e" d="M360,248 V286" marker-end="url(#queue-ah)"/>
+<path class="e" d="M590,248 V286" marker-end="url(#queue-ah)"/>
+<text class="t-mut" x="245" y="266">one Complete branch per item</text>
+<rect class="n-ok" x="60" y="290" width="140" height="52" rx="10"/>
+<text class="t-strong" x="130" y="311">item 1</text>
+<text class="t-code t-mut" x="130" y="331">Complete</text>
+<rect class="n-ok" x="290" y="290" width="140" height="52" rx="10"/>
+<text class="t-strong" x="360" y="311">item 2</text>
+<text class="t-code t-mut" x="360" y="331">Complete</text>
+<rect class="n-ok" x="520" y="290" width="140" height="52" rx="10"/>
+<text class="t-strong" x="590" y="311">item n</text>
+<text class="t-code t-mut" x="590" y="331">Complete</text>
+</svg>
+</div>
+</div>
+
 ```rust
 use cano::prelude::*;
 use std::collections::VecDeque;
@@ -220,6 +264,64 @@ Cap parallelism when a downstream resource (API keys, connections) is scarce. Th
 below shows the manual alternative — a shared <code>tokio::sync::Semaphore</code> acquired inside each
 task — for cases where you need the limit to span more than one split.
 </p>
+
+<div class="diagram-frame">
+<p class="diagram-label">Resource-limited fan-out: 20 tasks, 5 permits</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 296" role="img">
+<title>Resource-limited fan-out: 20 split tasks share 5 permits, so at most 5 run concurrently and the fan-out completes in four waves of five.</title>
+<defs><marker id="bulk-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<text class="t-code t-hot ta-s" x="16" y="30">Semaphore::new(5)</text>
+<text class="t-mut ta-s" x="16" y="50">= with_bulkhead(5)</text>
+<text class="t-strong" x="188" y="30">wave 1</text>
+<text class="t-strong" x="343" y="30">wave 2</text>
+<text class="t-strong" x="498" y="30">wave 3</text>
+<text class="t-strong" x="653" y="30">wave 4</text>
+<text class="t-mut" x="188" y="50">tasks 0-4</text>
+<text class="t-mut" x="343" y="50">tasks 5-9</text>
+<text class="t-mut" x="498" y="50">tasks 10-14</text>
+<text class="t-mut" x="653" y="50">tasks 15-19</text>
+<text class="t-mut ta-e" x="100" y="84">permit 1</text>
+<text class="t-mut ta-e" x="100" y="114">permit 2</text>
+<text class="t-mut ta-e" x="100" y="144">permit 3</text>
+<text class="t-mut ta-e" x="100" y="174">permit 4</text>
+<text class="t-mut ta-e" x="100" y="204">permit 5</text>
+<rect class="band-hot" x="113" y="68" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="268" y="68" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="423" y="68" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="578" y="68" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="113" y="98" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="268" y="98" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="423" y="98" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="578" y="98" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="113" y="128" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="268" y="128" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="423" y="128" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="578" y="128" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="113" y="158" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="268" y="158" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="423" y="158" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="578" y="158" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="113" y="188" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="268" y="188" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="423" y="188" width="149" height="22" rx="5"/>
+<rect class="band-hot" x="578" y="188" width="149" height="22" rx="5"/>
+<line class="axis" x1="110" y1="224" x2="730" y2="224"/>
+<path class="e e-dim" d="M730,224 H752" marker-end="url(#bulk-ah)"/>
+<line class="tick" x1="110" y1="224" x2="110" y2="230"/>
+<line class="tick" x1="265" y1="224" x2="265" y2="230"/>
+<line class="tick" x1="420" y1="224" x2="420" y2="230"/>
+<line class="tick" x1="575" y1="224" x2="575" y2="230"/>
+<line class="tick" x1="730" y1="224" x2="730" y2="230"/>
+<text class="t-mut" x="110" y="246">0</text>
+<text class="t-mut" x="265" y="246">T</text>
+<text class="t-mut" x="420" y="246">2T</text>
+<text class="t-mut" x="575" y="246">3T</text>
+<text class="t-mut" x="730" y="246">4T</text>
+<text class="t-mut" x="420" y="276">T = one task duration — 5 permits gate 20 tasks, so the fan-out completes in 4 waves of 5</text>
+</svg>
+</div>
+</div>
 
 ```rust
 use cano::prelude::*;

--- a/docs/content/stepped-task/_index.md
+++ b/docs/content/stepped-task/_index.md
@@ -86,15 +86,39 @@ the step at and after the resume point may re-run.
 
 <div class="diagram-frame">
 <p class="diagram-label">The step loop, with a crash &amp; resume from the last cursor</p>
-<div class="mermaid">
-graph LR
-A["step(None)"] -->|"More(c1)"| P1[persist cursor c1]
-P1 --> B["step(Some c1)"]
-B -->|"More(c2)"| P2[persist cursor c2]
-P2 --> C[…]
-C -->|"Done(result)"| D[Next State]
-P2 -. crash .-> R["resume_from"]
-R -->|"step(Some c2)"| C
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 748 226" role="img">
+<title>The step loop: each step returns More(cursor), the engine persists that cursor to the checkpoint store and calls step again with it; after a crash, resume_from reads the last persisted cursor and re-enters the loop at that step, while Done(result) leaves for the next state.</title>
+<defs><marker id="stepped-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e" d="M68,90 V110 Q68,118 76,118 H120 Q128,118 128,126 V141" marker-end="url(#stepped-ah)"/>
+<text class="t-code" x="108" y="104">More(c1)</text>
+<path class="e" d="M188,146 V126 Q188,118 196,118 H237 Q245,118 245,110 V95" marker-end="url(#stepped-ah)"/>
+<path class="e" d="M273,90 V110 Q273,118 281,118 H322 Q330,118 330,126 V141" marker-end="url(#stepped-ah)"/>
+<text class="t-code" x="312" y="104">More(c2)</text>
+<path class="e" d="M390,146 V126 Q390,118 398,118 H439 Q447,118 447,110 V95" marker-end="url(#stepped-ah)"/>
+<path class="e" d="M520,67 H620" marker-end="url(#stepped-ah)"/>
+<text class="t-code" x="572" y="50">Done(result)</text>
+<path class="e e-dash" d="M444,168 H516" marker-end="url(#stepped-ah)"/>
+<text class="t-mut t-err" x="480" y="154">crash</text>
+<path class="e e-hot e-dash" d="M566,146 V120 Q566,112 558,112 H513 Q505,112 505,104 V95" marker-end="url(#stepped-ah)"/>
+<text class="t-code t-hot ta-s" x="578" y="130">step(Some c2)</text>
+<text class="t-mut" x="461" y="26">&hellip; repeats until Done</text>
+<rect class="n" x="20" y="44" width="96" height="46" rx="10"/>
+<text class="t-code" x="68" y="68">step(None)</text>
+<rect class="n" x="200" y="44" width="118" height="46" rx="10"/>
+<text class="t-code" x="259" y="68">step(Some c1)</text>
+<rect class="n" x="402" y="44" width="118" height="46" rx="10"/>
+<text class="t-code" x="461" y="68">step(Some c2)</text>
+<rect class="n-ok" x="624" y="44" width="104" height="46" rx="10"/>
+<text x="676" y="68">Next State</text>
+<rect class="n-cop" x="74" y="146" width="168" height="44" rx="10"/>
+<text x="158" y="169">persist cursor c1</text>
+<rect class="n-cop" x="276" y="146" width="168" height="44" rx="10"/>
+<text x="360" y="169">persist cursor c2</text>
+<rect class="n-hot" x="520" y="146" width="118" height="44" rx="10"/>
+<text class="t-code t-strong" x="579" y="169">resume_from</text>
+<text class="t-mut" x="259" y="206">written to the checkpoint store</text>
+</svg>
 </div>
 </div>
 

--- a/docs/content/store/_index.md
+++ b/docs/content/store/_index.md
@@ -46,13 +46,29 @@ the full <code>insert</code> / <code>get</code> API.
 
 <div class="diagram-frame">
 <p class="diagram-label">One shared map, many readers and writers</p>
-<div class="mermaid">
-graph LR
-S["Arc&lt;RwLock&lt;HashMap&gt;&gt;"]
-S --> R1["Task A (read)"]
-S --> R2["Task B (read)"]
-S --> W1["Task C (write)"]
-style S fill:#1e293b,stroke:#38bdf8
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 770 280" role="img">
+<title>One MemoryStore — an Arc&lt;RwLock&lt;HashMap&gt;&gt; — shared by three tasks: Task A and Task B hold the read lock concurrently while Task C takes the write lock exclusively.</title>
+<defs><marker id="store-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e" d="M242,124 H330 Q342,124 342,112 V88 Q342,76 354,76 H494" marker-end="url(#store-ah)"/>
+<text class="t-code t-mut" x="424" y="59">.get()</text>
+<path class="e" d="M242,132 H494" marker-end="url(#store-ah)"/>
+<text class="t-code t-mut" x="424" y="115">.get()</text>
+<path class="e" d="M242,140 H330 Q342,140 342,152 V210 Q342,222 354,222 H494" marker-end="url(#store-ah)"/>
+<text class="t-code t-mut" x="424" y="205">.put()</text>
+<rect class="n-ghost" x="468" y="40" width="252" height="128" rx="12"/>
+<rect class="n-hot" x="28" y="96" width="214" height="72" rx="10"/>
+<text class="t-strong" x="135" y="121">MemoryStore</text>
+<text class="t-code t-mut" x="135" y="145">Arc&lt;RwLock&lt;HashMap&gt;&gt;</text>
+<rect class="n" x="498" y="54" width="192" height="44" rx="10"/>
+<text x="594" y="77">Task A (read)</text>
+<rect class="n" x="498" y="110" width="192" height="44" rx="10"/>
+<text x="594" y="133">Task B (read)</text>
+<text class="t-mut" x="594" y="186">shared read lock — concurrent</text>
+<rect class="n" x="498" y="200" width="192" height="44" rx="10"/>
+<text x="594" y="223">Task C (write)</text>
+<text class="t-mut" x="594" y="264">exclusive write lock — readers wait</text>
+</svg>
 </div>
 </div>
 

--- a/docs/content/stream-task/_index.md
+++ b/docs/content/stream-task/_index.md
@@ -163,16 +163,40 @@ cancelled/exhausted, and resumes from a cursor.
 
 <div class="diagram-frame">
 <p class="diagram-label">open &rarr; process_item (×window) &rarr; flush_window &rarr; commit cursor &rarr; … &rarr; on_close</p>
-<div class="mermaid">
-graph LR
-A["open(cursor)"] --> B[process_item]
-B -->|"buffer until window full"| B
-B -->|"window full"| F[flush_window]
-F -->|"Continue"| P[commit cursor]
-P --> B
-F -->|"Stop(result)"| D[Next State]
-B -->|"source exhausted"| C[on_close]
-C --> D
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 340" role="img">
+<title>The stream loop: open resumes from a cursor, process_item buffers items until the window is full, flush_window emits that window, its cursor is committed and the loop repeats; a Stop signal or an exhausted source ends via on_close in the next state.</title>
+<defs><marker id="stream-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e e-dim" d="M292,64 V44 Q292,36 300,36 H362 Q370,36 370,44 V61" marker-end="url(#stream-ah)"/>
+<text class="t-mut" x="331" y="18">buffer until window full</text>
+<path class="e" d="M688,87 H722 Q734,87 734,99 V287 Q734,299 722,299 H692" marker-end="url(#stream-ah)"/>
+<text class="t-code ta-e" x="724" y="124">Stop(result)</text>
+<path class="e" d="M158,87 H248" marker-end="url(#stream-ah)"/>
+<text class="t-mut" x="203" y="70">once per run</text>
+<path class="e e-hot" d="M410,87 H526" marker-end="url(#stream-ah)"/>
+<text class="t-code t-hot" x="468" y="70">window full</text>
+<path class="e" d="M609,110 V186" marker-end="url(#stream-ah)"/>
+<text class="t-code ta-e" x="598" y="150">Continue</text>
+<path class="e" d="M530,213 H352 Q340,213 340,201 V114" marker-end="url(#stream-ah)"/>
+<text class="t-mut" x="440" y="196">next window</text>
+<path class="e" d="M292,110 V272" marker-end="url(#stream-ah)"/>
+<text class="t-mut ta-e" x="282" y="160">source exhausted</text>
+<path class="e" d="M372,299 H526" marker-end="url(#stream-ah)"/>
+<text class="t-code t-mut" x="449" y="282">TaskResult::Single</text>
+<rect class="n" x="16" y="64" width="142" height="46" rx="10"/>
+<text class="t-code" x="87" y="88">open(cursor)</text>
+<rect class="n" x="252" y="64" width="158" height="46" rx="10"/>
+<text class="t-code" x="331" y="88">process_item</text>
+<rect class="n-hot" x="530" y="64" width="158" height="46" rx="10"/>
+<text class="t-code t-strong" x="609" y="88">flush_window</text>
+<rect class="n-cop" x="530" y="190" width="158" height="46" rx="10"/>
+<text x="609" y="214">commit cursor</text>
+<text class="t-mut" x="609" y="252">StepCursor checkpoint row</text>
+<rect class="n" x="212" y="276" width="160" height="46" rx="10"/>
+<text class="t-code" x="292" y="300">on_close(reason)</text>
+<rect class="n-ok" x="530" y="276" width="158" height="46" rx="10"/>
+<text x="609" y="300">Next State</text>
+</svg>
 </div>
 </div>
 
@@ -312,8 +336,10 @@ flush + checkpoint cost.
  </div>
  <div class="card">
  <h3><code>StreamWindow::Duration(d)</code></h3>
- <p>Flush every <code>d</code> of wall-clock time, tumbling. <strong>Empty windows are skipped</strong>
- — an idle source emits no spurious empty flushes; the deadline simply advances.</p>
+ <p>Flush every <code>d</code> of wall-clock time, tumbling (clamped to a floor of <strong>1ms</strong>
+ — a zero duration would leave the tick permanently ready and busy-loop without ever polling the
+ source). <strong>Empty windows are skipped</strong> — an idle source emits no spurious empty flushes;
+ the deadline simply advances.</p>
  </div>
  </div>
 
@@ -406,6 +432,44 @@ drain</strong>:
 <li>the run ends as <code>CanoError::Cancelled</code> (category <code>"cancelled"</code>).</li>
 </ol>
 
+<p>
+The window boundary is not the only cancellable point: <code>open()</code> races the <em>same</em>
+effective token as the loop. A source that hangs while connecting — a broker that never hands back a
+consumer — is cancellable and timeoutable too, not just the gaps between windows. No cursor exists
+yet at that point, so there is nothing to flush or commit; the pending <code>open</code> future is
+simply dropped.
+</p>
+
+<p>
+<a href="../resilience/#workflow-total-timeout"><code>Workflow::with_total_timeout</code></a> is
+honoured for Stream states, and it is honoured <em>through that same drain</em>. Instead of wrapping
+the state in a deadline that would drop the future mid-window, the engine folds the budget into the
+token the loop already watches — so a deadline trip still flushes the in-flight window and still
+commits its cursor, exactly like a real cancel. Only the error at the end differs:
+</p>
+
+<table class="styled-table">
+<thead>
+<tr>
+<th>Stop trigger</th>
+<th>In-flight window</th>
+<th>Surfaced error</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>the run's <code>CancellationToken</code> fires</td>
+<td>flushed, cursor committed, <code>on_close(Cancelled)</code> runs</td>
+<td><code>CanoError::Cancelled</code> (category <code>"cancelled"</code>)</td>
+</tr>
+<tr>
+<td>the <code>with_total_timeout</code> deadline trips</td>
+<td>identical — the same cooperative drain</td>
+<td><code>CanoError::WorkflowTimeout</code> (category <code>"workflow_timeout"</code>)</td>
+</tr>
+</tbody>
+</table>
+
 <div class="callout callout-warning">
 <span class="callout-label">Cancel means "stop cleanly + resumable", not "transition onward"</span>
 <p>
@@ -414,6 +478,32 @@ A cancelled stream does <strong>not</strong> gracefully transition to another st
 <code>resume_from</code> continues from the last committed window. So cancellation is a clean,
 resumable stop, not a hand-off. (An <code>Err</code> returned by <code>on_close</code> during the
 drain <em>is</em> propagated.)
+</p>
+</div>
+
+<div class="callout callout-warning">
+<span class="callout-label">If the drain's own flush fails, that window replays</span>
+<p>
+The drain's <code>flush_window</code> can itself return an <code>Err</code>. When it does,
+<code>on_close(CloseReason::Cancelled)</code> still gets its cleanup shot — best-effort, its own error
+discarded in favour of the flush error — and the window's cursor is <strong>not</strong> committed.
+The flush error is what the run surfaces, and a later <code>resume_from</code> re-opens at the
+<em>previous</em> committed cursor, replaying that window. That is the
+<a href="#idempotency">at-least-once contract</a> earning its keep.
+</p>
+</div>
+
+<div class="callout callout-info">
+<div class="callout-label">"Cancelled" is a classification, not just a trigger</div>
+<p>
+A run is <em>reported</em> as cancelled — the
+<a href="../observers/#on-cancelled"><code>on_cancelled</code></a> observer hook, the
+<code>"cancelled"</code> metrics label — only when the engine's drain fired <strong>and</strong> the
+final result is still <code>Cancelled</code>. If something after an otherwise successful drain fails,
+most realistically the <code>StepCursor</code> checkpoint append, that error wins and the run is
+reported as <strong>failed</strong>. Conversely, a <code>StreamTask</code> that organically returns
+<code>Err(CanoError::Cancelled)</code> from <code>process_item</code> / <code>flush_window</code> /
+<code>on_close</code> never triggered the drain, so it stays on the failure path too.
 </p>
 </div>
 

--- a/docs/content/task/_index.md
+++ b/docs/content/task/_index.md
@@ -48,6 +48,38 @@ example on this page wires a task into a <code>Workflow</code> and pulls depende
 <h2 id="implementing"><a href="#implementing" class="anchor-link" aria-hidden="true">#</a>Implementing a Task</h2>
 <p>To create a task, implement the <code>Task</code> trait for your struct. The trait requires a <code>run</code> method and an optional <code>config</code> method.</p>
 
+<div class="diagram-frame">
+<p class="diagram-label">One dispatch: config &rarr; retry envelope &rarr; run &rarr; TaskResult</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 270" role="img">
+<title>One task dispatch: config() supplies the TaskConfig when the task is registered, run_with_retries drives run(&amp;Resources) one attempt at a time — a failed attempt waits its backoff and retries, a success returns TaskResult::Single(next) and the workflow enters that state, and a failure on the last attempt propagates as a CanoError.</title>
+<defs><marker id="life-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e e-dim" d="M660,64 V42 Q660,34 652,34 H365 Q357,34 357,42 V57" marker-end="url(#life-ah)"/>
+<text class="t-mut" x="508" y="26">Err &#8594; wait backoff, then retry</text>
+<path class="e" d="M140,87 H248" marker-end="url(#life-ah)"/>
+<text class="t-code t-mut" x="194" y="70">TaskConfig</text>
+<path class="e" d="M462,87 H568" marker-end="url(#life-ah)"/>
+<text class="t-mut" x="515" y="70">each attempt</text>
+<path class="e" d="M357,114 V148 Q357,156 349,156 H109 Q101,156 101,164 V192" marker-end="url(#life-ah)"/>
+<text class="t-mut t-err ta-e" x="345" y="144">last attempt failed</text>
+<path class="e" d="M357,114 V148 Q357,156 365,156 H664 Q672,156 672,164 V192" marker-end="url(#life-ah)"/>
+<text class="t-code t-mut ta-s" x="367" y="144">Ok(TaskResult::Single(next))</text>
+<rect class="n" x="16" y="64" width="124" height="46" rx="10"/>
+<text class="t-code" x="78" y="88">config()</text>
+<text class="t-mut" x="78" y="128">once, at register</text>
+<rect class="n-hot" x="252" y="60" width="210" height="54" rx="10"/>
+<text class="t-code t-strong" x="357" y="78">run_with_retries</text>
+<text class="t-mut" x="357" y="97">retry &#183; timeout &#183; breaker</text>
+<rect class="n" x="572" y="64" width="176" height="46" rx="10"/>
+<text class="t-code" x="660" y="88">run(&amp;Resources)</text>
+<rect class="n-err" x="16" y="196" width="170" height="46" rx="10"/>
+<text class="t-code" x="101" y="220">Err(CanoError)</text>
+<rect class="n-ok" x="596" y="196" width="152" height="46" rx="10"/>
+<text x="672" y="220">Next State</text>
+</svg>
+</div>
+</div>
+
 <div class="code-block">
 <span class="code-block-label"><span class="label-icon">&#9998;</span> Implementing Task trait</span>
 
@@ -335,6 +367,43 @@ Beyond the plain <code>Task</code>, Cano ships
 they all ultimately dispatch as a <code>Task</code>, so you mix them freely in one workflow — and
 each has its own page with the full reference.
 </p>
+
+<div class="diagram-frame">
+<p class="diagram-label">The seven processing models, grouped by what they add to a plain Task</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 272" role="img">
+<title>The task family: a plain Task runs once and picks the next state; RouterTask decides in the same single pass but records no checkpoint; PollTask and TimerTask add a wait the engine sleeps through; BatchTask, SteppedTask and StreamTask iterate many units inside one state.</title>
+<defs><marker id="fam-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e" d="M156,138 H174 Q182,138 182,130 V62 Q182,54 190,54 H202" marker-end="url(#fam-ah)"/>
+<path class="e" d="M156,138 H202" marker-end="url(#fam-ah)"/>
+<path class="e" d="M156,138 H174 Q182,138 182,146 V214 Q182,222 190,222 H202" marker-end="url(#fam-ah)"/>
+<rect class="n-hot" x="14" y="106" width="142" height="64" rx="10"/>
+<text class="t-strong" x="85" y="129">Task</text>
+<text class="t-mut" x="85" y="148">run &#8594; next state</text>
+<text class="t-mut ta-s" x="206" y="18">immediate &#8212; returns a state in one pass</text>
+<rect class="n" x="206" y="28" width="176" height="52" rx="10"/>
+<text class="t-strong" x="294" y="45">RouterTask</text>
+<text class="t-mut" x="294" y="64">decide, no checkpoint</text>
+<text class="t-mut ta-s" x="206" y="102">wait-based &#8212; the engine sleeps, then continues</text>
+<rect class="n" x="206" y="112" width="176" height="52" rx="10"/>
+<text class="t-strong" x="294" y="129">PollTask</text>
+<text class="t-mut" x="294" y="148">loop until Ready</text>
+<rect class="n" x="398" y="112" width="176" height="52" rx="10"/>
+<text class="t-strong" x="486" y="129">TimerTask</text>
+<text class="t-mut" x="486" y="148">wait once, then route</text>
+<text class="t-mut ta-s" x="206" y="186">iterating &#8212; many units inside one state</text>
+<rect class="n" x="206" y="196" width="176" height="52" rx="10"/>
+<text class="t-strong" x="294" y="213">BatchTask</text>
+<text class="t-mut" x="294" y="232">map over a collection</text>
+<rect class="n" x="398" y="196" width="176" height="52" rx="10"/>
+<text class="t-strong" x="486" y="213">SteppedTask</text>
+<text class="t-mut" x="486" y="232">cursor per step</text>
+<rect class="n" x="590" y="196" width="176" height="52" rx="10"/>
+<text class="t-strong" x="678" y="213">StreamTask</text>
+<text class="t-mut" x="678" y="232">flush per window</text>
+</svg>
+</div>
+</div>
 
 <div class="card-stack">
 <div class="card">

--- a/docs/content/task/configuration.md
+++ b/docs/content/task/configuration.md
@@ -33,18 +33,35 @@ The <code>TaskConfig</code> struct allows you to specify the retry behavior.
 <h3>Retry Strategy Examples</h3>
 <div class="diagram-frame">
 <p class="diagram-label">Retry with backoff between attempts</p>
-<div class="mermaid">
-sequenceDiagram
-participant W as Workflow
-participant T as Task
-W->>T: Execute
-T-->>W: Fail
-Note over W: Wait (backoff)
-W->>T: Retry 1
-T-->>W: Fail
-Note over W: Wait (longer)
-W->>T: Retry 2
-T-->>W: Success ✓
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 720 398" role="img">
+<title>Retry with backoff: the workflow calls the task, the attempt fails, the workflow waits a backoff delay, retries, fails again, waits twice as long, and the third attempt succeeds.</title>
+<defs><marker id="cfg-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<line class="lifeline" x1="190" y1="46" x2="190" y2="332"/>
+<line class="lifeline" x1="530" y1="46" x2="530" y2="332"/>
+<rect class="n" x="120" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="190" y="32">Workflow</text>
+<rect class="n" x="460" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="530" y="32">Task</text>
+<rect class="band" x="182" y="120" width="16" height="40" rx="5"/>
+<text class="t-mut ta-e" x="172" y="145">wait (backoff)</text>
+<rect class="band" x="182" y="202" width="16" height="80" rx="5"/>
+<text class="t-mut ta-e" x="172" y="247">wait (longer, 2×)</text>
+<path class="e" d="M190,82 H526" marker-end="url(#cfg-ah)"/>
+<text class="t-mut" x="358" y="70">Execute</text>
+<path class="e e-dash" d="M530,116 H194" marker-end="url(#cfg-ah)"/>
+<text class="t-mut t-err" x="362" y="104">Fail</text>
+<path class="e" d="M190,164 H526" marker-end="url(#cfg-ah)"/>
+<text class="t-mut" x="358" y="152">Retry 1</text>
+<path class="e e-dash" d="M530,198 H194" marker-end="url(#cfg-ah)"/>
+<text class="t-mut t-err" x="362" y="186">Fail</text>
+<path class="e" d="M190,286 H526" marker-end="url(#cfg-ah)"/>
+<text class="t-mut" x="358" y="274">Retry 2</text>
+<path class="e e-dash" d="M530,320 H194" marker-end="url(#cfg-ah)"/>
+<text class="t-mut t-ok" x="362" y="308">Success ✓</text>
+<rect class="n-hot" x="40" y="340" width="640" height="34" rx="10"/>
+<text class="t-strong" x="360" y="362">Backoff grows between attempts; the loop stops at the first success.</text>
+</svg>
 </div>
 </div>
 

--- a/docs/content/testing/_index.md
+++ b/docs/content/testing/_index.md
@@ -48,7 +48,7 @@ so the helpers compile only for tests and never ship in your release build:
 
 ```toml
 [dev-dependencies]
-cano = { version = "0.14", features = ["testing"] }
+{{ cano_dep(features=["testing"]) }}
 ```
 
 <p>The <code>testing</code> feature pulls in no extra dependencies and is zero-cost when off.</p>

--- a/docs/content/testing/_index.md
+++ b/docs/content/testing/_index.md
@@ -62,6 +62,34 @@ assert against the recorded path — or use the <code>assert_path</code> /
 <code>assert_completed_with</code> convenience checks.
 </p>
 
+<div class="diagram-frame">
+<p class="diagram-label">Attach the observer, run the workflow, assert on what it recorded</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 272" role="img">
+<title>A RecordingObserver is attached with with_observer, the workflow under test is orchestrated, every observer hook lands in a Vec of RecordedEvent, and the test asserts against that recording.</title>
+<defs><marker id="harness-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e" d="M270,68 H466" marker-end="url(#harness-ah)"/>
+<text class="t-code t-mut" x="368" y="56">.with_observer(obs)</text>
+<path class="e" d="M595,92 V162" marker-end="url(#harness-ah)"/>
+<text class="t-code ta-e" x="583" y="118">orchestrate(Start, &hellip;)</text>
+<text class="t-mut ta-e" x="583" y="136">every hook recorded</text>
+<path class="e" d="M466,190 H316" marker-end="url(#harness-ah)"/>
+<text class="t-code t-mut" x="388" y="178">observer.events()</text>
+<rect class="n-hot" x="40" y="44" width="230" height="48" rx="10"/>
+<text class="t-code" x="155" y="69">RecordingObserver</text>
+<rect class="n" x="470" y="44" width="250" height="48" rx="10"/>
+<text class="t-strong" x="595" y="69">Workflow under test</text>
+<rect class="n-cop" x="470" y="166" width="250" height="48" rx="10"/>
+<text class="t-code" x="595" y="191">Vec&lt;RecordedEvent&gt;</text>
+<rect class="n-ok" x="20" y="152" width="290" height="76" rx="10"/>
+<text class="t-code" x="165" y="170">assert_path(&amp;[&hellip;])</text>
+<text class="t-code" x="165" y="190">assert_completed_with</text>
+<text class="t-code" x="165" y="210">assert_registered_states_entered</text>
+<text class="t-mut" x="390" y="254">Fixtures plug into the normal builders; the recording is what the test asserts against.</text>
+</svg>
+</div>
+</div>
+
 ```rust
 use cano::prelude::*;
 use cano::testing::*;
@@ -118,6 +146,40 @@ you can inspect the gap (<code>?</code>-propagate, <code>.expect(..)</code>, or
 <li><code>assert_all_states_entered(&amp;[..])</code> — check an explicit list of states (compared by their <code>Debug</code> rendering).</li>
 <li><code>assert_registered_states_entered(&amp;workflow)</code> — check <em>every state the workflow registered a handler for</em> (via <a href="../workflows/"><code>Workflow::registered_states</code></a>). Exit-only states added with <code>add_exit_state</code> and no handler are not required.</li>
 </ul>
+
+<div class="diagram-frame">
+<p class="diagram-label">Dead-state check: registered states minus states entered</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 272" role="img">
+<title>assert_registered_states_entered compares the states the workflow registered a handler for against the states the RecordingObserver saw entered; an empty difference is Ok, and anything left over is a dead state reported as Err.</title>
+<defs><marker id="cover-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e" d="M280,78 H298 Q306,78 306,86 V110 Q306,118 314,118 H326" marker-end="url(#cover-ah)"/>
+<path class="e" d="M280,190 H298 Q306,190 306,182 V148 Q306,140 314,140 H326" marker-end="url(#cover-ah)"/>
+<path class="e" d="M550,120 H562 Q570,120 570,112 V80 Q570,72 578,72 H596" marker-end="url(#cover-ah)"/>
+<text class="t-mut t-ok ta-e" x="556" y="90">all entered</text>
+<path class="e" d="M550,138 H562 Q570,138 570,146 V180 Q570,188 578,188 H596" marker-end="url(#cover-ah)"/>
+<text class="t-mut t-err ta-e" x="556" y="176">missing</text>
+<rect class="n" x="20" y="34" width="260" height="88" rx="10"/>
+<text class="t-code" x="150" y="57">workflow.registered_states()</text>
+<text class="t-strong" x="150" y="78">Start · Worker</text>
+<text class="t-mut" x="150" y="99">exit-only Done excluded</text>
+<rect class="n-cop" x="20" y="146" width="260" height="88" rx="10"/>
+<text class="t-code" x="150" y="169">observer.states_entered()</text>
+<text class="t-strong" x="150" y="190">Start · Done</text>
+<text class="t-mut" x="150" y="211">from StateEntered events</text>
+<rect class="n-hot" x="330" y="100" width="220" height="58" rx="10"/>
+<text class="t-strong" x="440" y="120">compare</text>
+<text class="t-code" x="440" y="138">registered &minus; entered</text>
+<rect class="n-ok" x="600" y="44" width="160" height="56" rx="10"/>
+<text class="t-code" x="680" y="63">Ok(())</text>
+<text class="t-mut" x="680" y="81">no dead states</text>
+<rect class="n-err" x="600" y="160" width="160" height="56" rx="10"/>
+<text class="t-code" x="680" y="179">Err(["Worker"])</text>
+<text class="t-mut t-err" x="680" y="197">dead state</text>
+<text class="t-mut" x="390" y="254">assert_registered_states_entered names every registered state nothing ever routed to.</text>
+</svg>
+</div>
+</div>
 
 ```rust
 use cano::prelude::*;

--- a/docs/content/timer-task/_index.md
+++ b/docs/content/timer-task/_index.md
@@ -76,11 +76,27 @@ waiting. A timer wakes once; a poller loops.
 
 <div class="diagram-frame">
 <p class="diagram-label">wait &rarr; sleep once &rarr; after_wait</p>
-<div class="mermaid">
-graph LR
-A[wait] -->|"TimerOutcome"| B[sleep once]
-B --> C[after_wait]
-C --> D[Next State]
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 726 204" role="img">
+<title>A TimerTask waits exactly once: wait returns a TimerOutcome, the engine schedules a single sleep for that duration or until that instant, then after_wait runs and its TaskResult moves the workflow to the next state.</title>
+<defs><marker id="timer-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e" d="M130,51 H276" marker-end="url(#timer-ah)"/>
+<text class="t-code" x="205" y="34">TimerOutcome</text>
+<path class="e" d="M440,51 H576" marker-end="url(#timer-ah)"/>
+<text class="t-mut" x="510" y="34">wakes once</text>
+<rect class="n" x="26" y="28" width="104" height="46" rx="10"/>
+<text class="t-code" x="78" y="52">wait</text>
+<rect class="n-hot" x="280" y="28" width="160" height="46" rx="10"/>
+<text class="t-strong" x="360" y="52">sleep once</text>
+<text class="t-code t-mut" x="360" y="96">Duration(d) &middot; Until(instant)</text>
+<text class="t-mut" x="360" y="116">exactly one wake-up &mdash; not a poll loop</text>
+<rect class="n" x="580" y="28" width="120" height="46" rx="10"/>
+<text class="t-code" x="640" y="52">after_wait</text>
+<path class="e" d="M640,74 V129" marker-end="url(#timer-ah)"/>
+<text class="t-code t-mut ta-e" x="630" y="102">TaskResult</text>
+<rect class="n-ok" x="582" y="134" width="116" height="46" rx="10"/>
+<text x="640" y="158">Next State</text>
+</svg>
 </div>
 </div>
 

--- a/docs/content/tracing/_index.md
+++ b/docs/content/tracing/_index.md
@@ -108,6 +108,39 @@ tracing_subscriber::registry()
 <p>Workflow scheduling, concurrent execution, run counts, durations.</p>
 </div>
 </div>
+
+<div class="diagram-frame">
+<p class="diagram-label">The span tree one run emits &mdash; spans nest, fields inherit</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 292" role="img">
+<title>The nested span tree a run emits: a root workflow_orchestrate span holds one single_task_execution span per dispatched state, each of those holds a run_with_retries span, and every attempt of the task gets its own task_attempt child &mdash; so a state that retried once shows two.</title>
+<rect class="n-hot" x="16" y="40" width="748" height="192" rx="10"/>
+<text class="t-code ta-s" x="30" y="60">workflow_orchestrate { workflow_id }</text>
+<text class="t-mut ta-e" x="750" y="60">root span &mdash; every child inherits its fields</text>
+<rect class="n" x="32" y="74" width="400" height="144" rx="10"/>
+<text class="t-code ta-s" x="46" y="94">single_task_execution</text>
+<text class="t-mut ta-e" x="418" y="94">state = FetchData</text>
+<rect class="n" x="48" y="108" width="368" height="96" rx="10"/>
+<text class="t-code ta-s" x="62" y="128">run_with_retries { max_attempts = 2 }</text>
+<rect class="n-err" x="64" y="142" width="161" height="48" rx="10"/>
+<text class="t-code" x="145" y="158">task_attempt</text>
+<text class="t-mut" x="145" y="176">attempt = 1</text>
+<rect class="n-ok" x="239" y="142" width="161" height="48" rx="10"/>
+<text class="t-code" x="320" y="158">task_attempt</text>
+<text class="t-mut" x="320" y="176">attempt = 2</text>
+<rect class="n" x="446" y="74" width="302" height="144" rx="10"/>
+<text class="t-code ta-s" x="460" y="94">single_task_execution</text>
+<text class="t-mut ta-e" x="734" y="94">state = Persist</text>
+<rect class="n" x="462" y="108" width="272" height="96" rx="10"/>
+<text class="t-code ta-s" x="476" y="128">run_with_retries</text>
+<rect class="n-ok" x="478" y="142" width="240" height="48" rx="10"/>
+<text class="t-code" x="598" y="158">task_attempt</text>
+<text class="t-mut" x="598" y="176">attempt = 1</text>
+<text class="t-mut" x="390" y="254">Each event carries the fields of every span above it &mdash; workflow_id reaches the innermost attempt.</text>
+<text class="t-mut" x="390" y="276">Scheduled runs nest under execute_flow, resumes under workflow_resume, split branches under split_task.</text>
+</svg>
+</div>
+</div>
 <hr class="section-divider">
 
 <h2 id="error-tracing"><a href="#error-tracing" class="anchor-link" aria-hidden="true">#</a>Error Tracing</h2>
@@ -115,6 +148,42 @@ tracing_subscriber::registry()
 When the <code>tracing</code> feature is enabled, Cano automatically instruments error paths
 at appropriate severity levels so you can diagnose failures without adding custom logging.
 </p>
+
+<div class="diagram-frame">
+<p class="diagram-label">WARN per failed attempt, ERROR only when max_attempts is reached</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 296" role="img">
+<title>Severity escalation across a retried task: every failed attempt logs a WARN inside its own task_attempt span, the attempt that reaches max_attempts logs an ERROR instead, and the resulting CanoError surfaces again as an ERROR on the workflow span, carrying the failing state.</title>
+<defs><marker id="trace-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e" d="M172,122 H220" marker-end="url(#trace-ah)"/>
+<text class="t-mut" x="198" y="108">retry</text>
+<path class="e" d="M364,122 H412" marker-end="url(#trace-ah)"/>
+<text class="t-mut" x="390" y="108">retry</text>
+<path class="e e-hot" d="M556,122 H604" marker-end="url(#trace-ah)"/>
+<path class="e" d="M678,176 V204" marker-end="url(#trace-ah)"/>
+<text class="t-mut ta-e" x="668" y="192">propagates as CanoError</text>
+<rect class="n" x="16" y="44" width="748" height="132" rx="10"/>
+<text class="t-code ta-s" x="30" y="64">run_with_retries { max_attempts = 4 }</text>
+<text class="t-mut t-hot" x="582" y="74">attempt reaches max_attempts</text>
+<rect class="n-warn" x="32" y="88" width="140" height="68" rx="10"/>
+<text class="t-code" x="102" y="110">attempt = 1</text>
+<text class="t-strong t-warn" x="102" y="134">WARN</text>
+<rect class="n-warn" x="224" y="88" width="140" height="68" rx="10"/>
+<text class="t-code" x="294" y="110">attempt = 2</text>
+<text class="t-strong t-warn" x="294" y="134">WARN</text>
+<rect class="n-warn" x="416" y="88" width="140" height="68" rx="10"/>
+<text class="t-code" x="486" y="110">attempt = 3</text>
+<text class="t-strong t-warn" x="486" y="134">WARN</text>
+<rect class="n-err" x="608" y="88" width="140" height="68" rx="10"/>
+<text class="t-code" x="678" y="110">attempt = 4</text>
+<text class="t-strong t-err" x="678" y="134">ERROR</text>
+<rect class="n-err" x="16" y="208" width="748" height="56" rx="10"/>
+<text class="t-code" x="390" y="227">workflow_orchestrate</text>
+<text class="t-mut" x="390" y="247"><tspan class="t-err">ERROR</tspan> &mdash; Task failed in state FetchData after exhausting retries</text>
+<text class="t-mut" x="390" y="282">Any attempt that succeeds logs INFO and ends the loop &mdash; the ERROR level is reserved for exhaustion.</text>
+</svg>
+</div>
+</div>
 
 <div class="card-stack">
 <div class="card">

--- a/docs/content/workflows/_index.md
+++ b/docs/content/workflows/_index.md
@@ -57,12 +57,30 @@ configuration, or clients), or <code>Workflow::bare()</code> when every task is 
 </p>
 <div class="diagram-frame">
 <p class="diagram-label">Workflow State Transitions</p>
-<div class="mermaid">
-graph TD
-A[Start] --> B[Validate]
-B -->|Valid| C[Process]
-B -->|Invalid| D[Failed]
-C --> E[Complete]
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 660 368" role="img">
+<title>Workflow state transitions: Start moves to Validate, which branches to Process when the input is valid or to Failed when it is not; Process finishes at Complete.</title>
+<defs><marker id="wfstate-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<path class="e" d="M150,68 V106" marker-end="url(#wfstate-ah)"/>
+<path class="e" d="M150,156 V194" marker-end="url(#wfstate-ah)"/>
+<path class="e" d="M215,133 H497 Q505,133 505,141 V194" marker-end="url(#wfstate-ah)"/>
+<path class="e" d="M150,244 V282" marker-end="url(#wfstate-ah)"/>
+<text class="t-mut t-ok ta-s" x="162" y="175">Valid</text>
+<text class="t-mut t-err" x="356" y="121">Invalid</text>
+<rect class="n" x="85" y="22" width="130" height="46" rx="10"/>
+<text x="150" y="46">Start</text>
+<rect class="n-hot" x="85" y="110" width="130" height="46" rx="10"/>
+<text class="t-strong" x="150" y="134">Validate</text>
+<rect class="n" x="85" y="198" width="130" height="46" rx="10"/>
+<text x="150" y="222">Process</text>
+<rect class="n-ok" x="85" y="286" width="130" height="46" rx="10"/>
+<text x="150" y="310">Complete</text>
+<rect class="n-err" x="440" y="198" width="130" height="46" rx="10"/>
+<text x="505" y="222">Failed</text>
+<text class="t-mut" x="505" y="262">exit state</text>
+<text class="t-mut ta-s" x="228" y="309">exit state</text>
+<text class="t-mut" x="330" y="348">Each task returns the next state; the workflow stops at an exit state.</text>
+</svg>
 </div>
 </div>
 
@@ -325,19 +343,39 @@ concurrent requests.
 
 <div class="diagram-frame">
 <p class="diagram-label">Workflow per Request</p>
-<div class="mermaid">
-sequenceDiagram
-participant Client
-participant Handler as HTTP Handler
-participant Store as MemoryStore
-participant WF as Workflow FSM
-Client->>Handler: POST /process {text}
-Handler->>Store: put("input_text", text)
-Handler->>WF: orchestrate(Parse)
-WF->>Store: get / put during tasks
-WF-->>Handler: Ok(Done)
-Handler->>Store: get("word_count"), get("uppercased")
-Handler-->>Client: 200 JSON response
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 730 428" role="img">
+<title>One HTTP request: the handler writes the request data into a fresh store, orchestrates the workflow to its exit state, reads the results back out of the store, and returns the response.</title>
+<defs><marker id="wfreq-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<line class="lifeline" x1="70" y1="46" x2="70" y2="364"/>
+<line class="lifeline" x1="258" y1="46" x2="258" y2="364"/>
+<line class="lifeline" x1="448" y1="46" x2="448" y2="364"/>
+<line class="lifeline" x1="638" y1="46" x2="638" y2="364"/>
+<rect class="n" x="15" y="8" width="110" height="38" rx="8"/>
+<text class="t-strong" x="70" y="28">Client</text>
+<rect class="n" x="188" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="258" y="28">HTTP Handler</text>
+<rect class="n-cop" x="378" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="448" y="28">MemoryStore</text>
+<rect class="n" x="568" y="8" width="140" height="38" rx="8"/>
+<text class="t-strong" x="638" y="28">Workflow FSM</text>
+<path class="e" d="M76,90 H252" marker-end="url(#wfreq-ah)"/>
+<text class="t-code" x="164" y="78">POST /process {text}</text>
+<path class="e" d="M264,134 H442" marker-end="url(#wfreq-ah)"/>
+<text class="t-code" x="353" y="122">put("input_text", text)</text>
+<path class="e" d="M264,178 H632" marker-end="url(#wfreq-ah)"/>
+<text class="t-code" x="545" y="166">orchestrate(Parse)</text>
+<path class="e" d="M632,222 H454" marker-end="url(#wfreq-ah)"/>
+<text class="t-mut" x="545" y="210">get / put during tasks</text>
+<path class="e e-dash" d="M632,266 H264" marker-end="url(#wfreq-ah)"/>
+<text class="t-code t-ok" x="510" y="254">Ok(Done)</text>
+<path class="e" d="M264,310 H442" marker-end="url(#wfreq-ah)"/>
+<text class="t-code" x="353" y="298">get("word_count"), get("uppercased")</text>
+<path class="e e-dash" d="M252,354 H76" marker-end="url(#wfreq-ah)"/>
+<text class="t-code t-ok" x="164" y="342">200 JSON response</text>
+<rect class="n-hot" x="14" y="374" width="702" height="34" rx="10"/>
+<text class="t-strong" x="365" y="392">One fresh store and one workflow per request — no leaks between requests.</text>
+</svg>
 </div>
 </div>
 

--- a/docs/content/workflows/validation-and-errors.md
+++ b/docs/content/workflows/validation-and-errors.md
@@ -32,6 +32,41 @@ Before orchestrating a workflow, you can validate its configuration to catch com
 Cano provides two validation methods that check for different categories of problems.
 </p>
 
+<div class="diagram-frame">
+<p class="diagram-label">The gate every <code>orchestrate()</code> call passes through</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 300" role="img">
+<title>orchestrate() runs validate() once per workflow and validate_initial_state() on every call, before any resource setup; either check failing returns CanoError::Configuration before a task runs.</title>
+<defs><marker id="valgate-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<rect class="n-hot" x="25" y="40" width="200" height="58" rx="10"/>
+<text class="t-code" x="125" y="65">validate()</text>
+<text class="t-mut" x="125" y="85">cached — runs once</text>
+<rect class="n" x="285" y="40" width="215" height="58" rx="10"/>
+<text class="t-code" x="392" y="65">validate_initial_state</text>
+<text class="t-mut" x="392" y="85">every call · O(1)</text>
+<rect class="n-ok" x="560" y="40" width="195" height="58" rx="10"/>
+<text class="t-code" x="657" y="65">setup_all() → FSM</text>
+<text class="t-mut" x="657" y="85">the run begins</text>
+<path class="e" d="M229,69 H281" marker-end="url(#valgate-ah)"/>
+<text class="t-mut t-ok" x="255" y="57">Ok</text>
+<path class="e" d="M504,69 H556" marker-end="url(#valgate-ah)"/>
+<text class="t-mut t-ok" x="530" y="57">Ok</text>
+<path class="e" d="M125,98 V231 Q125,239 133,239 H186" marker-end="url(#valgate-ah)"/>
+<text class="t-mut t-err ta-s" x="136" y="124">no registered state handlers</text>
+<text class="t-mut t-err ta-s" x="136" y="142">no exit states defined</text>
+<text class="t-mut t-err ta-s" x="136" y="160">a split join_state that is neither</text>
+<text class="t-mut t-err ta-s" x="136" y="178">registered nor an exit state</text>
+<path class="e" d="M392,98 V206" marker-end="url(#valgate-ah)"/>
+<text class="t-mut t-err ta-s" x="402" y="124">initial state neither</text>
+<text class="t-mut t-err ta-s" x="402" y="142">registered nor an exit state</text>
+<rect class="n-err" x="190" y="210" width="400" height="58" rx="10"/>
+<text class="t-code" x="390" y="235">CanoError::Configuration</text>
+<text class="t-mut" x="390" y="255">returned before setup_all() or any task runs</text>
+<text class="t-mut" x="390" y="288">Calling validate() yourself runs the same checks earlier — at build time, not on the first run.</text>
+</svg>
+</div>
+</div>
+
 <h3 id="validate-method"><a href="#validate-method" class="anchor-link" aria-hidden="true">#</a>validate()</h3>
 <p>
 Checks the overall workflow structure. Returns <code>CanoError::Configuration</code> if problems are found.
@@ -107,6 +142,50 @@ exact errors <code>validate()</code> / <code>validate_initial_state()</code> ret
 The <code>orchestrate()</code> method can return several error variants depending on what goes wrong
 during execution. Understanding these errors helps you build robust error recovery logic.
 </p>
+
+<div class="diagram-frame">
+<p class="diagram-label">Where each runtime error comes from</p>
+<div class="cd-wrap">
+<svg class="cd" viewBox="0 0 780 332" role="img">
+<title>Map of orchestrate() failures: the run-wide budget and cancellation abort the in-flight attempt, state dispatch raises CanoError::Workflow, the attempt itself raises CircuitOpen, Timeout, RetryExhausted or TaskExecution, and a clean run returns Ok(final_state).</title>
+<defs><marker id="errmap-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+<rect class="n-ghost" x="20" y="16" width="740" height="48" rx="10"/>
+<text class="t-strong ta-s" x="38" y="36">Whole-run budget &amp; cancellation</text>
+<text class="t-code t-err ta-s" x="38" y="55">WorkflowTimeout · Cancelled</text>
+<text class="t-mut ta-e" x="742" y="46">in-flight task aborted → compensation stack drained</text>
+<path class="e e-dash e-dim" d="M390,64 V96" marker-end="url(#errmap-ah)"/>
+<text class="t-mut ta-s" x="398" y="84">aborts the attempt</text>
+<rect class="n" x="25" y="100" width="200" height="58" rx="10"/>
+<text class="t-strong" x="125" y="125">dispatch state</text>
+<text class="t-mut" x="125" y="145">find the handler</text>
+<rect class="n-hot" x="290" y="100" width="200" height="58" rx="10"/>
+<text class="t-strong" x="390" y="125">run attempt</text>
+<text class="t-mut" x="390" y="145">breaker → try → retry</text>
+<rect class="n-ok" x="555" y="100" width="200" height="58" rx="10"/>
+<text class="t-strong" x="655" y="125">next state</text>
+<text class="t-mut" x="655" y="145">or a registered exit</text>
+<path class="e" d="M229,129 H286" marker-end="url(#errmap-ah)"/>
+<path class="e" d="M494,129 H551" marker-end="url(#errmap-ah)"/>
+<path class="e" d="M125,158 V186" marker-end="url(#errmap-ah)"/>
+<path class="e" d="M390,158 V186" marker-end="url(#errmap-ah)"/>
+<path class="e" d="M655,158 V186" marker-end="url(#errmap-ah)"/>
+<rect class="n-err" x="25" y="190" width="200" height="78" rx="10"/>
+<text class="t-code t-err" x="125" y="213">CanoError::Workflow</text>
+<text class="t-mut" x="125" y="233">no handler for state</text>
+<text class="t-mut" x="125" y="251">single task → Split</text>
+<rect class="n-err" x="290" y="190" width="200" height="78" rx="10"/>
+<text class="t-code t-err" x="390" y="213">CircuitOpen · Timeout</text>
+<text class="t-code t-err" x="390" y="233">RetryExhausted</text>
+<text class="t-code t-err" x="390" y="251">TaskExecution · panic</text>
+<rect class="n-ok" x="555" y="190" width="200" height="78" rx="10"/>
+<text class="t-code t-ok" x="655" y="213">Ok(final_state)</text>
+<text class="t-mut" x="655" y="233">exit state reached</text>
+<text class="t-mut" x="655" y="251">teardown, then return</text>
+<rect class="n-hot" x="25" y="286" width="730" height="34" rx="10"/>
+<text class="t-strong" x="390" y="308">Every failure raised during the run is wrapped in CanoError::WithStateContext</text>
+</svg>
+</div>
+</div>
 
 <table class="styled-table">
 <thead>

--- a/docs/static/script.js
+++ b/docs/static/script.js
@@ -77,19 +77,6 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // --------------------------------------------------------------------------
-  // Mermaid initialization (one-time). startOnLoad is false because we drive
-  // rendering manually in initContent() so diagrams also render after a swap.
-  // --------------------------------------------------------------------------
-  if (window.mermaid) {
-    mermaid.initialize({
-      startOnLoad: false,
-      theme: 'dark',
-      securityLevel: 'loose',
-      fontFamily: 'Outfit, sans-serif'
-    });
-  }
-
-  // --------------------------------------------------------------------------
   // setActiveLinks() — runs on first load and after every content swap.
   // Highlights the current page's link and reveals its ancestor <details>
   // (unless the user explicitly collapsed it).
@@ -117,7 +104,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // --------------------------------------------------------------------------
   // initContent(scope) — idempotent per-page setup for the swapped-in content.
   // Runs on first load (scope = document) and after every Swup swap
-  // (scope = #swup), so Prism / Mermaid / external links re-apply to new content.
+  // (scope = #swup), so Prism / external links re-apply to new content.
   // --------------------------------------------------------------------------
   function initContent(scope) {
     scope = scope || document.getElementById('swup') || document;
@@ -129,15 +116,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     if (window.Prism) {
       Prism.highlightAll();
-    }
-
-    // Mermaid: render only diagrams that haven't been processed yet, so a swap
-    // never double-renders an existing diagram or skips a new one.
-    if (window.mermaid) {
-      const nodes = Array.from(scope.querySelectorAll('.mermaid:not([data-processed])'));
-      if (nodes.length) {
-        try { mermaid.run({ nodes }); } catch (e) { /* malformed diagram — leave as-is */ }
-      }
     }
 
     // External links — open in new tab.

--- a/docs/static/styles.css
+++ b/docs/static/styles.css
@@ -85,6 +85,16 @@
     --duration-fast: 150ms;
     --duration-normal: 250ms;
     --duration-slow: 400ms;
+
+    /* Diagram palette — derived from static/logo.png:
+       pipe steel, crab orange, copper banding on navy. */
+    --dg-steel: hsl(207, 26%, 64%);
+    --dg-steel-dim: hsl(210, 20%, 46%);
+    --dg-steel-fill: hsla(207, 40%, 62%, 0.10);
+    --dg-crab: hsl(24, 89%, 56%);
+    --dg-crab-fill: hsla(24, 89%, 56%, 0.13);
+    --dg-copper: hsl(16, 62%, 48%);
+    --dg-copper-fill: hsla(16, 62%, 48%, 0.12);
 }
 
 /* --------------------------------------------------------------------------
@@ -770,24 +780,11 @@ code {
 }
 
 /* --------------------------------------------------------------------------
-   8. Mermaid Diagrams & Diagram Frames
+   8. Diagrams — hand-crafted inline SVG themed after the logo (steel pipe
+   structure, crab-orange highlights, copper accents). All diagram styling
+   lives here: SVGs carry classes only, never hardcoded colors, so every
+   diagram stays consistent and re-themes from one place.
    -------------------------------------------------------------------------- */
-.mermaid {
-    background-color: var(--card-bg);
-    padding: var(--space-8);
-    border-radius: var(--radius-lg);
-    margin: var(--space-8) 0;
-    text-align: center;
-    border: 1px solid var(--border-color);
-    overflow-x: auto;
-}
-
-.mermaid svg {
-    max-width: 100%;
-    height: auto;
-}
-
-/* Labelled diagram wrapper — pairs a caption with a mermaid block */
 .diagram-frame {
     background: var(--card-bg);
     border: 1px solid var(--border-color);
@@ -806,13 +803,61 @@ code {
     margin: 0;
 }
 
-.diagram-frame .mermaid {
-    margin: 0;
-    border: none;
-    border-radius: 0;
-    background: transparent;
+.cd-wrap {
     padding: var(--space-6);
+    overflow-x: auto;
+    text-align: center;
 }
+
+svg.cd {
+    width: 100%;
+    height: auto;
+    max-width: 780px;
+    display: inline-block;
+}
+
+.cd text {
+    font-family: 'Inter', 'Outfit', system-ui, sans-serif;
+    font-size: 15px;
+    fill: var(--text-color);
+    text-anchor: middle;
+    dominant-baseline: middle;
+}
+
+/* Nodes (rect / ellipse / path containers) */
+.cd .n       { fill: var(--dg-steel-fill);  stroke: var(--dg-steel);      stroke-width: 1.4; }
+.cd .n-hot   { fill: var(--dg-crab-fill);   stroke: var(--dg-crab);       stroke-width: 1.6; }
+.cd .n-cop   { fill: var(--dg-copper-fill); stroke: var(--dg-copper);     stroke-width: 1.4; }
+.cd .n-ok    { fill: var(--success-muted);  stroke: var(--success-color); stroke-width: 1.4; }
+.cd .n-warn  { fill: var(--warning-muted);  stroke: var(--warning-color); stroke-width: 1.4; }
+.cd .n-err   { fill: var(--danger-muted);   stroke: var(--danger-color);  stroke-width: 1.4; }
+.cd .n-ghost { fill: transparent; stroke: var(--dg-steel-dim); stroke-width: 1.3; stroke-dasharray: 4 4; }
+
+/* Edges & lifelines */
+.cd .e        { fill: none; stroke: var(--dg-steel);     stroke-width: 1.6; }
+.cd .e-hot    { stroke: var(--dg-crab); }
+.cd .e-dim    { stroke: var(--dg-steel-dim); }
+.cd .e-dash   { stroke-dasharray: 5 5; }
+.cd .lifeline { fill: none; stroke: var(--dg-steel-dim); stroke-width: 1.1; stroke-dasharray: 3 6; opacity: 0.75; }
+
+/* Text variants */
+.cd .t-strong { font-weight: 600; }
+.cd .t-mut    { fill: var(--text-muted); font-size: 12.5px; }
+.cd .t-code   { font-family: 'Fira Code', monospace; font-size: 12.5px; }
+.cd .t-hot    { fill: var(--dg-crab); }
+.cd .t-ok     { fill: var(--success-color); }
+.cd .t-warn   { fill: var(--warning-color); }
+.cd .t-err    { fill: var(--danger-color); }
+
+/* Text anchoring utilities (override the .cd text default) */
+.cd .ta-s { text-anchor: start; }
+.cd .ta-e { text-anchor: end; }
+
+/* Timeline bars, axes, ticks (scheduler-style diagrams) */
+.cd .band     { fill: var(--dg-steel-fill); stroke: var(--dg-steel-dim); stroke-width: 1; }
+.cd .band-hot { fill: var(--dg-crab-fill);  stroke: var(--dg-crab);      stroke-width: 1.2; }
+.cd .axis     { stroke: var(--dg-steel-dim); stroke-width: 1.4; }
+.cd .tick     { stroke: var(--border-color); stroke-width: 1; }
 
 /* --------------------------------------------------------------------------
    9. Badges

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -16,7 +16,6 @@
     {% endblock head_extra %}
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@500;700&family=Fira+Code&display=swap" rel="stylesheet">
     {% block scripts_head %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.6.1/mermaid.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js" data-manual></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-rust.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-toml.min.js"></script>


### PR DESCRIPTION
Nine commits on top of `main` (`a8ae714`), spanning 52 files (+3,568 / −491):
1,615 lines of code/test changes across 18 files and 1,949 lines of docs across 32.

### 1. StreamTask simplification (`0f7d2f8`)

A conservative, behavior-preserving pass over the code `a8ae714` introduced.
**No public API, signature, or doc-comment changes.**

- `task/stream.rs`: `drive_window`'s count- and duration-window arms collapse into one
  destructuring match; the byte-identical 12-line flush-and-return block duplicated
  across both flush arms is extracted into `flush_full_window`, whose doc records *why*
  the cancel-drain and exhausted paths deliberately don't share it (differing
  `WindowSignal` semantics). Drops a per-window `Arc::clone` in
  `StreamSession::next_window` — the borrows are disjoint fields of `*self`.
- `workflow/execution.rs`: removes a no-op `.map(|e| e.as_ref())`, two redundant type
  annotations, and four repeated fully-qualified `std::sync::atomic::` paths.
- `cano-macros/src/stream_task_impl.rs`: four repeated span+push validation blocks
  collapse into one closure; one shared error closure backs all 7 tuple-return-shape
  reject sites. Net −12 lines, and **all 45 compile-error strings verified unchanged**
  (consumers may match on them).
- `recovery/redb.rs`: drops `SEQUENCE_MIN`/`SEQUENCE_MAX`, aliases for `u64::MIN/MAX`
  carrying no behavior.

### 2. Test flakes fixed at the root (`29eee2d`)

`a8ae714` flagged `scheduler::running`'s timing-sensitive tests as flaking under parallel
load. This finds the actual causes rather than tolerating them.

- **Circuit breaker**: five short-circuit tests shared `cb_policy`'s `reset_timeout: 20ms`,
  a value only the half-open recovery test needs. Under load the 1ms retry sleep plus
  scheduler jitter could exceed it mid-loop, lazily promoting `Open -> HalfOpen` and
  admitting an extra probe — so a test asserting "ran exactly twice" would intermittently
  see 3 or 5. Added `cb_policy_stable_open` (60s window) for those five.
- **Scheduler**: two tests did `sleep(ms)` then a single exact-state assertion, racing the
  dispatch loop (observed: `left: Running, right: Completed`). Added `wait_for_status`, a
  budget-bounded 5ms poll loop, at the three racy points.

**No assertions were weakened** — every check still runs, against a snapshot taken once the
condition is actually true instead of after a wall-clock guess. Retry module went 5/40 →
0/40 failures under stress; scheduler 0/40 over 40 runs.

### 3. Docs: mermaid replaced by an inline-SVG diagram system (`5b7074d`, `ace2006`, `9f8350f`)

Mermaid was a runtime CDN dependency (10.6.1) re-rendered on every swup page swap. Every
diagram now ships as static inline SVG, styled entirely through CSS classes themed off
`static/logo.png`.

- **System**: palette tokens and a full class system (`.cd-wrap`, `.n-*` nodes, `.e-*`
  edges, `.lifeline`, timeline primitives) in `styles.css`; the `mermaid.min.js` tag and
  `mermaid.run()` re-render block are gone. SVGs carry **classes only** — never hardcoded
  `fill`/`stroke`/`font-*` — so everything re-themes from one place.
- **Coverage**: all 22 pre-existing mermaid diagrams ported faithfully, plus 26 new ones
  for the 15 pages that had none. **48 diagrams across 28 pages** — every content page now
  has at least one. Gantt timelines became proportional timelines with real tick math
  instead of mermaid's date-axis approximation.
- Each diagram was grounded against the actual Rust source, which surfaced two doc bugs:
  - `router-task`: the Quick Start claimed `route` may return `TaskResult::Split`. It
    cannot — `execution.rs:947-949` rejects it with `CanoError::Workflow`. Replaced with a
    warning stating the real constraint.
  - `stream-task`: five behaviors implemented in this branch were under-documented —
    `StreamWindow::Duration`'s 1ms floor, `with_total_timeout` folding into the same
    cooperative drain (`Cancelled` vs `WorkflowTimeout`, identical flush + cursor commit),
    `open()` racing the effective token, cursor *not* committed if the drain flush itself
    fails, and "Cancelled" being a classification rather than a trigger.

### 4. New: processing-model reliability suites (`6f03bee`)

11 black-box integration tests (public API only, engine-driven paths) pinning down how the
complex models behave under crash, cancel, flaky dependency, hung call, and crash-resume.
Split per model over five suites sharing `tests/support/mod.rs` (a non-target include with
an in-memory `CheckpointStore` exposing cursor introspection). No feature flags required.

| Suite | Contracts pinned |
|---|---|
| `stream_reliability` | A crash between flushes loses only the uncommitted window and resume replays it at-least-once, whereas a **cancel drains and commits** so resume dedups. `RetryOnError` is an error *budget* — failed items are dropped, never re-pulled. A hung `process_item` is bounded only by `attempt_timeout`. |
| `batch_reliability` | A poisoned item fills its own slot without aborting siblings; slots stay in input order under shuffled completion; concurrency caps in-flight items. A `finish` failure replays the **entire** load/process/finish cycle. |
| `stepped_reliability` | A transient error retries the **same cursor** rather than restarting from `None`; a hard failure resumes at the last persisted cursor. |
| `poll_reliability` | The budget counts *consecutive* errors and `Pending` resets it; budget+1 kills the run. Always-`Pending` is bounded only by `attempt_timeout`. |
| `pipeline_reliability` | A crash in a late state re-enters **only** that state on resume, leaving completed poll/batch side effects un-replayed. |

These deliberately cover the *in-process* failure paths; the SIGKILL variant of cursor
resume remains in `stepped_resume_e2e.rs`.

### 5. Release 0.15.0 (`50d93bd`, `e70116c`)

- Workspace `version = "0.15.0"`; `cano-macros` and `cano-e2e` inherit it. Lockfile
  regenerated for the three workspace entries.
- Every non-derived version reference updated: the `cano-macros` requirement, the
  scheduler module's install snippet, and `docs/config.toml`'s `extra.version` (which
  drives the sidebar badge and every `cano_dep` snippet).
- The testing guide hardcoded its dependency line instead of using the `cano_dep`
  shortcode every other page uses — which is exactly why it drifted. It now calls the
  shortcode, leaving `docs/config.toml` as the single source of truth.
- `docs(task)`: the `Task` trait's headline example was marked `rust,ignore`, so rustdoc
  never compiled it. It passes as-is, so the marker was hiding a working doctest rather
  than papering over a broken one.

### Compatibility

No breaking changes. No public API, signature, or behavior changes — the stream work is a
pure simplification and the test/docs work touches no runtime code. The only manifest
changes are the version bump and two **dev**-dependencies (`futures-util`, `parking_lot`),
both already runtime dependencies at the same versions, so no new lockfile entries.

### Verification

- `cargo test --all-features`: **917 passed, 36 suites, 0 failed**.
- The 7 ignored are all doctests — 4 in `cano` (`resource.rs`, `saga.rs`, `workflow.rs`,
  `metrics.rs`) and 3 in `cano-macros` — every one an illustrative fragment referencing
  undefined bindings, so none can compile standalone. There are **zero `#[ignore]` unit
  tests** in the workspace.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --all-features`
  clean.
- Flake stress: full workspace suite green across 6 repeated runs (baseline was 3/6).
- Docs: `zola build` clean; every SVG structurally audited (div balance, unique marker ids,
  resolving refs, no hardcoded paint, `<title>`/`role="img"`) and rendered in headless
  Chromium against the real stylesheet — zero overlaps, zero console errors across all
  pages.

### Reviewing

The diff is docs-heavy; the load-bearing code review is `0f7d2f8` (6 files, +159/−177) and
`29eee2d`. The reliability suites are additive. For the docs, `5b7074d` establishes the CSS
system and is worth reading before the two conversion commits.