### PR TITLE
Replace rig-core with cuca; upgrade to Rust 1.98

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.89.0
+        toolchain: 1.98.0
         components: rustfmt, clippy
 
     - name: Cache cargo registry

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.89.0
+          toolchain: 1.98.0
           components: clippy
 
       - name: Cache cargo

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.89.0
+          toolchain: 1.98.0
 
       - name: Cache cargo
         uses: actions/cache@v6
@@ -50,8 +50,10 @@ jobs:
         run: |
           set -uo pipefail
 
-          # `ai_workflow_yes_and` needs a running Ollama daemon — nothing to talk
-          # to in CI, so it is intentionally skipped.
+          # `ai_workflow_yes_and` needs an OpenAI-compatible LLM server (LM Studio
+          # or equivalent) on port 1234 serving `google/gemma-4-12b-qat`, pointed at
+          # via `CUCA_BASE_URL` / `CUCA_MODEL`. There is no such server in CI, so
+          # the example is intentionally skipped.
           SKIP=("ai_workflow_yes_and")
           # `workflow_on_request` is an HTTP server: it never exits on its own,
           # so it gets the dedicated smoke test below instead of the run loop.
@@ -69,7 +71,7 @@ jobs:
           for path in cano/examples/*.rs; do
             ex="$(basename "$path" .rs)"
             if contains "$ex" "${SKIP[@]}"; then
-              echo "::notice::skipping example '$ex' (requires an external Ollama daemon)"
+              echo "::notice::skipping example '$ex' (needs an OpenAI-compatible LLM server on port 1234 serving google/gemma-4-12b-qat; configure with CUCA_BASE_URL / CUCA_MODEL)"
               continue
             fi
             contains "$ex" "${SERVERS[@]}" && continue

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,12 +199,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,12 +221,12 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.20.2"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
+checksum = "dbe8358268799ebb3e4df23cb9d47f4c72bbc4f5247e2fa6a1bf7b6c0baea220"
 dependencies = [
  "async-stream",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.13.1",
  "bollard-buildkit-proto",
  "bollard-stubs",
@@ -251,7 +245,7 @@ dependencies = [
  "log",
  "num",
  "pin-project-lite",
- "rand 0.9.5",
+ "rand 0.10.2",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -272,24 +266,23 @@ dependencies = [
 
 [[package]]
 name = "bollard-buildkit-proto"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
+checksum = "b5c97450e79c7c565302dd92e86b08823b47550fcb4fc5ce910194d1b087a1a3"
 dependencies = [
  "prost",
  "prost-types",
  "tonic",
  "tonic-prost",
- "ureq",
 ]
 
 [[package]]
 name = "bollard-stubs"
-version = "1.52.1-rc.29.1.3"
+version = "1.53.1-rc.29.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+checksum = "ce412eb6f7096743011dc3cb5c674caeb24ced61d8c498fe07cf7998a4fea889"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bollard-buildkit-proto",
  "bytes",
  "prost",
@@ -370,7 +363,6 @@ dependencies = [
  "serde",
  "serde_json",
  "testcontainers",
- "testcontainers-modules",
  "tokio",
  "tokio-postgres",
 ]
@@ -791,7 +783,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde",
  "serde_json",
 ]
@@ -1272,7 +1264,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1948,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "parse-display"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+checksum = "e78deb158fb1d73b29efb4b7e9b9860b78059c670de06bd28df8d0b458ded0eb"
 dependencies = [
  "parse-display-derive",
  "regex",
@@ -1959,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "parse-display-derive"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+checksum = "8e95a50d1084dab562913062c4c34bb204b68fc6ec38a1395909ff5aaaf4f10a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2132,7 +2124,7 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -2513,7 +2505,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2600,7 +2592,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2851,7 +2842,7 @@ version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bs58",
  "chrono",
  "hex",
@@ -3103,9 +3094,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.27.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
+checksum = "6e2bbe381afaaa58ea610c5fc3ffb2184063a32b3e358a179f0b4865dd59934a"
 dependencies = [
  "astral-tokio-tar",
  "async-trait",
@@ -3130,15 +3121,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "url",
-]
-
-[[package]]
-name = "testcontainers-modules"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5985fde5befe4ffa77a052e035e16c2da86e8bae301baa9f9904ad3c494d357"
-dependencies = [
- "testcontainers",
 ]
 
 [[package]]
@@ -3331,7 +3313,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "h2",
  "http",
@@ -3520,33 +3502,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
-dependencies = [
- "base64 0.23.1",
- "log",
- "percent-encoding",
- "rustls",
- "rustls-pki-types",
- "ureq-proto",
- "utf8-zero",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
-dependencies = [
- "base64 0.23.1",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3558,12 +3513,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,12 +48,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
-name = "as-any"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
-
-[[package]]
 name = "astral-tokio-tar"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,7 +93,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -125,9 +119,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -135,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -221,15 +215,6 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -356,6 +341,7 @@ dependencies = [
  "chrono",
  "criterion",
  "cron",
+ "cuca",
  "futures-util",
  "metrics",
  "metrics-tracing-context",
@@ -365,7 +351,6 @@ dependencies = [
  "rand 0.10.2",
  "redb",
  "reqwest",
- "rig-core",
  "serde",
  "serde_json",
  "smallvec",
@@ -399,7 +384,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.119",
+ "syn 3.0.5",
  "tokio",
 ]
 
@@ -411,9 +396,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -435,12 +420,12 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -536,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -549,15 +534,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "convert_case"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "core-foundation"
@@ -587,18 +563,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -654,14 +621,14 @@ dependencies = [
  "chrono",
  "once_cell",
  "phf 0.11.3",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -669,34 +636,24 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
 
 [[package]]
 name = "crypto-common"
@@ -714,6 +671,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "cuca"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563f1e7e475420495d26ad1caf0a6161e0b38cc83a738d030000d0f1cd48d178"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -749,12 +721,6 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "defmt"
@@ -798,23 +764,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 
@@ -826,7 +782,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -854,9 +810,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "embedded-io"
@@ -912,17 +868,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eventsource-stream"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
-dependencies = [
- "futures-core",
- "nom",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "fnv"
@@ -980,9 +925,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -995,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1005,15 +950,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1022,48 +967,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
-dependencies = [
- "gloo-timers",
- "send_wrapper",
-]
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1074,16 +1009,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1126,28 +1051,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
-
-[[package]]
-name = "gloo-timers"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1155,7 +1062,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -1229,7 +1136,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -1263,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1297,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1425,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1439,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1452,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1466,16 +1373,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1486,15 +1394,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1545,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -1699,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1722,9 +1630,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
@@ -1737,9 +1645,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1758,9 +1666,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru-slab"
@@ -1790,7 +1698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -1815,7 +1723,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93551ba7648013c25bece467fa087a54dd8dd50a4515182ecf9efb7630b1ed0d"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "itoa",
  "lockfree-object-pool",
  "metrics",
@@ -1836,7 +1744,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "metrics",
  "ordered-float",
  "quanta",
@@ -1854,26 +1762,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -1887,16 +1779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1949,9 +1831,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -2024,9 +1906,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
-version = "5.3.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
 dependencies = [
  "num-traits",
 ]
@@ -2122,7 +2004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -2184,9 +2066,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plotters"
@@ -2224,9 +2106,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -2258,7 +2140,7 @@ dependencies = [
  "md-5",
  "memchr",
  "rand 0.10.2",
- "sha2 0.11.0",
+ "sha2",
  "stringprep",
 ]
 
@@ -2275,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -2295,15 +2177,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
 ]
 
 [[package]]
@@ -2384,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2452,9 +2325,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -2569,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+checksum = "de6c3b63e007e90ce536ec2ae4690826136a20ec8dbbbb400daef1bb999d2e36"
 dependencies = [
  "libc",
 ]
@@ -2587,22 +2460,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2655,7 +2528,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2664,6 +2536,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2676,54 +2549,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "rig-core"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "432d83e0facf16749f91fe729cbffca84437e8062d2f4e92f4f12e903693922d"
-dependencies = [
- "as-any",
- "async-stream",
- "base64 0.22.1",
- "bytes",
- "eventsource-stream",
- "fastrand",
- "futures",
- "futures-timer",
- "glob",
- "http",
- "indexmap 2.14.0",
- "mime",
- "mime_guess",
- "ordered-float",
- "pin-project-lite",
- "reqwest",
- "rig-derive",
- "schemars 1.2.2",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror",
- "tokio",
- "tokio-tungstenite",
- "tracing",
- "tracing-futures",
- "url",
-]
-
-[[package]]
-name = "rig-derive"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0a33f1bac45f16e50146c248bcbbfaa44518c7252d274e972c7f4ad71aaba7"
-dependencies = [
- "convert_case",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -2835,9 +2660,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2859,9 +2684,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
+checksum = "42c6efa15875e6ecb39ca61fb0b0c1a40b84fac5a5ffe71eef7d1000c8eb3f5f"
 dependencies = [
  "bytemuck",
 ]
@@ -2904,21 +2729,8 @@ checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
- "schemars_derive",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 3.0.3",
 ]
 
 [[package]]
@@ -2957,12 +2769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
-
-[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,18 +2795,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3035,7 +2830,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3061,7 +2856,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
@@ -3084,36 +2879,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3177,9 +2950,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "socket2"
@@ -3265,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3385,7 +3158,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3429,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3449,9 +3222,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3486,7 +3259,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3517,9 +3290,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -3537,22 +3310,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
-dependencies = [
- "futures-util",
- "log",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tungstenite",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3564,36 +3321,6 @@ dependencies = [
  "libc",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.13+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
-dependencies = [
- "indexmap 2.14.0",
- "toml_datetime",
- "toml_parser",
- "winnow 1.0.4",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.3+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
-dependencies = [
- "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3644,7 +3371,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -3719,18 +3446,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "futures",
- "futures-task",
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3766,34 +3481,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.5",
- "rustls",
- "rustls-pki-types",
- "sha1",
- "thiserror",
-]
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -3821,12 +3512,6 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "untrusted"
@@ -3893,12 +3578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3952,9 +3631,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3965,9 +3644,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3975,9 +3654,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3985,22 +3664,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -4020,9 +3699,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4048,28 +3727,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "whoami"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
 dependencies = [
  "libc",
  "libredox",
@@ -4080,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
+checksum = "8cf05ca94c9fba0c51316899caa1d1e74a064fc310a5efa7375e614343d415be"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -4281,15 +3942,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winnow"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4297,9 +3949,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "xattr"
@@ -4383,9 +4035,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4394,9 +4046,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4405,13 +4057,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-members = ["cano", "cano-macros"]
 [workspace.package]
 version = "0.15.2"
 edition = "2024"
-rust-version = "1.89.0"
+rust-version = "1.98.0"
 license = "MIT OR Apache-2.0"
 homepage = "https://nassor.github.io/cano/"
 repository = "https://github.com/nassor/cano"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Downloads](https://img.shields.io/crates/d/cano.svg)](https://crates.io/crates/cano)
 [![License](https://img.shields.io/crates/l/cano.svg)](https://github.com/nassor/cano/blob/main/LICENSE)
 [![CI](https://github.com/nassor/cano/workflows/CI/badge.svg)](https://github.com/nassor/cano/actions)
-[![Rust Version](https://img.shields.io/badge/rust-1.89%2B-blue.svg)](https://www.rust-lang.org)
+[![Rust Version](https://img.shields.io/badge/rust-1.98%2B-blue.svg)](https://www.rust-lang.org)
 
 <em>**Orchestrate complex async processes with finite state machines, parallel execution, and built-in scheduling.**</em>
 

--- a/cano-e2e/Cargo.toml
+++ b/cano-e2e/Cargo.toml
@@ -16,8 +16,7 @@ serde_json = "1"
 anyhow = "1"
 
 [dev-dependencies]
-testcontainers = "0.27.3"
-testcontainers-modules = { version = "0.15.0", features = ["postgres"] }
+testcontainers = "0.28.0"
 
 # The "custom software" the e2e tests drive: a small Cano app over a Postgres-backed
 # CheckpointStore. Built into the Docker image (see `Dockerfile`) and also runnable

--- a/cano-e2e/Cargo.toml
+++ b/cano-e2e/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 
 [dependencies]
 cano = { path = "../cano" }
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.53.1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tokio-postgres = "0.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/cano-e2e/Dockerfile
+++ b/cano-e2e/Dockerfile
@@ -6,7 +6,7 @@
 #
 #   docker build -t cano-workflow-app:e2e -f cano-e2e/Dockerfile .
 
-FROM rust:1.95-slim AS build
+FROM rust:1.98-slim AS build
 WORKDIR /src
 COPY . .
 RUN cargo build --release -p cano-e2e --bin cano_workflow_app

--- a/cano-e2e/tests/e2e.rs
+++ b/cano-e2e/tests/e2e.rs
@@ -18,9 +18,9 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use cano_e2e::{UNITS, events, ledger_balance};
+use testcontainers::core::{IntoContainerPort, WaitFor};
 use testcontainers::runners::AsyncRunner;
 use testcontainers::{ContainerAsync, GenericImage, ImageExt};
-use testcontainers_modules::postgres::Postgres;
 use tokio_postgres::{Client, NoTls};
 
 const APP_IMAGE: &str = "cano-workflow-app";
@@ -62,10 +62,26 @@ fn unique(prefix: &str) -> String {
 
 /// A scenario fixture: a Postgres container plus a private network app containers join.
 struct Fixture {
-    _pg: ContainerAsync<Postgres>,
+    _pg: ContainerAsync<GenericImage>,
     network: String,
     pg_host_port: u16,
     pg_name: String,
+}
+
+/// The Postgres image the fixture runs — an inline reproduction of what
+/// `testcontainers_modules::postgres::Postgres::default()` used to provide (that crate
+/// hard-pins `testcontainers ^0.27`, so it can't come along to 0.28).
+fn postgres_image() -> GenericImage {
+    // The official entrypoint logs this line twice: once for the throwaway server
+    // `initdb` runs (which then shuts down) and again for the real server. Waiting for a
+    // single occurrence would hand us a server that is about to stop, so wait for both —
+    // one per stream, exactly as the modules image did. `with_wait_for` appends to the
+    // list of ready conditions rather than replacing it, so both are honoured.
+    const READY: &str = "database system is ready to accept connections";
+    GenericImage::new("postgres", "11-alpine")
+        .with_exposed_port(5432.tcp())
+        .with_wait_for(WaitFor::message_on_stderr(READY))
+        .with_wait_for(WaitFor::message_on_stdout(READY))
 }
 
 impl Fixture {
@@ -73,7 +89,12 @@ impl Fixture {
         ensure_app_image();
         let network = unique("cano-e2e-net");
         let pg_name = unique("cano-e2e-pg");
-        let pg = Postgres::default()
+        let pg = postgres_image()
+            .with_env_var("POSTGRES_DB", "postgres")
+            .with_env_var("POSTGRES_USER", "postgres")
+            .with_env_var("POSTGRES_PASSWORD", "postgres")
+            // `fsync=off`: the modules image's default — these containers are throwaway.
+            .with_cmd(["-c", "fsync=off"])
             .with_network(&network)
             .with_container_name(&pg_name)
             .start()
@@ -114,7 +135,7 @@ impl Fixture {
         let mut cmd: Vec<String> = vec![self.container_dsn()];
         cmd.extend(args.iter().map(|s| s.to_string()));
         GenericImage::new(APP_IMAGE, APP_TAG)
-            .with_wait_for(testcontainers::core::WaitFor::message_on_stdout(wait_for))
+            .with_wait_for(WaitFor::message_on_stdout(wait_for))
             .with_startup_timeout(Duration::from_secs(90))
             .with_network(&self.network)
             .with_container_name(unique("cano-e2e-app"))

--- a/cano-macros/Cargo.toml
+++ b/cano-macros/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2", features = ["full", "visit-mut"] }
+syn = { version = "3", features = ["full", "visit-mut"] }
 
 [dev-dependencies]
 cano = { path = "../cano" }

--- a/cano-macros/src/async_rewrite.rs
+++ b/cano-macros/src/async_rewrite.rs
@@ -10,8 +10,8 @@ use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 use syn::{
-    FnArg, GenericParam, ImplItem, ImplItemFn, ItemImpl, ItemTrait, LifetimeParam, ReturnType,
-    Signature, TraitItem, TraitItemFn, Type, WhereClause, WherePredicate,
+    FnArg, GenericParam, ImplItem, ImplItemFn, ItemImpl, ItemTrait, LifetimeParam, ReceiverKind,
+    ReturnType, Signature, TraitItem, TraitItemFn, Type, WhereClause, WherePredicate,
 };
 
 /// Entry point. Tries to parse `item` as a trait definition first, then an impl
@@ -149,12 +149,12 @@ fn transform_signature(sig: &Signature) -> Signature {
     }
     new_sig.inputs = new_inputs;
 
-    let has_ref_self = sig.inputs.iter().any(
-        |a| matches!(a, FnArg::Receiver(r) if r.reference.is_some() && r.mutability.is_none()),
-    );
-    let has_mut_self = sig.inputs.iter().any(
-        |a| matches!(a, FnArg::Receiver(r) if r.reference.is_some() && r.mutability.is_some()),
-    );
+    let has_ref_self = sig.inputs.iter().any(|a| {
+        matches!(a, FnArg::Receiver(r) if matches!(r.kind, ReceiverKind::Reference(_, _, None)))
+    });
+    let has_mut_self = sig.inputs.iter().any(|a| {
+        matches!(a, FnArg::Receiver(r) if matches!(r.kind, ReceiverKind::Reference(_, _, Some(_))))
+    });
 
     for lt_info in &synth_lifetimes {
         new_sig
@@ -216,9 +216,8 @@ fn transform_signature(sig: &Signature) -> Signature {
 fn rewrite_arg(arg: &FnArg, acc: &mut Vec<SynthLifetime>) -> FnArg {
     match arg {
         FnArg::Receiver(r) => {
-            if r.reference.is_some() {
+            if let ReceiverKind::Reference(_, _, mutability) = r.kind {
                 let lt = make_lifetime(acc);
-                let mutability = r.mutability;
                 let attrs = r.attrs.clone();
                 let self_token = r.self_token;
                 let new_receiver: syn::Receiver = syn::parse_quote! {

--- a/cano-macros/src/batch_task_impl.rs
+++ b/cano-macros/src/batch_task_impl.rs
@@ -321,7 +321,7 @@ fn expand_inherent_impl(
 fn extract_state_key_paths_and_prefix(
     item_impl: &ItemImpl,
 ) -> syn::Result<(Type, Option<Type>, Path, Path, ModulePrefix)> {
-    let (_, trait_path, _) = item_impl
+    let (trait_path, _) = item_impl
         .trait_
         .as_ref()
         .ok_or_else(|| syn::Error::new(item_impl.span(), "expected a trait impl block"))?;
@@ -466,7 +466,7 @@ fn synthesise_task_impl(
     let where_clause = &batch_impl.generics.where_clause;
     let self_ty = &batch_impl.self_ty;
 
-    let (_, batch_trait_path, _) = batch_impl.trait_.as_ref().ok_or_else(|| {
+    let (batch_trait_path, _) = batch_impl.trait_.as_ref().ok_or_else(|| {
         syn::Error::new(batch_impl.span(), "expected a BatchTask trait impl block")
     })?;
 

--- a/cano-macros/src/poll_task_impl.rs
+++ b/cano-macros/src/poll_task_impl.rs
@@ -251,7 +251,7 @@ fn expand_inherent_impl(
 fn extract_state_key_task_path_and_prefix(
     item_impl: &ItemImpl,
 ) -> syn::Result<(Type, Option<Type>, Path, ModulePrefix)> {
-    let (_, trait_path, _) = item_impl
+    let (trait_path, _) = item_impl
         .trait_
         .as_ref()
         .ok_or_else(|| syn::Error::new(item_impl.span(), "expected a trait impl block"))?;
@@ -341,7 +341,7 @@ fn synthesise_task_impl(
     let where_clause = &poll_impl.generics.where_clause;
     let self_ty = &poll_impl.self_ty;
 
-    let (_, poll_trait_path, _) = poll_impl
+    let (poll_trait_path, _) = poll_impl
         .trait_
         .as_ref()
         .ok_or_else(|| syn::Error::new(poll_impl.span(), "expected a PollTask trait impl block"))?;

--- a/cano-macros/src/router_task_impl.rs
+++ b/cano-macros/src/router_task_impl.rs
@@ -264,7 +264,7 @@ fn expand_inherent_impl(
 fn extract_state_key_task_path_and_prefix(
     item_impl: &ItemImpl,
 ) -> syn::Result<(Type, Option<Type>, Path, ModulePrefix)> {
-    let (_, trait_path, _) = item_impl
+    let (trait_path, _) = item_impl
         .trait_
         .as_ref()
         .ok_or_else(|| syn::Error::new(item_impl.span(), "expected a trait impl block"))?;
@@ -362,7 +362,7 @@ fn synthesise_task_impl(
     let self_ty = &router_impl.self_ty;
 
     // The RouterTask path is the trait path from the impl header — used for UFCS calls.
-    let (_, router_trait_path, _) = router_impl.trait_.as_ref().ok_or_else(|| {
+    let (router_trait_path, _) = router_impl.trait_.as_ref().ok_or_else(|| {
         syn::Error::new(router_impl.span(), "expected a RouterTask trait impl block")
     })?;
 

--- a/cano-macros/src/stepped_task_impl.rs
+++ b/cano-macros/src/stepped_task_impl.rs
@@ -259,7 +259,7 @@ fn expand_inherent_impl(
 fn extract_state_key_task_path_and_prefix(
     item_impl: &ItemImpl,
 ) -> syn::Result<(Type, Option<Type>, Path, ModulePrefix)> {
-    let (_, trait_path, _) = item_impl
+    let (trait_path, _) = item_impl
         .trait_
         .as_ref()
         .ok_or_else(|| syn::Error::new(item_impl.span(), "expected a trait impl block"))?;
@@ -362,7 +362,7 @@ fn synthesise_task_impl(
     let where_clause = &stepped_impl.generics.where_clause;
     let self_ty = &stepped_impl.self_ty;
 
-    let (_, stepped_trait_path, _) = stepped_impl.trait_.as_ref().ok_or_else(|| {
+    let (stepped_trait_path, _) = stepped_impl.trait_.as_ref().ok_or_else(|| {
         syn::Error::new(
             stepped_impl.span(),
             "expected a SteppedTask trait impl block",

--- a/cano-macros/src/stream_task_impl.rs
+++ b/cano-macros/src/stream_task_impl.rs
@@ -307,7 +307,7 @@ fn expand_inherent_impl(
 fn extract_state_key_task_path_and_prefix(
     item_impl: &ItemImpl,
 ) -> syn::Result<(Type, Option<Type>, Path, ModulePrefix)> {
-    let (_, trait_path, _) = item_impl
+    let (trait_path, _) = item_impl
         .trait_
         .as_ref()
         .ok_or_else(|| syn::Error::new(item_impl.span(), "expected a trait impl block"))?;
@@ -398,7 +398,7 @@ fn synthesise_task_impl(
     let where_clause = &stream_impl.generics.where_clause;
     let self_ty = &stream_impl.self_ty;
 
-    let (_, stream_trait_path, _) = stream_impl.trait_.as_ref().ok_or_else(|| {
+    let (stream_trait_path, _) = stream_impl.trait_.as_ref().ok_or_else(|| {
         syn::Error::new(stream_impl.span(), "expected a StreamTask trait impl block")
     })?;
 

--- a/cano-macros/src/timer_task_impl.rs
+++ b/cano-macros/src/timer_task_impl.rs
@@ -247,7 +247,7 @@ fn expand_inherent_impl(
 fn extract_state_key_task_path_and_prefix(
     item_impl: &ItemImpl,
 ) -> syn::Result<(Type, Option<Type>, Path, ModulePrefix)> {
-    let (_, trait_path, _) = item_impl
+    let (trait_path, _) = item_impl
         .trait_
         .as_ref()
         .ok_or_else(|| syn::Error::new(item_impl.span(), "expected a trait impl block"))?;
@@ -338,7 +338,7 @@ fn synthesise_task_impl(
     let where_clause = &timer_impl.generics.where_clause;
     let self_ty = &timer_impl.self_ty;
 
-    let (_, timer_trait_path, _) = timer_impl.trait_.as_ref().ok_or_else(|| {
+    let (timer_trait_path, _) = timer_impl.trait_.as_ref().ok_or_else(|| {
         syn::Error::new(timer_impl.span(), "expected a TimerTask trait impl block")
     })?;
 

--- a/cano/Cargo.toml
+++ b/cano/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools", "concurrency", "asynchronous"]
 
 [dependencies]
 cano-macros = { version = "0.15", path = "../cano-macros" }
-tokio = { version = "1.52.1", features = ["macros", "sync", "time", "rt-multi-thread"] }
+tokio = { version = "1.53.1", features = ["macros", "sync", "time", "rt-multi-thread"] }
 rand = "0.10"
 chrono = { version = "0.4", features = ["serde"], optional = true }
 cron = { version = "0.17.0", optional = true }
@@ -24,9 +24,9 @@ smallvec = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = { version = "0.1", optional = true }
-redb = { version = "4.1", optional = true }
+redb = { version = "4.2", optional = true }
 postcard = { version = "1", optional = true, features = ["use-std"] }
-metrics = { version = "0.24.5", optional = true }
+metrics = { version = "0.24.6", optional = true }
 
 [features]
 scheduler = ["dep:chrono", "dep:cron", "tokio/signal"]
@@ -39,19 +39,19 @@ all = ["scheduler", "tracing", "recovery", "metrics", "testing"]
 [dev-dependencies]
 axum = "0.8.9"
 criterion = { version = "0.8", features = ["html_reports", "async_tokio"] }
+cuca = { version = "0.3", features = ["provider-lmstudio"] }
 futures-util = "0.3"
 parking_lot = "0.12"
-redb = "4.1"
+redb = "4.2"
 reqwest = { version = "0.13", features = ["json"] }
-rig-core = "0.42.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
-wide = "1.2"
+wide = "1.7"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 chrono = { version = "0.4", features = ["serde"] }
-tokio = { version = "1.52.1", features = ["macros", "sync", "time", "rt-multi-thread", "signal", "test-util"] }
-metrics-util = { version = "0.20.3", features = ["debugging"] }
+tokio = { version = "1.53.1", features = ["macros", "sync", "time", "rt-multi-thread", "signal", "test-util"] }
+metrics-util = { version = "0.20.4", features = ["debugging"] }
 metrics-tracing-context = "0.18.1"
 
 # Subprocess driver for the SIGKILL recovery integration test (tests/recovery_e2e.rs).

--- a/cano/examples/ai_workflow_yes_and.rs
+++ b/cano/examples/ai_workflow_yes_and.rs
@@ -4,24 +4,40 @@
 //! - **Actor1Task** opens with a random subject; later turns continue the thread.
 //! - **Actor2Task** continues every other turn with "Yes, and...".
 //!
-//! The example wraps the rig-core Ollama client in an `OllamaResource` so the
-//! HTTP client is built once at workflow setup, shared across both actors via
-//! `Resources`, and torn down in one place. Actors hold no client state.
+//! The example wraps a [`cuca`](https://crates.io/crates/cuca) `CucaClient` in a
+//! `CucaResource` so the HTTP client is built once at workflow setup, shared
+//! across both actors via `Resources`, and torn down in one place. Actors hold
+//! no client state.
 //!
 //! Prerequisites:
-//! - Install Ollama: <https://ollama.ai/>
-//! - `ollama pull gemma4:e2b` and run the daemon
+//! - An OpenAI-compatible local inference server listening on port 1234 —
+//!   [LM Studio](https://lmstudio.ai/) is the default target, but llama.cpp,
+//!   vLLM, or anything else speaking `/v1/chat/completions` works.
+//! - The `google/gemma-4-12b-qat` model loaded and served.
+//! - A context window that holds the transcript plus `MAX_TOKEN` completion
+//!   tokens. The demo model's 8192-token window (LM Studio's default) is
+//!   plenty for both.
+//!
+//! Configuration (both optional, defaults target a local LM Studio server):
+//! - `CUCA_BASE_URL`: server base URL, defaults to `http://127.0.0.1:1234/v1`.
+//! - `CUCA_MODEL`: upstream model id, defaults to `google/gemma-4-12b-qat`.
 //!
 //! Run with:
 //! ```bash
 //! cargo run --example ai_workflow_yes_and
 //! ```
+//!
+//! Or point it at a server on the network:
+//! ```bash
+//! CUCA_BASE_URL=http://192.168.1.10:1234/v1 CUCA_MODEL=google/gemma-4-12b-qat \
+//!   cargo run --example ai_workflow_yes_and
+//! ```
 
 use cano::prelude::*;
+use cuca::types::{MessageContentBlock, ProviderEndpoint};
+use cuca::{CucaClient, ThinkingConfig, ThinkingParams, UnifiedRequest};
+use futures_util::StreamExt;
 use rand::RngExt;
-use rig_core::client::{CompletionClient, Nothing};
-use rig_core::completion::{AssistantContent, CompletionModel};
-use rig_core::providers::ollama::Client;
 
 // Configuration constants
 const CONTEXT: &str = r#"
@@ -34,9 +50,25 @@ Continue talking about the subject using the 'Yes, and...' improv principle:
 - Feel free to use any object from the previous conversation
 "#;
 
-const MODEL: &str = "gemma4:e2b";
-const MAX_TOKEN: u64 = 2048;
+const DEFAULT_BASE_URL: &str = "http://127.0.0.1:1234/v1";
+const DEFAULT_MODEL: &str = "google/gemma-4-12b-qat";
+/// Completion-token budget for one reply.
+///
+/// The visible replies are one-liners of 10-20 words, so this is already
+/// generous. The ceiling is the server's context window (8192 for the demo
+/// model), which has to hold the transcript as well as this budget.
+const MAX_TOKEN: u32 = 2048;
 const MAX_INTERACTIONS: u32 = 12;
+
+/// Server base URL: `CUCA_BASE_URL`, falling back to a local LM Studio server.
+fn base_url() -> String {
+    std::env::var("CUCA_BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string())
+}
+
+/// Upstream model id: `CUCA_MODEL`, falling back to the demo model.
+fn model_id() -> String {
+    std::env::var("CUCA_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string())
+}
 
 // Story subjects for random selection
 const SUBJECTS: &[&str] = &[
@@ -68,55 +100,93 @@ const SUBJECTS: &[&str] = &[
 ];
 
 // ============================================================================
-// OllamaResource — shared rig-core client
+// CucaResource — shared cuca client
 // ============================================================================
 
-/// Wraps the rig Ollama `Client` so it lives as a workflow resource.
+/// Wraps a single `CucaClient` so it lives as a workflow resource.
 ///
-/// `setup` is a no-op print today (the rig client is constructed eagerly in
-/// `new`), but real deployments could ping the model endpoint here to fail
-/// fast if Ollama is unreachable.
-struct OllamaResource {
-    client: Client,
+/// `setup` is a no-op print today (the client is constructed eagerly in `new`),
+/// but real deployments could ping the model endpoint here to fail fast if the
+/// inference server is unreachable.
+struct CucaResource {
+    client: CucaClient,
+    model: String,
 }
 
-impl OllamaResource {
+impl CucaResource {
     fn new() -> Result<Self, CanoError> {
         Ok(Self {
-            client: Client::new(Nothing)
-                .map_err(|e| CanoError::Generic(format!("Ollama client error: {e}")))?,
+            client: CucaClient::builder()
+                .with_provider(ProviderEndpoint::LmStudio)
+                .with_base_url(base_url())
+                .build()
+                .map_err(|e| CanoError::Generic(format!("Cuca client error: {e}")))?,
+            model: model_id(),
         })
     }
 
     /// Run one completion round against the shared client.
+    ///
+    /// `generate_stream` is cuca's single generation entry point, so the
+    /// streamed blocks are drained here and the `Text` payloads concatenated
+    /// into one reply. `Thinking` blocks carry the model's reasoning and are
+    /// dropped — no `<think>` tag scraping needed.
+    ///
+    /// The explicit `reasoning_effort: "none"` is deliberate — **do not remove
+    /// it**. `google/gemma-4-12b-qat` reasons by default, and cuca emits
+    /// `reasoning_effort` only when `thinking` is set, so leaving `thinking`
+    /// unset — or setting `ThinkingConfig::disabled()`, which also omits the
+    /// key — lets the server apply its own default and spend the whole
+    /// completion budget on reasoning, ending on `finish_reason: "length"`
+    /// with empty content. This server honours only `"none"` as off
+    /// (`Minimal` and `Low` still reason to exhaustion), so the raw
+    /// `ThinkingParams::OpenAi` override is what buys a plain completion.
     async fn complete(&self, prompt: &str) -> Result<String, CanoError> {
-        let model = self.client.completion_model(MODEL);
-        let request = model
-            .completion_request(prompt)
-            .preamble(CONTEXT.to_string())
-            .max_tokens(MAX_TOKEN)
-            .build();
-        let response = model
-            .completion(request)
-            .await
-            .map_err(|e| CanoError::Generic(format!("Ollama completion error: {e}")))?;
+        let request = UnifiedRequest::new(self.model.clone())
+            .add_system_message(CONTEXT)
+            .add_user_message(prompt)
+            .set_max_tokens(MAX_TOKEN)
+            .with_thinking(ThinkingConfig {
+                enabled: true,
+                effort: None,
+                params: ThinkingParams::OpenAi {
+                    reasoning_effort: Some("none".to_string()),
+                },
+            });
 
-        Ok(response
-            .choice
-            .into_iter()
-            .filter_map(|content| match content {
-                AssistantContent::Text(text) => Some(text.text),
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .join(""))
+        let mut stream = self
+            .client
+            .generate_stream(request)
+            .await
+            .map_err(|e| CanoError::Generic(format!("Cuca completion error: {e}")))?;
+
+        let mut answer = String::new();
+        while let Some(block) = stream.next().await {
+            let block = block.map_err(|e| CanoError::Generic(format!("Cuca stream error: {e}")))?;
+            if let MessageContentBlock::Text(text) = block {
+                answer.push_str(&text);
+            }
+        }
+
+        if answer.trim().is_empty() {
+            return Err(CanoError::Generic(
+                "model returned no text blocks: the stream ended without a visible reply"
+                    .to_string(),
+            ));
+        }
+
+        Ok(answer)
     }
 }
 
 #[resource]
-impl Resource for OllamaResource {
+impl Resource for CucaResource {
     async fn setup(&self) -> Result<(), CanoError> {
-        println!("OllamaResource: ready (model={MODEL})");
+        println!(
+            "CucaResource: ready (model={}, url={})",
+            self.model,
+            base_url()
+        );
         Ok(())
     }
 }
@@ -125,28 +195,9 @@ impl Resource for OllamaResource {
 // Helpers
 // ============================================================================
 
-/// Removes `<think>...</think>` reasoning blocks and normalizes whitespace.
-fn filter_think_tags(text: &str) -> String {
-    let mut result = text.to_string();
-
-    while let Some(start) = result.to_lowercase().find("<think>") {
-        if let Some(end) = result[start..].to_lowercase().find("</think>") {
-            let end_pos = start + end + "</think>".len();
-            result.replace_range(start..end_pos, "");
-        } else {
-            result.replace_range(start.., "");
-            break;
-        }
-    }
-
-    result = result
-        .replace("<think>", "")
-        .replace("</think>", "")
-        .replace("<THINK>", "")
-        .replace("</THINK>", "");
-
-    result
-        .lines()
+/// Collapse a streamed reply into a single trimmed line.
+fn normalize(text: &str) -> String {
+    text.lines()
         .map(|line| line.trim())
         .filter(|line| !line.is_empty())
         .collect::<Vec<_>>()
@@ -205,7 +256,7 @@ impl Actor1Task {
 impl Actor1Task {
     async fn run(&self, res: &Resources) -> Result<TaskResult<ConversationState>, CanoError> {
         let store = res.get::<MemoryStore, _>("store")?;
-        let ollama = res.get::<OllamaResource, _>("ollama")?;
+        let cuca = res.get::<CucaResource, _>("cuca")?;
         let history = get_conversation_history(&store)?;
 
         let subject = Self::pick_subject();
@@ -219,8 +270,8 @@ impl Actor1Task {
             history
         };
 
-        let response = match ollama.complete(&prompt).await {
-            Ok(r) => filter_think_tags(&r),
+        let response = match cuca.complete(&prompt).await {
+            Ok(r) => normalize(&r),
             Err(e) => {
                 eprintln!("Actor1Task AI error: {e:?}");
                 if is_empty {
@@ -260,8 +311,8 @@ struct Actor2Task;
 
 impl Actor2Task {
     fn ensure_yes_and_format(response: &str) -> String {
-        let cleaned = filter_think_tags(response);
-        if cleaned.trim().to_lowercase().starts_with("yes, and") {
+        let cleaned = normalize(response);
+        if cleaned.to_lowercase().starts_with("yes, and") {
             cleaned
         } else {
             format!(
@@ -278,10 +329,10 @@ impl Actor2Task {
 impl Actor2Task {
     async fn run(&self, res: &Resources) -> Result<TaskResult<ConversationState>, CanoError> {
         let store = res.get::<MemoryStore, _>("store")?;
-        let ollama = res.get::<OllamaResource, _>("ollama")?;
+        let cuca = res.get::<CucaResource, _>("cuca")?;
         let history = get_conversation_history(&store)?;
 
-        let response = match ollama.complete(&history).await {
+        let response = match cuca.complete(&history).await {
             Ok(r) => Self::ensure_yes_and_format(&r),
             Err(e) => {
                 eprintln!("Actor2Task AI error: {e:?}");
@@ -307,11 +358,16 @@ impl Actor2Task {
 
 #[tokio::main]
 async fn main() -> Result<(), CanoError> {
+    let model = model_id();
+    let url = base_url();
+
     println!("Starting 'Yes, and...' Improv Workflow");
     println!("==========================================");
-    println!("Using rig-core with Ollama and {MODEL}");
-    println!("Make sure Ollama is running and you have pulled the {MODEL} model:");
-    println!("  ollama pull {MODEL}");
+    println!("Using cuca against an OpenAI-compatible server");
+    println!("  endpoint: {url}");
+    println!("  model:    {model}");
+    println!("Load {model} in LM Studio (or any server on port 1234) before running.");
+    println!("Override with the CUCA_BASE_URL and CUCA_MODEL environment variables.");
     println!();
     println!("Rules of 'Yes, and...' Improv:");
     println!("   Accept what your partner says (the 'Yes')");
@@ -323,7 +379,7 @@ async fn main() -> Result<(), CanoError> {
     let store = MemoryStore::new();
     let resources = Resources::new()
         .insert("store", store.clone())
-        .insert("ollama", OllamaResource::new()?);
+        .insert("cuca", CucaResource::new()?);
 
     let workflow = Workflow::new(resources)
         .register(ConversationState::Start, Actor1Task)

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -35,7 +35,7 @@ It excels at managing complex lifecycles where state transitions matter:
 </p>
 <ul class="animate-in">
 <li><strong>Data Pipelines</strong>: ETL jobs with parallel processing (Split/Join) and aggregation.</li>
-<li><strong>AI Agents</strong>: Multi-step inference chains with shared context and memory — see <code>cargo run --example ai_workflow_yes_and</code> (needs a local Ollama).</li>
+<li><strong>AI Agents</strong>: Multi-step inference chains with shared context and memory — see <code>cargo run --example ai_workflow_yes_and</code> (needs a local OpenAI-compatible inference server).</li>
 <li><strong>Background Systems</strong>: Scheduled maintenance, periodic reporting, and distributed cron jobs.</li>
 </ul>
 </section>
@@ -172,7 +172,7 @@ the FSM dispatch hot path stays allocation-light whether or not you wire any of 
 <p>Full coverage: the <a href="resilience/">Resilience</a>, <a href="recovery/">Recovery</a>, <a href="saga/">Saga</a> and <a href="observers/">Observers</a> guides.</p>
 
 <h2>Getting Started</h2>
-<p>Cano requires <strong>Rust 1.89.0+</strong> (edition 2024). Add it to your <code>Cargo.toml</code>:</p>
+<p>Cano requires <strong>Rust 1.98.0+</strong> (edition 2024). Add it to your <code>Cargo.toml</code>:</p>
 
 <div class="getting-started-code">
 


### PR DESCRIPTION
## Summary

- Replaces the `rig-core` dev-dependency with [`cuca`](https://github.com/nassor/cuca) in `cano/examples/ai_workflow_yes_and.rs`, the only place `rig-core` was used in the repo.
- Bumps the workspace to Rust 1.98 and upgrades dependencies to their latest versions.

## cuca migration

- `OllamaResource` -> `CucaResource`, wrapping a single shared `CucaClient` (`provider-lmstudio`). `generate_stream` is cuca's only generation entry point, so `complete()` drains the stream and concatenates `Text` blocks.
- `filter_think_tags` deleted — cuca separates reasoning into `Thinking` blocks structurally instead of inline `<think>` tags.
- `CUCA_BASE_URL` / `CUCA_MODEL` env vars (defaulting to a local LM Studio server, `google/gemma-4-12b-qat`) replace the hardcoded Ollama target.
- `reasoning_effort` explicitly set to `"none"` via `ThinkingParams::OpenAi`: this model reasons to token exhaustion at every other effort level, including when the key is omitted entirely, which previously produced empty completions. Only `"none"` turns reasoning off on this server. The call site has a comment explaining this so it doesn't get "cleaned up" later.
- Live-verified end to end against a running LM Studio instance — full 12-interaction run, real model text, no fallback strings.
- Repo-wide sweep for other rig/Ollama references (CI wording, docs) updated to match.

## Rust 1.98 + dependencies

- `rust-version` 1.89.0 -> 1.98.0 (root `Cargo.toml`, inherited by every workspace member). This also unblocked Cargo's MSRV-aware resolver, which was silently holding back in-range patch upgrades (e.g. `redb` 4.1 -> 4.2) because the manifest still declared 1.89.
- CI toolchain pins (`ci.yml`, `e2e.yml`, `examples.yml`) and `cano-e2e/Dockerfile`'s base image bumped to match.
- `syn` 2 -> 3 in `cano-macros`, with the resulting `Receiver`/`ItemImpl` API changes fixed mechanically across every macro implementation file.
- `tokio`, `redb`, `metrics`, `metrics-util`, `wide`, and transitive dependencies bumped to latest.

## testcontainers 0.28.0

`testcontainers-modules` 0.15.0 (still the latest release) hard-pins `testcontainers = "^0.27.0"`, so the two cannot resolve together. modules was earning its place with exactly one type — `testcontainers_modules::postgres::Postgres` — while every other container in the suite already used a plain `GenericImage`. Rather than stay a major version behind for one image definition, that image is now reproduced inline and the dependency is dropped.

- `postgres:11-alpine`, `POSTGRES_DB`/`USER`/`PASSWORD=postgres`, `-c fsync=off`, exposed port 5432 — matching `Postgres::default()`, so both DSNs keep working unchanged.
- Ready condition preserved exactly. The official postgres entrypoint logs `database system is ready to accept connections` **twice** — once for the throwaway server `initdb` runs, then again for the real one — landing on different streams. The wait is therefore stderr + stdout, one per stream, as the modules image did; waiting for a single occurrence would return a server about to shut down and make the suite flaky. `GenericImage::with_wait_for` appends, so both conditions are honoured.
- The 0.27 -> 0.28 major required no call-site changes: diffing the two vendored source trees shows only an SSHd sidecar tag change and a `bollard::models::MountTypeEnum` -> `MountType` rename internal to the crate. The major is driven by public dependency bumps (bollard 0.20 -> 0.21 and friends), not by testcontainers' own API.

## Verification

- `cargo build` / `cargo build --all-features` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --lib` / `--all-features`, `cargo test --doc --all-features` — all green
- Each feature validated in isolation (`scheduler`, `tracing`, `recovery`, `metrics`, `testing`) — no failures
- `cargo check --benches --all-features`, `cargo check --examples --all-features` — clean
- **`cano-e2e` executed for real** against Docker (server 29.4.3), exactly as `e2e.yml` does it: `docker build -t cano-workflow-app:e2e -f cano-e2e/Dockerfile .` then `cargo test -p cano-e2e --test e2e -- --test-threads=1` — 4/4 scenarios green, run twice to rule out a wait-strategy race
- `cargo update --dry-run` — lockfile fully current under 1.98; the only remaining holdout is `matchit`, pinned transitively by `axum`
- Live run of `ai_workflow_yes_and` against a real LM Studio server — all 12 interactions completed with real model output
